### PR TITLE
fix backend/core test failures

### DIFF
--- a/backend/core/jest.json
+++ b/backend/core/jest.json
@@ -1,8 +1,8 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": "..",
+  "rootDir": ".",
   "testEnvironment": "node",
-  "testRegex": ".spec.ts$",
+  "testRegex": "\\.spec\\.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }

--- a/backend/core/src/auth/auth.controller.spec.ts
+++ b/backend/core/src/auth/auth.controller.spec.ts
@@ -2,6 +2,11 @@ import { Test, TestingModule } from "@nestjs/testing"
 import { AuthController } from "./auth.controller"
 import { AuthService } from "./auth.service"
 
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
 describe("Auth Controller", () => {
   let controller: AuthController
 

--- a/backend/core/src/auth/auth.controller.spec.ts
+++ b/backend/core/src/auth/auth.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { AuthController } from "./auth.controller"
 import { AuthService } from "./auth.service"
+import { UserService } from "../user/user.service"
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
@@ -13,7 +14,10 @@ describe("Auth Controller", () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       // Add mock implementations here as needed for tests.
-      providers: [{ provide: AuthService, useValue: {} }],
+      providers: [
+        { provide: AuthService, useValue: {} },
+        { provide: UserService, useValue: {} },
+      ],
       controllers: [AuthController],
     }).compile()
 

--- a/backend/core/src/auth/auth.service.spec.ts
+++ b/backend/core/src/auth/auth.service.spec.ts
@@ -3,6 +3,11 @@ import { AuthService } from "./auth.service"
 import { User } from "../entity/user.entity"
 import { JwtModule, JwtService } from "@nestjs/jwt"
 
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
 describe("AuthService", () => {
   let service: AuthService
   let jwtService: JwtService

--- a/backend/core/src/auth/auth.service.spec.ts
+++ b/backend/core/src/auth/auth.service.spec.ts
@@ -2,6 +2,8 @@ import { Test, TestingModule } from "@nestjs/testing"
 import { AuthService } from "./auth.service"
 import { User } from "../entity/user.entity"
 import { JwtModule, JwtService } from "@nestjs/jwt"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { RevokedToken } from "../entity/revokedToken.entity"
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
@@ -15,7 +17,13 @@ describe("AuthService", () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [JwtModule.register({ secret: "secret" })],
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(RevokedToken),
+          useValue: {},
+        },
+      ],
     }).compile()
 
     service = module.get<AuthService>(AuthService)

--- a/backend/core/src/auth/constants.ts
+++ b/backend/core/src/auth/constants.ts
@@ -1,5 +1,9 @@
 // Ensure that a secret key is defined if we're not in dev mode
-if (process.env.NODE_ENV !== "development" && !process.env.APP_SECRET) {
+if (
+  process.env.NODE_ENV !== "development" &&
+  process.env.NODE_ENV !== "test" &&
+  !process.env.APP_SECRET
+) {
   throw new Error("APP_SECRET not found! This is a required config variable in production.")
 }
 

--- a/backend/core/src/entity/revokedToken.entity.ts
+++ b/backend/core/src/entity/revokedToken.entity.ts
@@ -2,7 +2,7 @@ import { PrimaryColumn, CreateDateColumn, Entity } from "typeorm"
 
 @Entity({ name: "revoked_tokens" })
 class RevokedToken {
-  @PrimaryColumn()
+  @PrimaryColumn("string")
   token: string
 
   @CreateDateColumn()

--- a/backend/core/src/entity/revokedToken.entity.ts
+++ b/backend/core/src/entity/revokedToken.entity.ts
@@ -5,7 +5,7 @@ class RevokedToken {
   @PrimaryColumn("varchar")
   token: string
 
-  @CreateDateColumn("timestamp without time zone")
+  @CreateDateColumn()
   revokedAt: Date
 }
 

--- a/backend/core/src/entity/revokedToken.entity.ts
+++ b/backend/core/src/entity/revokedToken.entity.ts
@@ -2,10 +2,10 @@ import { PrimaryColumn, CreateDateColumn, Entity } from "typeorm"
 
 @Entity({ name: "revoked_tokens" })
 class RevokedToken {
-  @PrimaryColumn("string")
+  @PrimaryColumn("varchar")
   token: string
 
-  @CreateDateColumn()
+  @CreateDateColumn("timestamp without time zone")
   revokedAt: Date
 }
 

--- a/backend/core/src/entity/user.entity.ts
+++ b/backend/core/src/entity/user.entity.ts
@@ -26,9 +26,9 @@ class User {
   lastName: string
   @Column("timestamp without time zone")
   dob: Date
-  @CreateDateColumn("timestamp without time zone")
+  @CreateDateColumn()
   createdAt: Date
-  @UpdateDateColumn("timestamp without time zone")
+  @UpdateDateColumn()
   updatedAt: Date
   @OneToMany((type) => Application, (application) => application.user)
   applications: Application[]

--- a/backend/core/src/entity/user.entity.ts
+++ b/backend/core/src/entity/user.entity.ts
@@ -14,21 +14,21 @@ import { Application } from "./application.entity"
 class User {
   @PrimaryGeneratedColumn("uuid")
   id: string
-  @Column({ select: false })
+  @Column("varchar", { select: false })
   passwordHash: string
-  @Column()
+  @Column("varchar")
   email: string
-  @Column()
+  @Column("varchar")
   firstName: string
-  @Column({ nullable: true })
+  @Column("varchar", { nullable: true })
   middleName?: string
-  @Column()
+  @Column("varchar")
   lastName: string
-  @Column()
+  @Column("timestamp without time zone")
   dob: Date
-  @CreateDateColumn()
+  @CreateDateColumn("timestamp without time zone")
   createdAt: Date
-  @UpdateDateColumn()
+  @UpdateDateColumn("timestamp without time zone")
   updatedAt: Date
   @OneToMany((type) => Application, (application) => application.user)
   applications: Application[]

--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -4,7 +4,6 @@ import { ListingsSeederService } from "./seeder/listings-seeder/listings-seeder.
 import { UserService } from "./user/user.service"
 import { CreateUserDto } from "./user/createUser.dto"
 import { plainToClass } from "class-transformer"
-import { ApplicationsService } from "./applications/applications.service"
 import { Application } from "./entity/application.entity"
 import { ListingsService } from "./listings/listings.service"
 

--- a/backend/core/src/user/user.controller.spec.ts
+++ b/backend/core/src/user/user.controller.spec.ts
@@ -2,6 +2,11 @@ import { Test, TestingModule } from "@nestjs/testing"
 import { UserController } from "./user.controller"
 import { PassportModule } from "@nestjs/passport"
 
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
 describe("User Controller", () => {
   let controller: UserController
 

--- a/backend/core/src/user/user.service.spec.ts
+++ b/backend/core/src/user/user.service.spec.ts
@@ -1,17 +1,27 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { UserService } from "./user.service"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { User } from "../entity/user.entity"
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
 // see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
 declare const expect: jest.Expect
 
+const mockUserRepo = {}
+
 describe("UserService", () => {
   let service: UserService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepo,
+        },
+      ],
     }).compile()
 
     service = module.get(UserService)

--- a/backend/core/src/user/user.service.spec.ts
+++ b/backend/core/src/user/user.service.spec.ts
@@ -1,6 +1,11 @@
 import { Test, TestingModule } from "@nestjs/testing"
 import { UserService } from "./user.service"
 
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
 describe("UserService", () => {
   let service: UserService
 

--- a/backend/core/test/applications/applications.e2e-spec.ts
+++ b/backend/core/test/applications/applications.e2e-spec.ts
@@ -11,6 +11,11 @@ import { ListingsModule } from "../../src/listings/listings.module"
 import { ApplicationsModule } from "../../src/applications/applications.module"
 import { applicationSetup } from "../../src/app.module"
 
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
 describe("Applications", () => {
   let app: INestApplication
   let user1Id: string

--- a/backend/core/test/lib/url_helper.spec.ts
+++ b/backend/core/test/lib/url_helper.spec.ts
@@ -3,6 +3,11 @@ import { formatUrlSlug, listingUrlSlug } from "../../src/lib/url_helper"
 import triton from "../../../../services/listings/listings/triton-test.json"
 import { Listing } from "../../src/entity/listing.entity"
 
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
 describe("formatUrlSlug", () => {
   test("reformats strings properly", () => {
     expect(formatUrlSlug("snake_case")).toEqual("snake_case")
@@ -24,6 +29,6 @@ describe("listingUrlSlug", () => {
 
   test("Generates a URL slug for a Listing", () => {
     const slug = listingUrlSlug(listing)
-    expect(slug).toEqual("the_triton_55_triton_park_lane_foster_city_ca")
+    expect(slug).toEqual("test_triton_55_triton_park_lane_foster_city_ca")
   })
 })

--- a/backend/core/test/listings/listings.spec.ts
+++ b/backend/core/test/listings/listings.spec.ts
@@ -7,6 +7,11 @@ import dbOptions = require("../../ormconfig.test")
 import supertest from "supertest"
 import { applicationSetup } from "../../src/app.module"
 
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
 describe("Listings", () => {
   let app
   beforeAll(async () => {

--- a/backend/core/test/listings/listings.spec.ts
+++ b/backend/core/test/listings/listings.spec.ts
@@ -1,16 +1,24 @@
-import listingsLoader from "@bloom-housing/listings-service/src/lib/listings_loader"
-import { Listing } from "@bloom-housing/core"
 import { Test } from "@nestjs/testing"
-import { ListingsModule } from "../../src/listings/listings.module"
 import { TypeOrmModule } from "@nestjs/typeorm"
-import dbOptions = require("../../ormconfig.test")
+import fs from "fs"
+import path from "path"
+import { Listing } from "@bloom-housing/core"
+import { ListingsModule } from "../../src/listings/listings.module"
 import supertest from "supertest"
 import { applicationSetup } from "../../src/app.module"
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const dbOptions = require("../../ormconfig.test")
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
 // see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
 declare const expect: jest.Expect
+
+// Get listings from the seed used by `yarn seed:test`
+const allListings = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "../../seeds.json")).toString()
+) as Listing[]
 
 describe("Listings", () => {
   let app
@@ -25,17 +33,13 @@ describe("Listings", () => {
 
   it("should return all listings", async () => {
     const res = await supertest(app.getHttpServer()).get("/").expect(200)
-    const allListings = (await listingsLoader("listings")) as Listing[]
     expect(res.body.listings.length).toEqual(allListings.length)
   })
 
   it("should return only the specified listings", async () => {
     const query = "/?jsonpath=%24%5B%3F%28%40.applicationAddress.city%3D%3D%22San%20Jose%22%29%5D"
     const res = await supertest(app.getHttpServer()).get(query).expect(200)
-    let sjListings = (await listingsLoader("listings")) as Listing[]
-    sjListings = sjListings.filter((item) => {
-      return item.applicationAddress.city == "San Jose"
-    })
+    const sjListings = allListings.filter((item) => item.applicationAddress.city == "San Jose")
     expect(res.body.listings.length).toEqual(sjListings.length)
   })
 
@@ -48,9 +52,8 @@ describe("Listings", () => {
   it("should return only active listings", async () => {
     const query = "/?jsonpath=%24%5B%3F%28%40.status%3D%3D%22active%22%29%5D"
     const res = await supertest(app.getHttpServer()).get(query).expect(200)
-    const sjListings = (await listingsLoader("listings")) as Listing[]
     // One listing has unapproved status.
-    expect(res.body.listings.length).toEqual(sjListings.length - 1)
+    expect(res.body.listings.length).toEqual(allListings.length - 1)
   })
 
   afterEach(() => {


### PR DESCRIPTION
This is a downpayment on #474. It looks like it's not just the jest config, but the actual tests need help (or I'm using them so incorrectly that they need much better documentation).

Based on the error messages that I was getting, I first updated all the relevant tests to make sure we were using jest's expect and not the one from cypress/chai, which seems to be a common monorepo problem.

Once I got past that, things got more interesting with the entities not reflecting metadata correctly and the app not starting up in many cases. I tried to update the metadata to include the actual database column types, which seemed to help but then created a new set of problems. @bencpeters or @pbn4, do you know how this was working right before? Is it something that broke with the upgrade to jest26 or a newer nest version? 