### PR TITLE
Don't rerun yarn install during heroku app startup

### DIFF
--- a/backend/core/package.json
+++ b/backend/core/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "rimraf dist && nest build",
-    "start": "yarn run build && node dist/src/main",
+    "start": "node dist/src/main",
     "dev": "NODE_ENV=development nest start --watch",
     "debug": "nest start --debug --watch",
     "test": "jest --config ./jest.json",

--- a/services/listings/package.json
+++ b/services/listings/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "yarn run clean && tsc -p tsconfig.prod.json && cp -r listings dist",
-    "start": "yarn install && yarn run build && node dist/src/index.js",
+    "start": "node dist/src/index.js",
     "dev": "ts-node-dev src/index.ts",
     "test": "jest",
     "herokusetup": "node heroku.setup.js"


### PR DESCRIPTION
Heroku service startup was starting to consistently fail because it was taking more than a minute, and investigation led to us trying to run `yarn install` every time we started up the service.

This should fix things for both the legacy listings service and the new nestjs backend core.