### PR TITLE
Fix the JS error on the error page

### DIFF
--- a/apps/partners-reference/pages/_error.jsx
+++ b/apps/partners-reference/pages/_error.jsx
@@ -3,7 +3,7 @@ import Head from "next/head"
 import { Hero, MarkdownSection, t } from "@bloom-housing/ui-components"
 
 export default () => {
-  const pageTitle = <>{t("error.notFound.title")}</>
+  const pageTitle = t("error.notFound.title")
 
   return (
     <Layout>

--- a/apps/public-reference/pages/_error.jsx
+++ b/apps/public-reference/pages/_error.jsx
@@ -4,7 +4,7 @@ import { Hero, MarkdownSection, t } from "@bloom-housing/ui-components"
 import PageContent from "../page_content/homepage.mdx"
 
 export default () => {
-  const pageTitle = <>{t("error.notFound.title")}</>
+  const pageTitle = t("error.notFound.title")
 
   return (
     <Layout>


### PR DESCRIPTION
Fixes #345, which was annoying me this morning.

I'm not sure if I'm missing some intended behavior with pageTitle being a JSX.Element here, but it was the unhappiness causing the error, and it seems to work reasonably as a string.