### PR TITLE
Expand CircleCI Coverage to include backend/core and app builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,15 +14,23 @@ jobs:
     steps:
       - checkout
       - run: yarn install
+      - save_cache:
+          key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/
   lint:
     docker:
       - image: circleci/node:12
     steps:
+      - restore_cache:
+          key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn lint
   jest-tests:
     docker:
       - image: circleci/node:12
     steps:
+      - restore_cache:
+          key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn test:shared:ui
       - run: yarn test:services:listings
       - run: yarn test:backend:core
@@ -31,6 +39,8 @@ jobs:
       - image: circleci/node:12
     working_directory: apps/public-reference
     steps:
+      - restore_cache:
+          key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn build
       - run: yarn export
   build-partners:
@@ -38,6 +48,8 @@ jobs:
       - image: circleci/node:12
     working_directory: apps/partners-reference
     steps:
+      - restore_cache:
+          key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn build
       - run: yarn export
 
@@ -59,6 +71,8 @@ workflows:
           requires:
             - setup
       - cypress/run:
+          requires:
+            - setup
           executor: cypress-node-12
           working_directory: apps/public-reference
           yarn: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
   version: 2
   build:
     jobs:
+      - setup
       - lint:
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,8 @@ jobs:
       - checkout
       - run: cd yarn install
       - run: yarn install
+      - run: yarn build
+      - run: yarn export
   build-partners:
     docker:
       - image: circleci/node:12
@@ -40,6 +42,8 @@ jobs:
       - checkout
       - run: cd yarn install
       - run: yarn install
+      - run: yarn build
+      - run: yarn export
 
 workflows:
   version: 2
@@ -53,4 +57,5 @@ workflows:
           start: yarn dev:all
           wait-on: "http://localhost:3000"
       - jest-tests
-      - build-apps
+      - build-public
+      - build-partners

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,33 +25,35 @@ jobs:
       - restore_cache:
           key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn lint
-  jest-tests:
+  jest-ui-components:
     docker:
       - image: circleci/node:12
     steps:
       - restore_cache:
           key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn test:shared:ui
+  jest-backend:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - restore_cache:
+          key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
       - run: yarn test:services:listings
       - run: yarn test:backend:core
   build-public:
     docker:
       - image: circleci/node:12
-    working_directory: apps/public-reference
     steps:
       - restore_cache:
           key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
-      - run: yarn build
-      - run: yarn export
+      - run: yarn build:app:public
   build-partners:
     docker:
       - image: circleci/node:12
-    working_directory: apps/partners-reference
     steps:
       - restore_cache:
           key: build-cache-{{ .Environment.CIRCLE_SHA1 }}
-      - run: yarn build
-      - run: yarn export
+      - run: yarn build:app:partners
 
 workflows:
   version: 2
@@ -61,7 +63,10 @@ workflows:
       - lint:
           requires:
             - setup
-      - jest-tests:
+      - jest-ui-components:
+          requires:
+            - setup
+      - jest-ui-backend:
           requires:
             - setup
       - build-public:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,13 @@ executors:
       - image: "cypress/base:12.16.1"
 
 jobs:
+  lint:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - run: yarn install
+      - run: yarn lint
   jest-tests:
     docker:
       - image: circleci/node:12
@@ -16,10 +23,29 @@ jobs:
       - run: yarn install
       - run: yarn test:shared:ui
       - run: yarn test:services:listings
+      - run: yarn test:backend:core
+  build-public:
+    docker:
+      - image: circleci/node:12
+    working_directory: apps/public-reference
+    steps:
+      - checkout
+      - run: cd yarn install
+      - run: yarn install
+  build-partners:
+    docker:
+      - image: circleci/node:12
+    working_directory: apps/partners-reference
+    steps:
+      - checkout
+      - run: cd yarn install
+      - run: yarn install
 
 workflows:
+  version: 2
   build:
     jobs:
+      - lint
       - cypress/run:
           executor: cypress-node-12
           working_directory: apps/public-reference
@@ -27,3 +53,4 @@ workflows:
           start: yarn dev:all
           wait-on: "http://localhost:3000"
       - jest-tests
+      - build-apps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,19 +8,21 @@ executors:
       - image: "cypress/base:12.16.1"
 
 jobs:
-  lint:
+  setup:
     docker:
       - image: circleci/node:12
     steps:
       - checkout
       - run: yarn install
+  lint:
+    docker:
+      - image: circleci/node:12
+    steps:
       - run: yarn lint
   jest-tests:
     docker:
       - image: circleci/node:12
     steps:
-      - checkout
-      - run: yarn install
       - run: yarn test:shared:ui
       - run: yarn test:services:listings
       - run: yarn test:backend:core
@@ -29,9 +31,6 @@ jobs:
       - image: circleci/node:12
     working_directory: apps/public-reference
     steps:
-      - checkout
-      - run: cd yarn install
-      - run: yarn install
       - run: yarn build
       - run: yarn export
   build-partners:
@@ -39,9 +38,6 @@ jobs:
       - image: circleci/node:12
     working_directory: apps/partners-reference
     steps:
-      - checkout
-      - run: cd yarn install
-      - run: yarn install
       - run: yarn build
       - run: yarn export
 
@@ -49,13 +45,21 @@ workflows:
   version: 2
   build:
     jobs:
-      - lint
+      - lint:
+          requires:
+            - setup
+      - jest-tests:
+          requires:
+            - setup
+      - build-public:
+          requires:
+            - setup
+      - build-partners:
+          requires:
+            - setup
       - cypress/run:
           executor: cypress-node-12
           working_directory: apps/public-reference
           yarn: true
           start: yarn dev:all
           wait-on: "http://localhost:3000"
-      - jest-tests
-      - build-public
-      - build-partners

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
       - jest-ui-components:
           requires:
             - setup
-      - jest-ui-backend:
+      - jest-backend:
           requires:
             - setup
       - build-public:

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "scripts": {
     "dev:app:public": "wait-on \"http://localhost:${PORT:-3100}/\" && cd apps/public-reference && yarn dev",
     "test:app:public": "wait-on \"http://localhost:${PORT:-3101}/\" && cd apps/public-reference && yarn test",
+    "build:app:public": "cd apps/public-reference && yarn build",
     "dev:app:partners": "wait-on \"http://localhost:${PORT:-3100}/\" && cd apps/partners-reference && yarn dev",
     "test:app:partners": "wait-on \"http://localhost:${PORT:-3101}/\" && cd apps/partners-reference && yarn test",
+    "build:app:partners": "cd apps/partners-reference && yarn build",
     "dev:listings": "cd services/listings && yarn dev",
     "dev:backend": "cd backend/core && yarn dev",
     "dev:all": "concurrently --names \" OLD_LISTINGS,BACKEND_CORE,APP_PUBLIC,APP_PARTNERS\" --prefix \"{name}\" \"yarn dev:listings\" \"yarn dev:backend\" \"yarn dev:app:public\" \"yarn dev:app:partners\"",


### PR DESCRIPTION
Fixes #368
Fixes #425 (at least for CI)

Note that backend/core auth tests are failing for lack of a database. I split that off into #517 so that we can get at least some of the new coverage in the meantime.
 
There's also a build failure with partners, but that's already fixed in #500.