### PR TITLE
Add utility hook + component to require login to access a page

### DIFF
--- a/apps/partners-reference/pages/_app.jsx
+++ b/apps/partners-reference/pages/_app.jsx
@@ -1,7 +1,12 @@
 import React from "react"
 import App from "next/app"
 import "@bloom-housing/ui-components/styles/index.scss"
-import { addTranslation, ConfigProvider, UserProvider } from "@bloom-housing/ui-components"
+import {
+  addTranslation,
+  ConfigProvider,
+  UserProvider,
+  RequireLogin,
+} from "@bloom-housing/ui-components"
 
 class MyApp extends App {
   constructor(props) {
@@ -53,10 +58,14 @@ class MyApp extends App {
       }
     }
 
+    const signInMessage = "Login is required to view this page."
+
     return (
       <ConfigProvider apiUrl={process.env.listingServiceUrl}>
         <UserProvider>
-          <Component {...pageProps} />
+          <RequireLogin signInPath={`/sign-in?message=${encodeURIComponent(signInMessage)}`}>
+            <Component {...pageProps} />
+          </RequireLogin>
         </UserProvider>
       </ConfigProvider>
     )

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -51,3 +51,96 @@ resulting user will be returned along with a valid `accessToken`.
 
 The app must be configured with an app secret to sign JWT tokens. In development, the app uses a hard-coded value, but
 the app will throw an error in production mode if `APP_SECRET` is not provided as an environment variable.
+
+
+# Front End Authentication/User Management
+
+A few tools are provided to help handle authentication/users in the front end. These are collected under 
+`shared/ui-components/authentication`. 
+
+## UserContext
+
+`UserContext` is a React Context that keeps track of the current user state and provides user-related utility
+functions.
+
+It provides:
+
+```typescript
+type ContextProps = {
+  login: (email: string, password: string) => Promise<void>
+  createUser: (user: CreateUserDto) => Promise<User>
+  signOut: () => void
+  // True when an API request is processing
+  loading: boolean
+  profile?: User
+  accessToken?: string
+  initialStateLoaded: boolean
+}
+```
+
+The context is provided to a React App using `UserProvider`, which in turn requires a `ConfigProvider` to function
+properly:
+
+```typescript
+import { UserProvider, ConfigProvider } from "@bloom-housing/ui-components"
+
+<ConfigProvider apiUrl={...}>
+  <UserProvider>
+     {/* ...rest of app tree */}
+  </UserProvider>
+</ConfigProvider>
+```
+
+`profile` and `accessToken` will be automatically populated if available. `accessToken` is stored in either Session
+or Local storage depending on the config (default to session storage) and will be read on initial load. If the token
+is current, the provider will attempt to fetch the user profile (and verify login status at the same time). The
+provider also reads the token for the expiry and automatically schedules background updates to refresh the token
+while the user remains signed in.
+
+## useAuthenticatedClient
+
+This is a convenience hook that allows a component to access a protected route on the API using an Axios client that
+has been pre-configured to send an auth token to the API. It will return `undefined` if the user is not logged in.
+
+```typescript
+const authClient = useAuthenticatedClient();
+if (authClient) {
+  authClient.get('/protected-route')
+}
+```
+
+This hook relies on access to the `UserContext` and the `ConfigContext`, so it will not work if the component isn't
+in a tree that has both of these providers.
+
+## RequireLogin
+
+This component waits for `UserProvider` to determine current login status before rendering its children. If no login
+is found, the component will redirect to its `signInPath` component without rendering children. It can be configured
+to require login for all paths other than `signInPath` (default), with a "whitelist" of paths to require login for
+(`requireForRoutes`) or a "blacklist" of paths to skip authentication checks for (`skipForRoutes`). These props are
+both lists of strings, and may contain RegEx strings.
+
+```typescript
+<RequireLogin signInPath="/sign-in">
+  {/* will only render if logged in */}
+</RequireLogin>
+
+<RequireLogin signInPath="/sign-in" skipForRoutes={["/public/*", "/other-path"]}>
+  {/* login not required for /public/* or /other-path */}
+</RequireLogin>
+```
+
+## useRequireLoggedInUser
+
+This is a hook that can be applied to protect a single component by requiring a login without modifying the full app
+tree. It returns the logged in `User` if found, and `undefined` before the initial state has loaded. If no login is
+found, it redirects to `signInPath`. This hook requires `UserProvider` to be defined on the app tree to work. 
+
+```typescript
+const user = useRequireLoggedInUser("/sign-in")
+
+// Make sure not to render the component before the user state has loaded
+if (!user) {
+  return null // or loading screen
+}
+```

--- a/docs/Authentication.md
+++ b/docs/Authentication.md
@@ -81,7 +81,7 @@ type ContextProps = {
 The context is provided to a React App using `UserProvider`, which in turn requires a `ConfigProvider` to function
 properly:
 
-```typescript
+```tsx
 import { UserProvider, ConfigProvider } from "@bloom-housing/ui-components"
 
 <ConfigProvider apiUrl={...}>
@@ -102,7 +102,7 @@ while the user remains signed in.
 This is a convenience hook that allows a component to access a protected route on the API using an Axios client that
 has been pre-configured to send an auth token to the API. It will return `undefined` if the user is not logged in.
 
-```typescript
+```tsx
 const authClient = useAuthenticatedClient();
 if (authClient) {
   authClient.get('/protected-route')
@@ -120,7 +120,7 @@ to require login for all paths other than `signInPath` (default), with a "whitel
 (`requireForRoutes`) or a "blacklist" of paths to skip authentication checks for (`skipForRoutes`). These props are
 both lists of strings, and may contain RegEx strings.
 
-```typescript
+```tsx
 <RequireLogin signInPath="/sign-in">
   {/* will only render if logged in */}
 </RequireLogin>

--- a/shared/ui-components/__tests__/authentication/RequireLogin.test.tsx
+++ b/shared/ui-components/__tests__/authentication/RequireLogin.test.tsx
@@ -1,0 +1,174 @@
+import React from "react"
+import { mount } from "enzyme"
+import { RequireLogin } from "../../src/authentication/RequireLogin"
+import { UserContext } from "../../src/authentication/UserContext"
+import { User } from "@bloom-housing/backend-core"
+
+let mockPathname: string
+const mockPush = jest.fn()
+jest.mock("next/router", () => ({
+  __esModule: true,
+  useRouter: () => ({
+    pathname: mockPathname,
+    push: mockPush,
+  }),
+}))
+
+const mockUser: User = {
+  id: "123",
+  email: "test@test.com",
+  passwordHash: "123",
+  firstName: "Test",
+  lastName: "User",
+  dob: new Date("2020-01-01"),
+  createdAt: new Date("2020-01-01"),
+  updatedAt: new Date("2020-01-01"),
+}
+
+let initialStateLoaded = false
+let profile: User | undefined
+let props = {}
+
+beforeEach(() => {
+  mockPush.mockReset()
+})
+
+const renderComponent = () =>
+  mount(
+    <UserContext.Provider value={{ initialStateLoaded, profile }}>
+      <RequireLogin signInPath={"/sign-in"} {...props}>
+        <div id="child" />
+      </RequireLogin>
+    </UserContext.Provider>
+  )
+
+const itShouldRender = () =>
+  test("it renders successfully", () => {
+    const wrapper = renderComponent()
+    expect(wrapper.find("div#child").exists()).toBe(true)
+  })
+
+const itShouldNotRenderChildren = () =>
+  test("it should not render children", () => {
+    const wrapper = renderComponent()
+    expect(wrapper.find("div#child").exists()).toBe(false)
+  })
+
+const itShouldRedirect = () =>
+  test("it should redirect", () => {
+    renderComponent()
+    expect(mockPush).toHaveBeenCalledWith("/sign-in")
+  })
+
+const itShouldNotRedirect = () =>
+  test("it should not redirect", () => {
+    renderComponent()
+    expect(mockPush).not.toHaveBeenCalled()
+  })
+
+const itShouldWaitForAuthState = () =>
+  describe("Before the user state has loaded", () => {
+    beforeEach(() => {
+      initialStateLoaded = false
+      profile = undefined
+    })
+    itShouldNotRenderChildren()
+    itShouldNotRedirect()
+  })
+
+const itShouldRenderImmediately = () =>
+  describe("Before the user state has loaded", () => {
+    beforeEach(() => {
+      initialStateLoaded = false
+      profile = undefined
+    })
+    itShouldRender()
+    itShouldNotRedirect()
+  })
+
+const itShouldVerifyLoginState = () =>
+  describe("After user state has loaded", () => {
+    beforeEach(() => {
+      initialStateLoaded = true
+    })
+
+    describe("With a logged in user", () => {
+      beforeEach(() => {
+        profile = mockUser
+      })
+      itShouldRender()
+      itShouldNotRedirect()
+    })
+
+    describe("Without a logged in user", () => {
+      beforeEach(() => {
+        profile = undefined
+      })
+      itShouldNotRenderChildren()
+      itShouldRedirect()
+    })
+  })
+
+const itShouldIgnoreLoggedInState = () =>
+  describe("After user state has loaded", () => {
+    beforeEach(() => {
+      initialStateLoaded = true
+    })
+
+    describe("Without a logged in user", () => {
+      beforeEach(() => {
+        profile = undefined
+      })
+      itShouldRender()
+      itShouldNotRedirect()
+    })
+  })
+
+describe("Without any paths specified", () => {
+  itShouldWaitForAuthState()
+  itShouldVerifyLoginState()
+})
+
+describe("With a list of paths to require login for", () => {
+  beforeEach(() => {
+    props = { requireForRoutes: ["/login-required"] }
+  })
+
+  describe("for a path that is not on the list", () => {
+    beforeEach(() => {
+      mockPathname = "/allowed"
+    })
+    itShouldRenderImmediately()
+    itShouldIgnoreLoggedInState()
+  })
+
+  describe("for a path that matches the list", () => {
+    beforeEach(() => {
+      mockPathname = "/login-required"
+    })
+    itShouldWaitForAuthState()
+    itShouldVerifyLoginState()
+  })
+})
+
+describe("With a list of paths to bypass login", () => {
+  beforeEach(() => {
+    props = { skipForRoutes: ["/not-required"] }
+  })
+
+  describe("for a path that is not on the list", () => {
+    beforeEach(() => {
+      mockPathname = "/not-allowed"
+    })
+    itShouldWaitForAuthState()
+    itShouldVerifyLoginState()
+  })
+
+  describe("for a path that matches the list", () => {
+    beforeEach(() => {
+      mockPathname = "/not-required"
+    })
+    itShouldRenderImmediately()
+    itShouldIgnoreLoggedInState()
+  })
+})

--- a/shared/ui-components/package.json
+++ b/shared/ui-components/package.json
@@ -25,6 +25,7 @@
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^25.2.2",
+    "@types/jwt-decode": "^2.2.1",
     "@types/react-map-gl": "^5.0.4",
     "@types/react-test-renderer": "^16.9.2",
     "@types/webpack": "^4.41.18",

--- a/shared/ui-components/src/authentication/RequireLogin.tsx
+++ b/shared/ui-components/src/authentication/RequireLogin.tsx
@@ -1,0 +1,52 @@
+import React, { FunctionComponent, useContext, useEffect } from "react"
+import { useRouter } from "next/router"
+import { UserContext } from "./UserContext"
+
+// See https://github.com/Microsoft/TypeScript/issues/14094
+type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
+type XOR<T, U> = T | U extends object ? (Without<T, U> & U) | (Without<U, T> & T) : T | U
+
+type RequireLoginProps = {
+  signInPath: string
+} & XOR<{ requireForRoutes?: string[] }, { skipForRoutes: string[] }>
+
+/**
+ * Require a login to render children. Will redirect to `signInPath` if not logged in.
+ *
+ * Props can be specified with either a "whitelist" (list of routes to skip check for) or a "blacklist" (list of
+ * routes to apply test on). If no list of routes is provided, then will always apply check.
+ */
+const RequireLogin: FunctionComponent<RequireLoginProps> = ({ children, signInPath, ...rest }) => {
+  const router = useRouter()
+  const { profile, initialStateLoaded } = useContext(UserContext)
+
+  // Parse just the pathname portion of the signInPath (in case we want to pass URL params)
+  const [signInPathname] = signInPath.split("?")
+
+  // Check if this route requires a login or not (can be specified as a whitelist or a blacklist).
+  const loginRequiredForPath =
+    // by definition, we shouldn't require login on the sign in page itself
+    router.pathname !== signInPathname &&
+    ("requireForRoutes" in rest
+      ? rest.requireForRoutes
+        ? rest.requireForRoutes.some((path) => new RegExp(path).exec(router.pathname))
+        : true
+      : rest.skipForRoutes
+      ? !rest.skipForRoutes.some((path) => new RegExp(path).exec(router.pathname))
+      : true)
+
+  useEffect(() => {
+    if (loginRequiredForPath && initialStateLoaded && !profile) {
+      router.push(signInPath)
+    }
+  }, [loginRequiredForPath, initialStateLoaded, profile, router, signInPath])
+
+  if (loginRequiredForPath && !profile) {
+    return null
+  }
+
+  // Login either isn't required, or the user object is loaded successfully, continue rendering as normal.
+  return <>{children}</>
+}
+
+export { RequireLogin as default, RequireLogin }

--- a/shared/ui-components/src/authentication/index.ts
+++ b/shared/ui-components/src/authentication/index.ts
@@ -1,2 +1,4 @@
 export { UserContext, UserProvider } from "./UserContext"
 export { useAuthenticatedClient } from "./useAuthenticatedClient"
+export { RequireLogin } from "./RequireLogin"
+export { useRequireLoggedInUser } from "./useRequireLoggedInUser"

--- a/shared/ui-components/src/authentication/token.ts
+++ b/shared/ui-components/src/authentication/token.ts
@@ -1,7 +1,5 @@
 import jwtDecode from "jwt-decode"
 
-declare module "jwt-decode"
-
 const ACCESS_TOKEN_LOCAL_STORAGE_KEY = "@bht"
 
 const getStorage = (type: string) => (type === "local" ? localStorage : sessionStorage)
@@ -14,6 +12,6 @@ export const clearToken = (storageType: string) =>
   getStorage(storageType).removeItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY)
 
 export const getTokenTtl = (token: string) => {
-  const { exp = 0 } = jwtDecode(token) as { exp?: number }
+  const { exp = 0 } = jwtDecode(token)
   return new Date(exp * 1000).valueOf() - new Date().valueOf()
 }

--- a/shared/ui-components/src/authentication/useRequireLoggedInUser.ts
+++ b/shared/ui-components/src/authentication/useRequireLoggedInUser.ts
@@ -1,0 +1,19 @@
+import { useContext } from "react"
+import { useRouter } from "next/router"
+import { UserContext } from "./UserContext"
+
+/**
+ * Require a logged in user. Waits on initial load, then initiates a redirect to `redirectPath` if user is not
+ * logged in.
+ */
+function useRequireLoggedInUser(redirectPath: string) {
+  const { profile, initialStateLoaded } = useContext(UserContext)
+  const router = useRouter()
+
+  if (initialStateLoaded && !profile) {
+    router.push(redirectPath)
+  }
+  return profile
+}
+
+export { useRequireLoggedInUser as default, useRequireLoggedInUser }


### PR DESCRIPTION
# Add utility hook + component to require login to access a page

This PR adds a utility component `<RequireLogin>` and hook (`useRequireLoggedInUser`) to help manage protected front end routes.

`<RequireLogin>` only renders its children if the user is signed in, or the path doesn't require login. Login is based on props using either a blacklist (`requireForRoutes`) or whitelist (`skipForRoutes`), both of which can be RegExp. If a user isn't logged in and the requested path matches the appropriate list, the user will be redirected to the `signInPath` prop. If no lists are provided, login is required for all paths other than the sign in path.

Closes #387