### PR TITLE
Update gitignore to prevent cypress artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ yarn-error.log*
 storybook-static
 
 # Cypress test output videos
-apps/public-reference/cypress/videos
+apps/**/cypress/videos
 
 # Complied Typescript
 dist


### PR DESCRIPTION
This is really a downstream problem, but it seemed best to fix it here for the future. The goal is to prevent cypress videos from being added to checkins from non-reference apps.