### PR TITLE
Fix minor issues with Cypress for partners-reference

### DIFF
--- a/apps/partners-reference/cypress/support/index.ts
+++ b/apps/partners-reference/cypress/support/index.ts
@@ -54,7 +54,7 @@ declare global {
 
 Cypress.Commands.add(
   "login",
-  (email: string, password: string, { apiBase = "http://localhost:3001" } = {}) => {
+  (email: string, password: string, { apiBase = "http://localhost:3100" } = {}) => {
     return cy
       .request({
         url: `${apiBase}/auth/login`,
@@ -74,7 +74,7 @@ Cypress.Commands.add("logout", () =>
   cy.window().then((window) => window.sessionStorage.removeItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY))
 )
 
-Cypress.Commands.add("createUser", (user: UserFields, { apiBase = "http://localhost:3001" } = {}) =>
+Cypress.Commands.add("createUser", (user: UserFields, { apiBase = "http://localhost:3100" } = {}) =>
   cy
     .request({
       url: `${apiBase}/auth/register`,

--- a/apps/partners-reference/package.json
+++ b/apps/partners-reference/package.json
@@ -31,12 +31,15 @@
     "react-hook-form": "^6.3.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.11.1",
+    "@babel/preset-env": "^7.11.0",
     "@cypress/webpack-preprocessor": "^5.4.2",
     "@next/bundle-analyzer": "9.5.1",
     "@types/node": "^12.12.50",
     "@types/react": "^16.9.44",
+    "babel-loader": "^8.1.0",
     "concurrently": "^5.2.0",
-    "cypress": "^4.12.0",
+    "cypress": "^4.12.1",
     "js-levenshtein": "^1.1.6",
     "next-transpile-modules": "^4.0.2",
     "sass-loader": "^9.0.2",

--- a/apps/public-reference/package.json
+++ b/apps/public-reference/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^12.12.50",
     "@types/react": "^16.9.44",
     "concurrently": "^5.2.0",
-    "cypress": "^4.12.0",
+    "cypress": "^4.12.1",
     "js-levenshtein": "^1.1.6",
     "next-transpile-modules": "^4.0.2",
     "sass-loader": "^9.0.2",

--- a/backend/core/package.json
+++ b/backend/core/package.json
@@ -53,7 +53,7 @@
     "typescript": "^3.9.7"
   },
   "devDependencies": {
-    "@babel/core": "^7.10.5",
+    "@babel/core": "^7.11.1",
     "@babel/plugin-proposal-decorators": "^7.10.5",
     "@nestjs/schematics": "^7.0.0",
     "@nestjs/testing": "^7.4.2",

--- a/services/listings/package.json
+++ b/services/listings/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-3.0",
   "private": true,
   "devDependencies": {
-    "@babel/core": "^7.10.5",
+    "@babel/core": "^7.11.1",
     "@babel/preset-typescript": "^7.10.4",
     "@types/jest": "^26.0.8",
     "@types/jsonpath": "^0.2.0",

--- a/shared/core/package.json
+++ b/shared/core/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@babel/core": "^7.10.5",
+    "@babel/core": "^7.11.1",
     "@types/jest": "^26.0.8",
     "babel-jest": "^26.2.2",
     "babel-loader": "^8.1.0",

--- a/shared/ui-components/package.json
+++ b/shared/ui-components/package.json
@@ -12,7 +12,7 @@
     "test": "jest shared/ui-components"
   },
   "devDependencies": {
-    "@babel/core": "^7.10.5",
+    "@babel/core": "^7.11.1",
     "@emotion/core": "^10.0.27",
     "@emotion/styled": "10.0.27",
     "@storybook/addon-a11y": "6.0.0-rc.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -169,7 +169,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@7.10.5", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.7.5":
+"@babel/core@7.10.5", "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.10.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.10.5.tgz#1f15e2cca8ad9a1d78a38ddba612f5e7cdbbd330"
   integrity sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==
@@ -207,6 +207,28 @@
     debug "^4.1.0"
     json5 "^2.1.0"
     lodash "^4.17.13"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.11.1":
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.1.tgz#2c55b604e73a40dc21b0e52650b11c65cf276643"
+  integrity sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.11.0"
+    "@babel/helper-module-transforms" "^7.11.0"
+    "@babel/helpers" "^7.10.4"
+    "@babel/parser" "^7.11.1"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.11.0"
+    "@babel/types" "^7.11.0"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
     resolve "^1.3.2"
     semver "^5.4.1"
     source-map "^0.5.0"
@@ -506,6 +528,11 @@
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.0.tgz#a9d7e11aead25d3b422d17b2c6502c8dddef6a5d"
   integrity sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==
+
+"@babel/parser@^7.11.1":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.2.tgz#0882ab8a455df3065ea2dcb4c753b2460a24bead"
+  integrity sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4", "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.10.5"
@@ -1240,7 +1267,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.9.5", "@babel/preset-env@^7.9.6":
+"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.9.5", "@babel/preset-env@^7.9.6":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.11.0.tgz#860ee38f2ce17ad60480c2021ba9689393efb796"
   integrity sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
@@ -7486,10 +7513,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@^4.12.0:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.12.0.tgz#b9d9b16d45be28543edc0e4dc89987bed5bb090b"
-  integrity sha512-ZDngKMwoQ2UYmeSUJikLMZG6t2N7lTHHlzBzh5W0MbPfXSMv36YUgL2ZVD+t4ZLA63WWkvhwxIkDG+WJknBgHw==
+cypress@^4.12.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.12.1.tgz#0ead1b9f4c0917d69d8b57f996b6e01fe693b6ec"
+  integrity sha512-9SGIPEmqU8vuRA6xst2CMTYd9sCFCxKSzrHt0wr+w2iAQMCIIsXsQ5Gplns1sT6LDbZcmLv6uehabAOl3fhc9Q==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
- Fixes the port numbers in the partners-reference Cypress API tests to match the new numbering scheme in #468. 
- Makes explicit the peerDependencies for the Cypress webpack processor, which is the last thing for fixes #137. 
- Bumped the babel and cypress versions globally while I was at it.