### PR TITLE
Support dynamic listing IDs and add name to progress nav

### DIFF
--- a/apps/public-reference/pages/applications/contact/address.tsx
+++ b/apps/public-reference/pages/applications/contact/address.tsx
@@ -66,7 +66,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/contact/alternate-contact-contact.tsx
+++ b/apps/public-reference/pages/applications/contact/alternate-contact-contact.tsx
@@ -30,7 +30,7 @@ export default () => {
   }
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/contact/alternate-contact-name.tsx
+++ b/apps/public-reference/pages/applications/contact/alternate-contact-name.tsx
@@ -26,7 +26,7 @@ export default () => {
   }
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/contact/alternate-contact-type.tsx
+++ b/apps/public-reference/pages/applications/contact/alternate-contact-type.tsx
@@ -31,7 +31,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/contact/name.tsx
+++ b/apps/public-reference/pages/applications/contact/name.tsx
@@ -31,7 +31,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/financial/income.tsx
+++ b/apps/public-reference/pages/applications/financial/income.tsx
@@ -92,7 +92,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/financial/vouchers.tsx
+++ b/apps/public-reference/pages/applications/financial/vouchers.tsx
@@ -32,7 +32,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/household/ada.tsx
+++ b/apps/public-reference/pages/applications/household/ada.tsx
@@ -43,7 +43,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/household/add-members.tsx
+++ b/apps/public-reference/pages/applications/household/add-members.tsx
@@ -51,7 +51,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/household/live-alone.tsx
+++ b/apps/public-reference/pages/applications/household/live-alone.tsx
@@ -32,7 +32,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/household/member.tsx
+++ b/apps/public-reference/pages/applications/household/member.tsx
@@ -104,7 +104,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/household/members-info.tsx
+++ b/apps/public-reference/pages/applications/household/members-info.tsx
@@ -23,7 +23,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/household/preferred-units.tsx
+++ b/apps/public-reference/pages/applications/household/preferred-units.tsx
@@ -46,7 +46,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/preferences/general.tsx
+++ b/apps/public-reference/pages/applications/preferences/general.tsx
@@ -32,7 +32,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/preferences/select.tsx
+++ b/apps/public-reference/pages/applications/preferences/select.tsx
@@ -35,7 +35,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/review/demographics.tsx
+++ b/apps/public-reference/pages/applications/review/demographics.tsx
@@ -21,7 +21,7 @@ import {
 import FormStep from "../../../src/forms/applications/FormStep"
 
 const demographics = () => {
-  const { conductor, application } = useContext(AppSubmissionContext)
+  const { conductor, application, listing } = useContext(AppSubmissionContext)
   const currentPageStep = 5
 
   /* Form Handler */
@@ -53,7 +53,7 @@ const demographics = () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/review/summary.tsx
+++ b/apps/public-reference/pages/applications/review/summary.tsx
@@ -78,7 +78,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/review/terms.tsx
+++ b/apps/public-reference/pages/applications/review/terms.tsx
@@ -53,7 +53,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/start/choose-language.tsx
+++ b/apps/public-reference/pages/applications/start/choose-language.tsx
@@ -47,7 +47,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/apps/public-reference/pages/applications/start/choose-language.tsx
+++ b/apps/public-reference/pages/applications/start/choose-language.tsx
@@ -4,7 +4,7 @@ Applicants are given the option to start the Application in one of a number of l
 https://github.com/bloom-housing/bloom/issues/277
 */
 import axios from "axios"
-import Router from "next/router"
+import { useRouter } from "next/router"
 import {
   Button,
   ImageCard,
@@ -19,20 +19,24 @@ import { AppSubmissionContext } from "../../../lib/AppSubmissionContext"
 import ApplicationConductor from "../../../lib/ApplicationConductor"
 import { useContext, useEffect, useMemo, useState } from "react"
 
-const loadListing = async (stateFunction, conductor, context) => {
+const loadListing = async (listingId, stateFunction, conductor, context) => {
   const response = await axios.get(process.env.listingServiceUrl)
-  conductor.listing = response.data.listings[2]
+  conductor.listing =
+    response.data.listings.find((listing) => listing.id == listingId) || response.data.listings[2] // FIXME: temporary fallback
   stateFunction(conductor.listing)
   context.syncListing(conductor.listing)
 }
 
 export default () => {
+  const router = useRouter()
   const [listing, setListing] = useState(null)
   const context = useContext(AppSubmissionContext)
   const { conductor, application } = context
 
+  const listingId = router.query.listingId
+
   useEffect(() => {
-    loadListing(setListing, conductor, context)
+    loadListing(listingId, setListing, conductor, context)
   }, [])
 
   const currentPageStep = 1
@@ -42,7 +46,7 @@ export default () => {
   const onSubmit = () => {
     conductor.sync()
 
-    Router.push("/applications/start/what-to-expect").then(() => window.scrollTo(0, 0))
+    router.push("/applications/start/what-to-expect").then(() => window.scrollTo(0, 0))
   }
 
   return (

--- a/apps/public-reference/pages/applications/start/what-to-expect.tsx
+++ b/apps/public-reference/pages/applications/start/what-to-expect.tsx
@@ -10,7 +10,7 @@ import { AppSubmissionContext } from "../../../lib/AppSubmissionContext"
 import { useContext } from "react"
 
 export default () => {
-  const { application } = useContext(AppSubmissionContext)
+  const { application, listing } = useContext(AppSubmissionContext)
   const currentPageStep = 1
 
   /* Form Handler */
@@ -21,7 +21,7 @@ export default () => {
 
   return (
     <FormsLayout>
-      <FormCard header="LISTING">
+      <FormCard header={listing?.name}>
         <ProgressNav
           currentPageStep={currentPageStep}
           completedSteps={application.completedStep}

--- a/backend/core/seeds.json
+++ b/backend/core/seeds.json
@@ -54,7 +54,7 @@
     "unitAmenities": "Washer and dryer, AC and Heater, Gas Stove",
     "attachments": [
       {
-        "fileUrl": "/applications/start/choose-language",
+        "fileUrl": "/applications/start/choose-language?listingId=jsQvgvy6eJy56TNCFfQp8",
         "type": 2
       }
     ],

--- a/services/listings/listings/triton-test.json
+++ b/services/listings/listings/triton-test.json
@@ -55,7 +55,7 @@
   "unitAmenities": "Washer and dryer, AC and Heater, Gas Stove",
   "attachments": [
     {
-      "fileUrl": "/applications/start/choose-language",
+      "fileUrl": "/applications/start/choose-language?listingId=jsQvgvy6eJy56TNCFfQp8",
       "type": 2
     }
   ],

--- a/shared/ui-components/src/headers/Hero/__snapshots__/Hero.stories.storyshot
+++ b/shared/ui-components/src/headers/Hero/__snapshots__/Hero.stories.storyshot
@@ -1143,7 +1143,7 @@ exports[`Storyshots Headers/Hero With Listings 1`] = `
         "applicationPhone": "(650) 437-2039",
         "attachments": Array [
           Object {
-            "fileUrl": "/applications/start/choose-language",
+            "fileUrl": "/applications/start/choose-language?listingId=jsQvgvy6eJy56TNCFfQp8",
             "type": 2,
           },
         ],

--- a/shared/ui-components/src/page_components/listing/__snapshots__/ListingsGroup.stories.storyshot
+++ b/shared/ui-components/src/page_components/listing/__snapshots__/ListingsGroup.stories.storyshot
@@ -1088,7 +1088,7 @@ exports[`Storyshots PageComponents/ListingGroup Show Listings Group 1`] = `
         "applicationPhone": "(650) 437-2039",
         "attachments": Array [
           Object {
-            "fileUrl": "/applications/start/choose-language",
+            "fileUrl": "/applications/start/choose-language?listingId=jsQvgvy6eJy56TNCFfQp8",
             "type": 2,
           },
         ],


### PR DESCRIPTION
Closes #513 

Also loads in the `listingId`query parameter to pull in the requested listing data. Currently has a fallback using the previous behavior, so we should file a separate issue to handle the real error condition of an invalid/missing ID.