### PR TITLE
Clean up application form warnings

### DIFF
--- a/apps/public-reference/lib/ApplicationConductor.ts
+++ b/apps/public-reference/lib/ApplicationConductor.ts
@@ -55,7 +55,9 @@ export default class ApplicationConductor {
     setTimeout(() => {
       if (typeof window != "undefined") {
         window.sessionStorage.setItem("bloom-app-autosave", JSON.stringify(this.application))
-        window.sessionStorage.setItem("bloom-app-listing", JSON.stringify(this.listing))
+        if (this.listing) {
+          window.sessionStorage.setItem("bloom-app-listing", JSON.stringify(this.listing))
+        }
       }
     }, 800)
   }

--- a/apps/public-reference/pages/applications/contact/address.tsx
+++ b/apps/public-reference/pages/applications/contact/address.tsx
@@ -76,7 +76,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/contact/address.tsx
+++ b/apps/public-reference/pages/applications/contact/address.tsx
@@ -82,7 +82,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href="/applications/contact/name">{t("t.back")}</Link>
+            <Link href="/applications/contact/name">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/contact/address.tsx
+++ b/apps/public-reference/pages/applications/contact/address.tsx
@@ -4,7 +4,6 @@ Primary applicant contact information
 https://github.com/bloom-housing/bloom/issues/256
 */
 import Link from "next/link"
-import Router from "next/router"
 import {
   Button,
   ErrorMessage,
@@ -19,7 +18,7 @@ import FormsLayout from "../../../layouts/forms"
 import { useForm } from "react-hook-form"
 import { AppSubmissionContext, blankApplication } from "../../../lib/AppSubmissionContext"
 import ApplicationConductor from "../../../lib/ApplicationConductor"
-import React, { useContext, useMemo } from "react"
+import React, { useContext, useMemo, Fragment } from "react"
 import { StateSelect } from "@bloom-housing/ui-components/src/forms/StateSelect"
 import { PhoneField } from "@bloom-housing/ui-components/src/forms/PhoneField"
 
@@ -194,10 +193,14 @@ export default () => {
                       defaultValue={application.additionalPhoneNumberType}
                       ref={register({ required: true })}
                     >
-                      <option value="">What type of number is this?</option>
-                      <option value="Work">Work</option>
-                      <option value="Home">Home</option>
-                      <option value="Cell">Cell</option>
+                      {["prompt", "work", "home", "cell"].map((key) => (
+                        <option
+                          key={key}
+                          value={key === "prompt" ? "" : key[0].toUpperCase() + key.slice(1)}
+                        >
+                          {t(`application.contact.phoneNumberTypes.${key}`)}
+                        </option>
+                      ))}
                     </select>
                     <ErrorMessage error={errors?.additionalPhoneNumberType}>
                       {t("application.contact.phoneNumberTypeError")}
@@ -362,7 +365,7 @@ export default () => {
             <div className={"field " + (errors.contactPreferences ? "error" : "")}>
               {contactPreferencesKeys.map((preference) => {
                 return (
-                  <>
+                  <Fragment key={preference}>
                     <input
                       type="checkbox"
                       name="contactPreferences"
@@ -378,7 +381,7 @@ export default () => {
                     >
                       {t("application.form.options.contact." + preference)}
                     </label>
-                  </>
+                  </Fragment>
                 )
               })}
               <ErrorMessage error={errors.contactPreferences}>

--- a/apps/public-reference/pages/applications/contact/alternate-contact-name.tsx
+++ b/apps/public-reference/pages/applications/contact/alternate-contact-name.tsx
@@ -36,7 +36,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/contact/alternate-contact-type.tsx
+++ b/apps/public-reference/pages/applications/contact/alternate-contact-type.tsx
@@ -41,7 +41,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/contact/alternate-contact-type.tsx
+++ b/apps/public-reference/pages/applications/contact/alternate-contact-type.tsx
@@ -9,7 +9,7 @@ import FormsLayout from "../../../layouts/forms"
 import { useForm } from "react-hook-form"
 import { AppSubmissionContext } from "../../../lib/AppSubmissionContext"
 import ApplicationConductor from "../../../lib/ApplicationConductor"
-import { useContext, useMemo } from "react"
+import { useContext, useMemo, Fragment } from "react"
 
 export default () => {
   const context = useContext(AppSubmissionContext)
@@ -68,7 +68,7 @@ export default () => {
             </p>
             {options.map((option, i) => {
               return (
-                <>
+                <Fragment key={option}>
                   <div className={"field " + (errors.type ? "error" : "")}>
                     <input
                       key={option}
@@ -105,7 +105,7 @@ export default () => {
                       </ErrorMessage>
                     )}
                   </div>
-                </>
+                </Fragment>
               )
             })}
           </div>

--- a/apps/public-reference/pages/applications/contact/name.tsx
+++ b/apps/public-reference/pages/applications/contact/name.tsx
@@ -41,7 +41,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/financial/income.tsx
+++ b/apps/public-reference/pages/applications/financial/income.tsx
@@ -102,7 +102,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/financial/income.tsx
+++ b/apps/public-reference/pages/applications/financial/income.tsx
@@ -109,7 +109,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href="/applications/financial/vouchers">{t("t.back")}</Link>
+            <Link href="/applications/financial/vouchers">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/financial/vouchers.tsx
+++ b/apps/public-reference/pages/applications/financial/vouchers.tsx
@@ -42,7 +42,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/financial/vouchers.tsx
+++ b/apps/public-reference/pages/applications/financial/vouchers.tsx
@@ -49,7 +49,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href="/applications/reserved/units">{t("t.back")}</Link>
+            <Link href="/applications/reserved/units">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/household/ada.tsx
+++ b/apps/public-reference/pages/applications/household/ada.tsx
@@ -60,7 +60,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href="/applications/household/current">{t("t.back")}</Link>
+            <Link href="/applications/household/current">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/household/ada.tsx
+++ b/apps/public-reference/pages/applications/household/ada.tsx
@@ -53,7 +53,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/household/add-members.tsx
+++ b/apps/public-reference/pages/applications/household/add-members.tsx
@@ -61,7 +61,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/household/add-members.tsx
+++ b/apps/public-reference/pages/applications/household/add-members.tsx
@@ -68,7 +68,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href="/applications/household/members-info">{t("t.back")}</Link>
+            <Link href="/applications/household/members-info">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
         <div className="form-card__lead border-b">

--- a/apps/public-reference/pages/applications/household/current.tsx
+++ b/apps/public-reference/pages/applications/household/current.tsx
@@ -37,7 +37,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/household/current.tsx
+++ b/apps/public-reference/pages/applications/household/current.tsx
@@ -44,7 +44,9 @@ export default () => {
       <FormCard>
         <p className="text-bold">
           <strong>
-            <Link href="/applications/household/preferred-units">{t("t.back")}</Link>
+            <Link href="/applications/household/preferred-units">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/household/live-alone.tsx
+++ b/apps/public-reference/pages/applications/household/live-alone.tsx
@@ -49,7 +49,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href={backUrl}>{t("t.back")}</Link>
+            <Link href={backUrl}>
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
         <div className="form-card__lead border-b">

--- a/apps/public-reference/pages/applications/household/live-alone.tsx
+++ b/apps/public-reference/pages/applications/household/live-alone.tsx
@@ -42,7 +42,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/household/member.tsx
+++ b/apps/public-reference/pages/applications/household/member.tsx
@@ -113,7 +113,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/household/members-info.tsx
+++ b/apps/public-reference/pages/applications/household/members-info.tsx
@@ -40,7 +40,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href="/applications/household/live-alone">{t("t.back")}</Link>
+            <Link href="/applications/household/live-alone">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
         <div className="form-card__lead">

--- a/apps/public-reference/pages/applications/household/members-info.tsx
+++ b/apps/public-reference/pages/applications/household/members-info.tsx
@@ -33,7 +33,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/household/preferred-units.tsx
+++ b/apps/public-reference/pages/applications/household/preferred-units.tsx
@@ -49,7 +49,9 @@ export default () => {
       <FormCard>
         <p className="text-bold">
           <strong>
-            <Link href={backPath}>Back</Link>
+            <Link href={backPath}>
+              <a>Back</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/household/preferred-units.tsx
+++ b/apps/public-reference/pages/applications/household/preferred-units.tsx
@@ -42,7 +42,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/preferences/general.tsx
+++ b/apps/public-reference/pages/applications/preferences/general.tsx
@@ -47,7 +47,9 @@ export default () => {
       <FormCard>
         <p className="text-bold">
           <strong>
-            <Link href="/applications/preferences/live-or-work">{t("t.back")}</Link>
+            <Link href="/applications/preferences/live-or-work">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/preferences/general.tsx
+++ b/apps/public-reference/pages/applications/preferences/general.tsx
@@ -40,7 +40,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/preferences/intro.tsx
+++ b/apps/public-reference/pages/applications/preferences/intro.tsx
@@ -37,7 +37,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/preferences/intro.tsx
+++ b/apps/public-reference/pages/applications/preferences/intro.tsx
@@ -44,7 +44,9 @@ export default () => {
       <FormCard>
         <p className="text-bold">
           <strong>
-            <Link href="/applications/financial/income">{t("t.back")}</Link>
+            <Link href="/applications/financial/income">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/preferences/live-or-work.tsx
+++ b/apps/public-reference/pages/applications/preferences/live-or-work.tsx
@@ -37,7 +37,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/preferences/live-or-work.tsx
+++ b/apps/public-reference/pages/applications/preferences/live-or-work.tsx
@@ -44,7 +44,9 @@ export default () => {
       <FormCard>
         <p className="text-bold">
           <strong>
-            <Link href="/applications/preferences/intro">{t("t.back")}</Link>
+            <Link href="/applications/preferences/intro">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/reserved/units.tsx
+++ b/apps/public-reference/pages/applications/reserved/units.tsx
@@ -47,7 +47,9 @@ export default () => {
       <FormCard>
         <p className="text-bold">
           <strong>
-            <Link href="/applications/household/ada">{t("t.back")}</Link>
+            <Link href="/applications/household/ada">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/reserved/units.tsx
+++ b/apps/public-reference/pages/applications/reserved/units.tsx
@@ -40,7 +40,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/review/demographics.tsx
+++ b/apps/public-reference/pages/applications/review/demographics.tsx
@@ -37,7 +37,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/review/demographics.tsx
+++ b/apps/public-reference/pages/applications/review/demographics.tsx
@@ -44,7 +44,9 @@ export default () => {
       <FormCard>
         <p className="text-bold">
           <strong>
-            <Link href="/applications/preferences/general">{t("t.back")}</Link>
+            <Link href="/applications/preferences/general">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/review/summary.tsx
+++ b/apps/public-reference/pages/applications/review/summary.tsx
@@ -88,7 +88,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/review/summary.tsx
+++ b/apps/public-reference/pages/applications/review/summary.tsx
@@ -10,7 +10,7 @@ import FormsLayout from "../../../layouts/forms"
 import { useForm } from "react-hook-form"
 import { AppSubmissionContext } from "../../../lib/AppSubmissionContext"
 import ApplicationConductor from "../../../lib/ApplicationConductor"
-import { useContext, useMemo, ReactNode } from "react"
+import { useContext, useMemo, ReactNode, Fragment } from "react"
 
 const EditLink = (props: { href: string }) => (
   <div className="float-right flex">
@@ -188,7 +188,7 @@ export default () => {
         {application.householdSize > 0 && (
           <div className="form-card__group info-group mx-0">
             {application.householdMembers.map((member) => (
-              <div className="info-group__item">
+              <div className="info-group__item" key={`${member.firstName} - ${member.lastName}`}>
                 <p className="info-item__value">
                   {member.firstName} {member.lastName}
                 </p>
@@ -221,10 +221,10 @@ export default () => {
         <div className="form-card__group mx-0">
           <ReviewItem label={t("application.ada.label")}>
             {accessibilityLabels(application.accessibility).map((item) => (
-              <>
+              <Fragment key={item}>
                 {item}
                 <br />
-              </>
+              </Fragment>
             ))}
           </ReviewItem>
         </div>

--- a/apps/public-reference/pages/applications/review/summary.tsx
+++ b/apps/public-reference/pages/applications/review/summary.tsx
@@ -95,7 +95,9 @@ export default () => {
       <FormCard>
         <p className="form-card__back">
           <strong>
-            <Link href="/applications/review/demographics">{t("t.back")}</Link>
+            <Link href="/applications/review/demographics">
+              <a>{t("t.back")}</a>
+            </Link>
           </strong>
         </p>
 

--- a/apps/public-reference/pages/applications/review/terms.tsx
+++ b/apps/public-reference/pages/applications/review/terms.tsx
@@ -65,7 +65,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/start/choose-language.tsx
+++ b/apps/public-reference/pages/applications/start/choose-language.tsx
@@ -56,7 +56,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/start/choose-language.tsx
+++ b/apps/public-reference/pages/applications/start/choose-language.tsx
@@ -42,9 +42,8 @@ export default () => {
   const currentPageStep = 1
 
   /* Form Handler */
-  const { register, handleSubmit, errors } = useForm()
-  const onSubmit = (data) => {
-    console.log(data)
+  const { handleSubmit } = useForm()
+  const onSubmit = () => {
     conductor.sync()
 
     Router.push("/applications/start/what-to-expect").then(() => window.scrollTo(0, 0))

--- a/apps/public-reference/pages/applications/start/what-to-expect.tsx
+++ b/apps/public-reference/pages/applications/start/what-to-expect.tsx
@@ -28,7 +28,6 @@ export default () => {
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}
-          totalNumberOfSteps={conductor.totalNumberOfSteps()}
           labels={["You", "Household", "Income", "Preferences", "Review"]}
         />
       </FormCard>

--- a/apps/public-reference/pages/applications/start/what-to-expect.tsx
+++ b/apps/public-reference/pages/applications/start/what-to-expect.tsx
@@ -7,14 +7,12 @@ import { Button, FormCard, ProgressNav, t } from "@bloom-housing/ui-components"
 import FormsLayout from "../../../layouts/forms"
 import { useForm } from "react-hook-form"
 import { AppSubmissionContext } from "../../../lib/AppSubmissionContext"
-import ApplicationConductor from "../../../lib/ApplicationConductor"
 import { useContext } from "react"
 
 export default () => {
   const context = useContext(AppSubmissionContext)
-  const { application, listing } = context
-  const conductor = new ApplicationConductor(application, listing, context)
-  const currentPageStep = 2
+  const { application } = context
+  const currentPageStep = 1
 
   /* Form Handler */
   const { handleSubmit } = useForm()

--- a/shared/ui-components/src/forms/ProgressNav.stories.tsx
+++ b/shared/ui-components/src/forms/ProgressNav.stories.tsx
@@ -11,7 +11,6 @@ export const Default = () => (
   <ProgressNav
     currentPageStep={2}
     completedSteps={1}
-    totalNumberOfSteps={5}
     labels={["You", "Household", "Income", "Preferences", "Review"]}
   />
 )

--- a/shared/ui-components/src/forms/ProgressNav.tsx
+++ b/shared/ui-components/src/forms/ProgressNav.tsx
@@ -10,7 +10,7 @@ const ProgressNavItem = (props: {
 }) => {
   let bgColor = "is-disabled"
   if (onClientSide()) {
-    if (props.step == props.currentPageStep) {
+    if (props.step === props.currentPageStep) {
       bgColor = "is-active"
     } else if (props.completedSteps >= props.step) {
       bgColor = ""
@@ -27,24 +27,22 @@ const ProgressNavItem = (props: {
 const ProgressNav = (props: {
   currentPageStep: number
   completedSteps: number
-  totalNumberOfSteps: number
   labels: string[]
 }) => {
-  let i = 0
-  const stepIndicators = []
-  while (i < props.totalNumberOfSteps) {
-    i++
-    stepIndicators.push(
-      <ProgressNavItem
-        step={i}
-        currentPageStep={props.currentPageStep}
-        completedSteps={props.completedSteps}
-        label={props.labels[i - 1]}
-      />
-    )
-  }
-
-  return <ul className={!onClientSide() ? "invisible" : "progress-nav"}>{stepIndicators}</ul>
+  return (
+    <ul className={!onClientSide() ? "invisible" : "progress-nav"}>
+      {props.labels.map((label, i) => (
+        <ProgressNavItem
+          key={label}
+          // Steps are 1-indexed
+          step={i + 1}
+          currentPageStep={props.currentPageStep}
+          completedSteps={props.completedSteps}
+          label={label}
+        />
+      ))}
+    </ul>
+  )
 }
 
 export { ProgressNav as default, ProgressNav }

--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -113,6 +113,12 @@
     "contact": {
       "title": "Thanks %{firstName}. Now we need to know how to contact you.",
       "yourPhoneNumber": "Your Phone Number",
+      "phoneNumberTypes": {
+        "prompt": "What type of number is this?",
+        "work": "Work",
+        "home": "Home",
+        "cell": "Cell"
+      },
       "phoneNumberError": "Please enter a phone number",
       "noPhoneNumber": "I don't have a telephone number",
       "phoneNumberTypeError": "Please enter a phone number type",


### PR DESCRIPTION
# Clean up application form warnings

This PR cleans up most of the warnings that we were seeing in the application forms.

- Missing Unique key warnings caused  by `<ProgressNav />`
- Missing Unique keys on a few of the form pages
- Fixed `<Link>` not having nested `<a>` tags for back buttons
- Fixed bug where the conductor was serializing the string literal `undefined` to sessionStorage if no listing was defined (which would then prevent the page from reloading properly).

I'm still seeing a couple warnings resulting from dynamically generated text:

![image](https://user-images.githubusercontent.com/1310129/88836150-246cf080-d18b-11ea-9be4-974ffba53cf4.png)

This occurs when the page text is updated based on a variable that's only available client-side (e.g. comes from local storage/an existing object - the version that React rehydrates the page with is different from Next.js's SSR. This doesn't really seem to be causing usability issues ATM, so it might not be worth investing too much time into.

Closes #294.