### PR TITLE
Add local development GTM key

### DIFF
--- a/apps/public-reference/.env.template
+++ b/apps/public-reference/.env.template
@@ -3,3 +3,6 @@ LISTING_SERVICE_URL=http://localhost:3001
 HOUSING_COUNSELOR_SERVICE_URL=https://housing.sfgov.org/assets/housing_counselors-7b0f260dac22dfa20871edd36135b62f1a25a9dad78faf2cf8e8e2514b80cf61.json
 NEXTJS_PORT=3000
 MAPBOX_TOKEN=pk.eyJ1IjoibWplZHJhcyIsImEiOiJjazI2OHA5YzQycTBpM29xdDVwbXNyMDlwIn0.XS5ilGzTh_yVl3XY-8UKeA
+
+# this GTM key is for local development only
+GTM_KEY=GTM-KF22FJP

--- a/apps/public-reference/netlify.toml
+++ b/apps/public-reference/netlify.toml
@@ -3,3 +3,10 @@
 NODE_VERSION = "12.16.1"
 YARN_VERSION = "1.22.4"
 NEXT_TELEMETRY_DISABLED = "1"
+LISTING_SERVICE_URL = "https://listings.bloom.exygy.dev/"
+
+[context.production]
+GTM_KEY = "GTM-W8LH9F9"
+
+[context.branch-deploy.environment]
+GTM_KEY = "GTM-KF22FJP"

--- a/docs/Analytics.md
+++ b/docs/Analytics.md
@@ -1,0 +1,28 @@
+# Setting up User Analytics
+
+User Analytics within the Bloom reference apps is handled by Google Analytics (GA). In order to support additional analytics or tag integrations in the future, the default implementation is to use Google Tag Manager (GTM) from the reference code, which is then set up to call GA from within the GTM console.
+
+## GA and GTM Console Setup
+
+A basic setup can be accomplished by:
+
+1. Setting up a new Property in the GA console for each new app to be deployed
+
+2. Setting up a new matching Container in the GTM console
+
+3. Creating a GA tag in the new GTM container that is linked to the GA property with the correct GA tag
+
+4. Setting up triggers on the GA tag in GTM for both Page Views and History Changes.
+    * NOTE: without the History Change trigger set up, only some pages will be captured, since react / next.js do not do a full page load to trigger the GTM page view event in all cases.
+
+5. Setting up GTM and GA events for any external links that need to be tracked, e.g. the download of a PDF application or referral to an external website.
+
+## GTM Tag Setup in Environment Variables / Code 
+
+Once all of the GTM and GA provisioning and configuration has been completed, the code-side changes should be as simple as setting the GTM_KEY environment variable to the key from the container created above. This should be set in .env for a local dev environment (see `.env.template`), or in netlify.toml for those apps being deployed via Netlify.
+
+See `apps/public-reference/src/customScripts.ts` for use of the GTM_KEY, noting that translation to gtmKey in process.env is automatic.
+
+## Netlify Analytics
+
+As a complement to Google Analytics, we also recommend enabling analytics on the Netlify platform for apps that are deployed there. In addition to providing a point of comparison / validation for the GA data, it also tracks things like 404s or other HTTP errors that may prevent GA from loading in the first place.

--- a/docs/DeployAppsNetlify.md
+++ b/docs/DeployAppsNetlify.md
@@ -16,3 +16,5 @@ In addition to those environment variables defined in .env.template for the rele
 
 - NODE_VERSION
 - YARN_VERSION
+
+Note that there is a `netlify.toml` file in each reference app directory so that settings can be specified in a version controlled manner. If there are any environment variables that should not be publically accessible as part of the source, they can be set direcly in the Netlify console so long as they're not in the toml file.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,15 +1181,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/core@^0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/core/-/core-0.0.8.tgz#90cf7eaee7a5e379487a180cf2a41f808206eaea"
-  integrity sha512-qMC6bB8datARTMSO1OEJEgSoWEvpuvLgWqXWUfGloiODQyMLBJzrhpf3YMZwrO+8YvCtI2dTNslIcC5cpshb4w==
-  dependencies:
-    "@types/node" "^12.12.31"
-    "@types/node-polyglot" "^0.4.34"
-    nanoid "^3.0.0"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.3.tgz#099139eaec7ebf07a27c1786a3ff64f39464d2ef"


### PR DESCRIPTION
Adds a key for local development testing that won't both anything else.

Also cleans up a yarn.lock reference to an older version of /core