### PR TITLE
Added basic version of redirect

### DIFF
--- a/apps/public-reference/lib/hooks.ts
+++ b/apps/public-reference/lib/hooks.ts
@@ -1,0 +1,13 @@
+import { useRouter } from "next/router"
+
+export function useRedirectToPrevPage(defaultPath = "/") {
+  const router = useRouter()
+
+  const redirectTo = (typeof document !== "undefined" && document.referrer) || defaultPath
+  return (queryParams: Record<string, any> = {}) => {
+    router.push({
+      pathname: redirectTo,
+      query: queryParams,
+    })
+  }
+}

--- a/apps/public-reference/lib/hooks.ts
+++ b/apps/public-reference/lib/hooks.ts
@@ -3,10 +3,11 @@ import { useRouter } from "next/router"
 export function useRedirectToPrevPage(defaultPath = "/") {
   const router = useRouter()
 
-  const redirectTo = (typeof document !== "undefined" && document.referrer) || defaultPath
   return (queryParams: Record<string, any> = {}) => {
+    const redirectUrl = router.query.redirectUrl
+
     router.push({
-      pathname: redirectTo,
+      pathname: redirectUrl && typeof redirectUrl === "string" ? redirectUrl : defaultPath,
       query: queryParams,
     })
   }

--- a/apps/public-reference/pages/applications/start/choose-language.tsx
+++ b/apps/public-reference/pages/applications/start/choose-language.tsx
@@ -116,7 +116,9 @@ export default () => {
             <p className="my-6">{t("application.chooseLanguage.signInSaveTime")}</p>
 
             <div>
-              <LinkButton href="/sign-in">{t("nav.signIn")}</LinkButton>
+              <LinkButton href="/sign-in?redirectUrl=/applications/start/choose-language">
+                {t("nav.signIn")}
+              </LinkButton>
             </div>
           </div>
         </div>

--- a/apps/public-reference/pages/create-account.tsx
+++ b/apps/public-reference/pages/create-account.tsx
@@ -10,12 +10,13 @@ import {
 } from "@bloom-housing/ui-components"
 import FormsLayout from "../layouts/forms"
 import { emailRegex } from "../lib/emailRegex"
+import { useRedirectToPrevPage } from "../lib/hooks"
 
 export default () => {
   const { createUser } = useContext(UserContext)
   /* Form Handler */
   const { register, handleSubmit, errors } = useForm()
-
+  const redirectToPrev = useRedirectToPrevPage()
   const onSubmit = async (data) => {
     try {
       const { birthDay, birthMonth, birthYear, ...rest } = data
@@ -23,6 +24,8 @@ export default () => {
         ...rest,
         dob: `${birthYear}-${birthMonth}-${birthDay}`,
       })
+
+      redirectToPrev()
       console.log("Created user: %o", user)
     } catch (err) {
       // TODO: better error handling

--- a/apps/public-reference/pages/sign-in.tsx
+++ b/apps/public-reference/pages/sign-in.tsx
@@ -12,11 +12,11 @@ import {
   UrlAlert,
 } from "@bloom-housing/ui-components"
 import FormsLayout from "../layouts/forms"
-import { useRouter } from "next/router"
+import { useRedirectToPrevPage } from "../lib/hooks"
 
 const SignIn = () => {
-  const { login, redirectToPrevPage } = useContext(UserContext)
-  const router = useRouter()
+  const { login } = useContext(UserContext)
+  const redirectToPrev = useRedirectToPrevPage()
   /* Form Handler */
   const { register, handleSubmit, errors } = useForm()
   const [requestError, setRequestError] = useState<string>()
@@ -26,15 +26,14 @@ const SignIn = () => {
 
     try {
       const user = await login(email, password)
-      redirectToPrevPage()
-      // router.back()
-      // router.push(
-      //   `?success=${encodeURIComponent(
-      //     t(`authentication.signIn.success`, { name: user.firstName })
-      //   )}`
-      // )
+
+      redirectToPrev({
+        success: `${encodeURIComponent(
+          t(`authentication.signIn.success`, { name: user.firstName })
+        )}`,
+      })
     } catch (err) {
-      const { status } = err.response
+      const { status } = err.response || {}
       if (status === 401) {
         setRequestError(`${t("authentication.signIn.error")}: ${err.message}`)
       } else {

--- a/apps/public-reference/pages/sign-in.tsx
+++ b/apps/public-reference/pages/sign-in.tsx
@@ -15,7 +15,7 @@ import FormsLayout from "../layouts/forms"
 import { useRouter } from "next/router"
 
 const SignIn = () => {
-  const { login } = useContext(UserContext)
+  const { login, redirectToPrevPage } = useContext(UserContext)
   const router = useRouter()
   /* Form Handler */
   const { register, handleSubmit, errors } = useForm()
@@ -26,11 +26,13 @@ const SignIn = () => {
 
     try {
       const user = await login(email, password)
-      router.push(
-        `/?success=${encodeURIComponent(
-          t(`authentication.signIn.success`, { name: user.firstName })
-        )}`
-      )
+      redirectToPrevPage()
+      // router.back()
+      // router.push(
+      //   `?success=${encodeURIComponent(
+      //     t(`authentication.signIn.success`, { name: user.firstName })
+      //   )}`
+      // )
     } catch (err) {
       const { status } = err.response
       if (status === 401) {


### PR DESCRIPTION
I created a basic version of the redirect. I'm not sure about a couple of things so please leave your feedback :)

To achieve 2 things:
- redirect the user to the latest path
- show success modal

I had to save a path before the change. We cannot use history.go(-1), because it is impossible to attach extra params to the URL.

So, I created property in the UserContext to store the last path, and additional method to change localization with query param including user name (to show it in the modal).

Also, the login success modal seems to work only on the homepage. 