### PR TITLE
Align backend URLs for netlify + remove trailing slashes

### DIFF
--- a/apps/partners-reference/netlify.toml
+++ b/apps/partners-reference/netlify.toml
@@ -3,7 +3,8 @@
 NODE_VERSION = "12.18.3"
 YARN_VERSION = "1.22.4"
 NEXT_TELEMETRY_DISABLED = "1"
-LISTING_SERVICE_URL = "https://listings-next.bloom.exygy.dev/"
+# reminder: URL should *not* have a trailing /
+LISTING_SERVICE_URL = "https://listings.bloom.exygy.dev"
 
 [context.production.environment]
 GTM_KEY = "GTM-TBD"

--- a/apps/public-reference/netlify.toml
+++ b/apps/public-reference/netlify.toml
@@ -3,7 +3,8 @@
 NODE_VERSION = "12.18.3"
 YARN_VERSION = "1.22.4"
 NEXT_TELEMETRY_DISABLED = "1"
-LISTING_SERVICE_URL = "https://listings.bloom.exygy.dev/"
+# reminder: URL should *not* have a trailing /
+LISTING_SERVICE_URL = "https://listings.bloom.exygy.dev"
 
 [context.production.environment]
 GTM_KEY = "GTM-W8LH9F9"


### PR DESCRIPTION
Some nest endpoints were getting double slashes, which made them unhappy, so standardizing on no trailing / in LISTING_SERVICE_URL in the toml files to line up with the implicit practice in .env.template.