### PR TITLE
Make listings service and tests use active record

### DIFF
--- a/backend/core/src/entity/Listing.ts
+++ b/backend/core/src/entity/Listing.ts
@@ -1,11 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from "typeorm"
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, BaseEntity } from "typeorm"
 import { Unit } from "./Unit"
 import { Preference } from "./Preference"
 import { Attachment } from "./Attachment"
 import { Address, UnitsSummarized } from "@bloom-housing/core"
 
 @Entity()
-class Listing {
+class Listing extends BaseEntity {
   @OneToMany((type) => Preference, (preference) => preference.listing)
   preferences: Preference[]
   @OneToMany((type) => Unit, (unit) => unit.listing)

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -1,6 +1,4 @@
 import { Injectable } from "@nestjs/common"
-import { InjectRepository } from "@nestjs/typeorm"
-import { Repository } from "typeorm"
 import { Listing } from "../entity/Listing"
 import { amiCharts } from "../lib/ami_charts"
 import { transformUnits } from "../lib/unit_transformations"
@@ -8,10 +6,8 @@ import { listingUrlSlug } from "../lib/url_helper"
 
 @Injectable()
 export class ListingsService {
-  constructor(@InjectRepository(Listing) private readonly repo: Repository<Listing>) {}
-
   public async findAll() {
-    const listings = await this.repo.find({ relations: ["units", "attachments", "preferences"] })
+    const listings = await Listing.find({ relations: ["units", "attachments", "preferences"] })
     listings.forEach((listing) => {
       listing.unitsSummarized = transformUnits(listing.units, amiCharts)
       listing.urlSlug = listingUrlSlug(listing)


### PR DESCRIPTION
Master branch uses Data Mapper and the PR changes that to use Active Record

##### Data Mapper vs Active Record:
- No need for class-transformer in Data Mapper (otherwise typescript complains about missing database access methods),
- Explicit dependencies in Data Mapper (one can see exactly what service depends on because it's injected in the constructor),
- Active Record requires entity classes to extend `BaseEntity` and based on what I see in [typeorm-model-shim](https://github.com/typeorm/typeorm/blob/master/extra/typeorm-model-shim.js) this is not going to work with models exporting since model shim is only providing empty definitions for decorators