### PR TITLE
Do not show map if lat & lng are null

### DIFF
--- a/apps/public-reference/pages/listing.tsx
+++ b/apps/public-reference/pages/listing.tsx
@@ -292,17 +292,19 @@ export default class extends Component<ListingProps> {
               </div>
             </ListingDetailItem>
 
-            <ListingDetailItem
-              imageAlt="neighborhood-buildings"
-              imageSrc="/images/listing-neighborhood.svg"
-              title={t("listings.sections.neighborhoodTitle")}
-              subtitle={t("listings.sections.neighborhoodSubtitle")}
-              desktopClass="bg-primary-lighter"
-            >
-              <div className="listing-detail-panel">
-                <ListingMap address={listing.buildingAddress} listing={listing} />
-              </div>
-            </ListingDetailItem>
+            {listing?.buildingAddress.latitude && listing?.buildingAddress.longitude && (
+              <ListingDetailItem
+                imageAlt="neighborhood-buildings"
+                imageSrc="/images/listing-neighborhood.svg"
+                title={t("listings.sections.neighborhoodTitle")}
+                subtitle={t("listings.sections.neighborhoodSubtitle")}
+                desktopClass="bg-primary-lighter"
+              >
+                <div className="listing-detail-panel">
+                  <ListingMap address={listing.buildingAddress} listing={listing} />
+                </div>
+              </ListingDetailItem>
+            )}
 
             <ListingDetailItem
               imageAlt="additional-information-envelope"


### PR DESCRIPTION
I created a check for null (buildingAddress or buildingAddress.lat || buildingAddress.lng) - I'm not sure if the situation exists when buildingAddress has few records, but not have lat & lng.