### PR TITLE
Use react-specific httpEquiv syntax in redirect

### DIFF
--- a/apps/public-reference/pages/redirect.tsx
+++ b/apps/public-reference/pages/redirect.tsx
@@ -8,7 +8,7 @@ interface RedirectProps {
 
 const Redirect: NextPage<RedirectProps> = ({ to }) => (
   <Head>
-    <meta http-equiv="refresh" content={`0; url=${to}`} />
+    <meta httpEquiv="refresh" content={`0; url=${to}`} />
   </Head>
 )
 


### PR DESCRIPTION
This is just to make an annoying console warning go away. It should not have any functional effect (and if so, that's probably a bug).

The warning in question looks like:

```
[1] Warning: Invalid DOM property `http-equiv`. Did you mean `httpEquiv`?
[1]     in meta (at redirect.tsx:11)
[1]     in head
[1]     in Head
[...]
```

See also https://github.com/facebook/react/issues/10863 and https://github.com/facebook/react/issues/11160 for the backstory. I did a view-source on the redirect page after making the change, and it seems to be doing the transformation as promised.