### PR TITLE
TypeORM shim to use entities in Next.js frontend

### DIFF
--- a/apps/public-reference/babel.config.json
+++ b/apps/public-reference/babel.config.json
@@ -1,0 +1,5 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [["@babel/plugin-proposal-decorators", { "legacy": true }]]
+}
+

--- a/apps/public-reference/next.config.js
+++ b/apps/public-reference/next.config.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /* eslint-disable @typescript-eslint/no-var-requires */
 
+const path = require("path")
 const withTM = require("next-transpile-modules")(["@bloom-housing"])
 const withSass = require("@zeit/next-sass")
 const withCSS = require("@zeit/next-css")
@@ -47,6 +48,10 @@ module.exports = withCSS(
           },
           sassLoaderOptions: {
             prependData: tailwindVars,
+          },
+          webpack: (config, { buildId, dev, isServer, defaultLoaders, webpack }) => {
+            config.resolve.alias.typeorm = path.resolve(__dirname, "src/typeorm-model-shim")
+            return config
           },
           // exportPathMap adapted from https://github.com/zeit/next.js/blob/canary/examples/with-static-export/next.config.js
           async exportPathMap() {

--- a/apps/public-reference/package.json
+++ b/apps/public-reference/package.json
@@ -15,6 +15,7 @@
     "dev:all": "concurrently \"yarn dev:listings\" \"yarn dev\""
   },
   "dependencies": {
+    "@babel/plugin-proposal-decorators": "^7.10.1",
     "@bloom-housing/core": "^0.2.5",
     "@bloom-housing/ui-components": "^0.2.7",
     "@mdx-js/loader": "1.6.6",

--- a/apps/public-reference/src/typeorm-model-shim.js
+++ b/apps/public-reference/src/typeorm-model-shim.js
@@ -1,0 +1,183 @@
+/* eslint-disable */
+
+// columns
+
+/* export */ function Column(typeOrOptions, options) {
+  return function (object, propertyName) {}
+}
+exports.Column = Column
+
+/* export */ function CreateDateColumn(options) {
+  return function (object, propertyName) {}
+}
+exports.CreateDateColumn = CreateDateColumn
+
+/* export */ function ObjectIdColumn(columnOptions) {
+  return function (object, propertyName) {}
+}
+exports.ObjectIdColumn = ObjectIdColumn
+
+/* export */ function PrimaryColumn(typeOrOptions, options) {
+  return function (object, propertyName) {}
+}
+exports.PrimaryColumn = PrimaryColumn
+
+/* export */ function PrimaryGeneratedColumn(options) {
+  return function (object, propertyName) {}
+}
+exports.PrimaryGeneratedColumn = PrimaryGeneratedColumn
+
+/* export */ function UpdateDateColumn(options) {
+  return function (object, propertyName) {}
+}
+exports.UpdateDateColumn = UpdateDateColumn
+
+/* export */ function VersionColumn(options) {
+  return function (object, propertyName) {}
+}
+exports.VersionColumn = VersionColumn
+
+// entities
+
+/* export */ function ChildEntity(tableName, options) {
+  return function (object) {}
+}
+exports.ChildEntity = ChildEntity
+
+/* export */ function Entity(name, options) {
+  return function (object) {}
+}
+exports.Entity = Entity
+
+/* export */ function BaseEntity(name, options) {
+  return function (object) {}
+}
+exports.BaseEntity = BaseEntity
+
+/* export */ function TableInheritance(type) {
+  return function (object) {}
+}
+exports.TableInheritance = TableInheritance
+
+// listeners
+
+/* export */ function AfterInsert() {
+  return function (object, propertyName) {}
+}
+exports.AfterInsert = AfterInsert
+
+/* export */ function AfterLoad() {
+  return function (object, propertyName) {}
+}
+exports.AfterLoad = AfterLoad
+
+/* export */ function AfterRemove() {
+  return function (object, propertyName) {}
+}
+exports.AfterRemove = AfterRemove
+
+/* export */ function AfterUpdate() {
+  return function (object, propertyName) {}
+}
+exports.AfterUpdate = AfterUpdate
+
+/* export */ function BeforeInsert() {
+  return function (object, propertyName) {}
+}
+exports.BeforeInsert = BeforeInsert
+
+/* export */ function BeforeRemove() {
+  return function (object, propertyName) {}
+}
+exports.BeforeRemove = BeforeRemove
+
+/* export */ function BeforeUpdate() {
+  return function (object, propertyName) {}
+}
+exports.BeforeUpdate = BeforeUpdate
+
+/* export */ function EventSubscriber() {
+  return function (object, propertyName) {}
+}
+exports.EventSubscriber = EventSubscriber
+
+// relations
+
+/* export */ function JoinColumn(options) {
+  return function (object, propertyName) {}
+}
+exports.JoinColumn = JoinColumn
+
+/* export */ function JoinTable(options) {
+  return function (object, propertyName) {}
+}
+exports.JoinTable = JoinTable
+
+/* export */ function ManyToMany(typeFunction, inverseSideOrOptions, options) {
+  return function (object, propertyName) {}
+}
+exports.ManyToMany = ManyToMany
+
+/* export */ function ManyToOne(typeFunction, inverseSideOrOptions, options) {
+  return function (object, propertyName) {}
+}
+exports.ManyToOne = ManyToOne
+
+/* export */ function OneToMany(typeFunction, inverseSideOrOptions, options) {
+  return function (object, propertyName) {}
+}
+exports.OneToMany = OneToMany
+
+/* export */ function OneToOne(typeFunction, inverseSideOrOptions, options) {
+  return function (object, propertyName) {}
+}
+exports.OneToOne = OneToOne
+
+/* export */ function RelationCount(relation) {
+  return function (object, propertyName) {}
+}
+exports.RelationCount = RelationCount
+
+/* export */ function RelationId(relation) {
+  return function (object, propertyName) {}
+}
+exports.RelationId = RelationId
+
+// tree
+
+/* export */ function Tree(name, options) {
+  return function (object) {}
+}
+exports.Tree = Tree
+
+/* export */ function TreeChildren(options) {
+  return function (object, propertyName) {}
+}
+exports.TreeChildren = TreeChildren
+
+/* export */ function TreeChildrenCount(options) {
+  return function (object, propertyName) {}
+}
+exports.TreeChildrenCount = TreeChildrenCount
+
+/* export */ function TreeLevelColumn() {
+  return function (object, propertyName) {}
+}
+exports.TreeLevelColumn = TreeLevelColumn
+
+/* export */ function TreeParent(options) {
+  return function (object, propertyName) {}
+}
+exports.TreeParent = TreeParent
+
+// other
+
+/* export */ function Generated(options) {
+  return function (object, propertyName) {}
+}
+exports.Generated = Generated
+
+/* export */ function Index(options) {
+  return function (object, propertyName) {}
+}
+exports.Index = Index

--- a/shared/core/index.ts
+++ b/shared/core/index.ts
@@ -1,6 +1,13 @@
 export * from "./src/HousingCounselors"
 export * from "./src/ami_charts"
 export * from "./src/general"
+
+// Using these for the time being:
 export * from "./src/listings"
 export * from "./src/preferences"
 export * from "./src/units"
+
+// Switch to using these once the DB backend is activated:
+// export * from "@bloom-housing/backend-core/src/entity/Listing"
+// export * from "@bloom-housing/backend-core/src/entity/Preference"
+// export * from "@bloom-housing/backend-core/src/entity/Unit"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react"
+    "jsx": "react",
+    "experimentalDecorators": true
   }
 }


### PR DESCRIPTION
(Coming soon with DB backend, not yet activated)

This was part of a previous PR that got overwritten, but since we haven't yet fully switched to the DB backend, we wouldn't have wanted to roll it out without keeping it under wraps for the time being. So this PR adds the functionality for the frontend to potentially use the backend TS interfaces but doesn't yet activate it.