### PR TITLE
Backend Record Localization

### DIFF
--- a/backend/core/src/entity/listing-translation.entity.ts
+++ b/backend/core/src/entity/listing-translation.entity.ts
@@ -1,0 +1,60 @@
+import { Entity, BaseEntity, Column, ManyToOne, PrimaryColumn } from "typeorm"
+import { Listing } from "./listing.entity"
+import { WhatToExpect } from "@bloom-housing/core"
+import { JoinColumn } from "typeorm/index"
+
+@Entity({ name: "listings_translations" })
+class ListingTranslation extends BaseEntity {
+  // Manually define this column ahead of languageCode so that it can appear first in the composite primary key that
+  // gets generated for better indexing performance.
+  // See https://github.com/typeorm/typeorm/issues/3069
+  @PrimaryColumn({ type: "uuid" })
+  listingId: string
+
+  @PrimaryColumn({ type: "citext" })
+  languageCode: string
+
+  @ManyToOne(() => Listing, (listing) => listing.translations, {
+    onDelete: "CASCADE",
+    nullable: false,
+  })
+  @JoinColumn({ name: "listing_id" })
+  listing: Listing
+
+  @Column({ type: "text", nullable: true })
+  accessibility: string
+  @Column({ type: "text", nullable: true })
+  amenities: string
+  @Column({ type: "text", nullable: true })
+  buildingSelectionCriteria: string
+  @Column({ type: "text", nullable: true })
+  costsNotIncluded: string
+  @Column({ type: "text", nullable: true })
+  creditHistory: string
+  @Column({ type: "text", nullable: true })
+  criminalBackground: string
+  @Column({ type: "text", nullable: true })
+  leasingAgentOfficeHours: string
+  @Column({ type: "text", nullable: true })
+  leasingAgentTitle: string
+  @Column({ type: "text", nullable: true })
+  name: string
+  @Column({ type: "text", nullable: true })
+  neighborhood: string
+  @Column({ type: "text", nullable: true })
+  petPolicy: string
+  @Column({ type: "text", nullable: true })
+  programRules?: string
+  @Column({ type: "text", nullable: true })
+  rentalHistory: string
+  @Column({ type: "text", nullable: true })
+  requiredDocuments: string
+  @Column({ type: "text", nullable: true })
+  smokingPolicy: string
+  @Column({ type: "text", nullable: true })
+  unitAmenities: string
+  @Column({ type: "jsonb", nullable: true })
+  whatToExpect?: WhatToExpect
+}
+
+export { ListingTranslation as default, ListingTranslation }

--- a/backend/core/src/entity/listing.entity.ts
+++ b/backend/core/src/entity/listing.entity.ts
@@ -5,6 +5,7 @@ import { Attachment } from "./attachment.entity"
 import { Address, UnitsSummarized, WhatToExpect } from "@bloom-housing/core"
 import { Application } from "./application.entity"
 import { ListingTranslation } from "./listing-translation.entity"
+import { Exclude } from "class-transformer"
 
 export enum ListingStatus {
   active = "active",
@@ -127,6 +128,9 @@ class Listing extends BaseEntity {
 
   @OneToMany(() => ListingTranslation, (translation) => translation.listing)
   translations: ListingTranslation[]
+
+  @Exclude()
+  languageCode = "en"
 }
 
 export { Listing as default, Listing }

--- a/backend/core/src/entity/listing.entity.ts
+++ b/backend/core/src/entity/listing.entity.ts
@@ -4,6 +4,7 @@ import { Preference } from "./preference.entity"
 import { Attachment } from "./attachment.entity"
 import { Address, UnitsSummarized, WhatToExpect } from "@bloom-housing/core"
 import { Application } from "./application.entity"
+import { ListingTranslation } from "./listing-translation.entity"
 
 export enum ListingStatus {
   active = "active",
@@ -12,11 +13,11 @@ export enum ListingStatus {
 
 @Entity({ name: "listings" })
 class Listing extends BaseEntity {
-  @OneToMany((type) => Preference, (preference) => preference.listing)
+  @OneToMany(() => Preference, (preference) => preference.listing)
   preferences: Preference[]
-  @OneToMany((type) => Unit, (unit) => unit.listing)
+  @OneToMany(() => Unit, (unit) => unit.listing)
   units: Unit[]
-  @OneToMany((type) => Attachment, (attachment) => attachment.listing)
+  @OneToMany(() => Attachment, (attachment) => attachment.listing)
   attachments: Attachment[]
   @PrimaryGeneratedColumn("uuid")
   id: string
@@ -115,7 +116,7 @@ class Listing extends BaseEntity {
 
   unitsSummarized?: UnitsSummarized
   urlSlug?: string
-  @OneToMany((type) => Application, (application) => application.listing)
+  @OneToMany(() => Application, (application) => application.listing)
   applications: Application[]
   @Column({
     type: "enum",
@@ -123,6 +124,9 @@ class Listing extends BaseEntity {
     default: ListingStatus.pending,
   })
   status: ListingStatus
+
+  @OneToMany(() => ListingTranslation, (translation) => translation.listing)
+  translations: ListingTranslation[]
 }
 
 export { Listing as default, Listing }

--- a/backend/core/src/entity/listing.entity.ts
+++ b/backend/core/src/entity/listing.entity.ts
@@ -130,7 +130,7 @@ class Listing extends BaseEntity {
   translations: ListingTranslation[]
 
   @Exclude()
-  languageCode = "en"
+  languageCode = "en-US"
 }
 
 export { Listing as default, Listing }

--- a/backend/core/src/entity/preference-translation.entity.ts
+++ b/backend/core/src/entity/preference-translation.entity.ts
@@ -1,0 +1,35 @@
+import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm/index"
+import { Preference } from "./preference.entity"
+import { PreferenceLink } from "@bloom-housing/core"
+
+@Entity({ name: "preferences_translations" })
+class PreferenceTranslation extends BaseEntity {
+  // Manually define this column ahead of languageCode so that it can appear first in the composite primary key that
+  // gets generated for better indexing performance.
+  // See https://github.com/typeorm/typeorm/issues/3069
+  @PrimaryColumn({ type: "uuid" })
+  preferenceId: string
+
+  @PrimaryColumn({ type: "citext" })
+  languageCode: string
+
+  @ManyToOne(() => Preference, (pref) => pref.translations, {
+    onDelete: "CASCADE",
+    nullable: false,
+  })
+  @JoinColumn({ name: "preference_id" })
+  preference: Preference
+
+  @Column({ type: "text", nullable: true })
+  ordinal?: string
+  @Column({ type: "text", nullable: true })
+  title?: string
+  @Column({ type: "text", nullable: true })
+  subtitle?: string
+  @Column({ type: "text", nullable: true })
+  description?: string
+  @Column({ type: "jsonb", nullable: true })
+  links?: PreferenceLink[]
+}
+
+export { PreferenceTranslation as default, PreferenceTranslation }

--- a/backend/core/src/entity/preference.entity.ts
+++ b/backend/core/src/entity/preference.entity.ts
@@ -1,9 +1,10 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from "typeorm"
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, BaseEntity } from "typeorm"
 import { Listing } from "./listing.entity"
 import { PreferenceLink } from "@bloom-housing/core"
+import { PreferenceTranslation } from "./preference-translation.entity"
 
 @Entity({ name: "preferences" })
-class Preference {
+class Preference extends BaseEntity {
   @PrimaryGeneratedColumn("uuid")
   id: string
   @Column({ type: "text", nullable: true })
@@ -21,6 +22,11 @@ class Preference {
     onUpdate: "CASCADE",
   })
   listing: Listing
+
+  @OneToMany(() => PreferenceTranslation, (translation) => translation.preference)
+  translations: PreferenceTranslation[]
+
+  languageCode: "us-EN"
 }
 
 export { Preference as default, Preference }

--- a/backend/core/src/lib/translations.ts
+++ b/backend/core/src/lib/translations.ts
@@ -1,7 +1,5 @@
-import { Request, Response } from "express"
+import { Response } from "express"
 import { BaseEntity } from "typeorm"
-
-export const getPreferredLanguage = (req: Request) => req.acceptsLanguages()[0]
 
 export class TranslationEntity extends BaseEntity {
   languageCode: string
@@ -18,9 +16,6 @@ export function appendGenericVersionsOfLanguages(languages) {
   return languages.map((l) => (l.indexOf("-") === -1 ? l : [l, l.split("-")[0]])).flat()
 }
 
-export const getPreferredLanguages = (req: Request) =>
-  appendGenericVersionsOfLanguages(req.acceptsLanguages())
-
 export class TranslateableEntity extends BaseEntity {
   translations: TranslationEntity[]
 
@@ -36,7 +31,7 @@ export function translateEntity<T extends TranslateableEntity>(
 
   // languagePreferences is an array of preferred language codes in order of preference. Find the most
   // preferred language that matches available translations. If nothing is found, we'll default to no translations.
-  const languageToTranslate = languagePreferences.find((l) => {
+  const languageToTranslate = appendGenericVersionsOfLanguages(languagePreferences).find((l) => {
     const language = l.toLowerCase()
     return language === "en" || availableLanguages.includes(l)
   })

--- a/backend/core/src/lib/translations.ts
+++ b/backend/core/src/lib/translations.ts
@@ -11,8 +11,23 @@ export class TranslateableEntity extends BaseEntity {
   translations: TranslationEntity[]
 }
 
-export function translateEntity<T extends TranslateableEntity>(entity: T): T {
-  const [translation] = entity.translations
+export function translateEntity<T extends TranslateableEntity>(
+  entity: T,
+  languagePreferences: string[] = []
+): T {
+  const availableLanguages = entity.translations.map((t) => t.languageCode)
+
+  // languagePreferences is an array of preferred language codes in order of preference. Find the most
+  // preferred language that matches available translations. If nothing is found, we'll default to no translations.
+  const languageToTranslate = languagePreferences.find((l) => {
+    const language = l.toLowerCase()
+    return language === "en" || availableLanguages.includes(l)
+  })
+
+  const translation =
+    languageToTranslate &&
+    entity.translations.find(({ languageCode }) => languageCode === languageToTranslate)
+
   if (translation) {
     Object.keys(translation)
       .filter(

--- a/backend/core/src/lib/translations.ts
+++ b/backend/core/src/lib/translations.ts
@@ -7,6 +7,20 @@ export class TranslationEntity extends BaseEntity {
   languageCode: string
 }
 
+/**
+ * This function adds "generic" (non locale specific) versions of languages after the locale-specific version in the
+ * language preference list if applicable.
+ *
+ * ["es", "en-US", "fr"] => ["es", "en-US", "en", "fr"]
+ * @param languages
+ */
+export function appendGenericVersionsOfLanguages(languages) {
+  return languages.map((l) => (l.indexOf("-") === -1 ? l : [l, l.split("-")[0]])).flat()
+}
+
+export const getPreferredLanguages = (req: Request) =>
+  appendGenericVersionsOfLanguages(req.acceptsLanguages())
+
 export class TranslateableEntity extends BaseEntity {
   translations: TranslationEntity[]
 

--- a/backend/core/src/lib/translations.ts
+++ b/backend/core/src/lib/translations.ts
@@ -1,4 +1,4 @@
-import { Request } from "express"
+import { Request, Response } from "express"
 import { BaseEntity } from "typeorm"
 
 export const getPreferredLanguage = (req: Request) => req.acceptsLanguages()[0]
@@ -9,6 +9,9 @@ export class TranslationEntity extends BaseEntity {
 
 export class TranslateableEntity extends BaseEntity {
   translations: TranslationEntity[]
+
+  // Language of the output object
+  languageCode: string
 }
 
 export function translateEntity<T extends TranslateableEntity>(
@@ -35,7 +38,16 @@ export function translateEntity<T extends TranslateableEntity>(
           key !== "languageCode" && key in entity && translation[key] && translation[key].length > 0
       )
       .forEach((key) => (entity[key] = translation[key]))
+    entity.languageCode = translation.languageCode
   }
   delete entity.translations
   return entity
+}
+
+export function setContentLanguageHeader(res: Response, languages: string[]) {
+  // Create a comma-separated list of unique languages
+  const headerLanguages = [...new Set(languages.filter((l) => l))].join(", ")
+  if (headerLanguages.length > 0) {
+    res.setHeader("Content-Language", headerLanguages)
+  }
 }

--- a/backend/core/src/lib/translations.ts
+++ b/backend/core/src/lib/translations.ts
@@ -1,0 +1,26 @@
+import { Request } from "express"
+import { BaseEntity } from "typeorm"
+
+export const getPreferredLanguage = (req: Request) => req.acceptsLanguages()[0]
+
+export class TranslationEntity extends BaseEntity {
+  languageCode: string
+}
+
+export class TranslateableEntity extends BaseEntity {
+  translations: TranslationEntity[]
+}
+
+export function translateEntity<T extends TranslateableEntity>(entity: T): T {
+  const [translation] = entity.translations
+  if (translation) {
+    Object.keys(translation)
+      .filter(
+        (key) =>
+          key !== "languageCode" && key in entity && translation[key] && translation[key].length > 0
+      )
+      .forEach((key) => (entity[key] = translation[key]))
+  }
+  delete entity.translations
+  return entity
+}

--- a/backend/core/src/listings/listing.service.spec.ts
+++ b/backend/core/src/listings/listing.service.spec.ts
@@ -1,0 +1,73 @@
+import { Test, TestingModule } from "@nestjs/testing"
+import { ListingsService } from "./listings.service"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { Listing } from "../entity/listing.entity"
+import { Repository } from "typeorm/index"
+import {
+  makeListing,
+  makeRelation,
+  RelationTypes,
+} from "../seeder/listings-seeder/listings-seeder.service"
+import listingsSeeds from "../../seeds.json"
+
+const ALL_LISTINGS = listingsSeeds.map((listingDefinition) => {
+  const [listing, relatedEntities] = makeListing(listingDefinition)
+  for (const key in relatedEntities) {
+    listing[key] = makeRelation(key as RelationTypes, listing, relatedEntities[key])
+  }
+  return listing
+})
+
+// Cypress brings in Chai types for the global expect, but we want to use jest
+// expect here so we need to re-declare it.
+// see: https://github.com/cypress-io/cypress/issues/1319#issuecomment-593500345
+declare const expect: jest.Expect
+
+describe("ListingService", () => {
+  let service: ListingsService
+  let repo: Repository<Listing>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ListingsService,
+        {
+          provide: getRepositoryToken(Listing),
+          useClass: Repository,
+        },
+      ],
+    }).compile()
+
+    repo = module.get(getRepositoryToken(Listing))
+    service = module.get(ListingsService)
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("list", () => {
+    let jsonpath
+    let languages
+    const subject = () => service.list(jsonpath, languages)
+
+    beforeEach(() => {
+      const mockListings = ALL_LISTINGS.map((listing) => {
+        listing.translations = []
+        return listing
+      })
+      const mockQueryBuilder: any = {
+        apply: () => mockQueryBuilder,
+        leftJoinAndSelect: () => mockQueryBuilder,
+        getMany: () => mockListings,
+      }
+
+      jest.spyOn(repo, "createQueryBuilder").mockImplementation(mockQueryBuilder)
+    })
+
+    it("Should return the correct number of listings", async () => {
+      const { listings } = await subject()
+      expect(listings.length).toEqual(ALL_LISTINGS.length)
+    })
+  })
+})

--- a/backend/core/src/listings/listings.controller.ts
+++ b/backend/core/src/listings/listings.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Get, Query, Request } from "@nestjs/common"
+import { Controller, Get, Query, Request, Res } from "@nestjs/common"
 import { ListingsService } from "./listings.service"
-import { ListingsListResponse } from "./listings.dto"
-import { Request as ExpressRequest } from "express"
+import { Request as ExpressRequest, Response } from "express"
+import { setContentLanguageHeader } from "../lib/translations"
 
 @Controller()
 export class ListingsController {
@@ -10,8 +10,14 @@ export class ListingsController {
   @Get()
   public async getAll(
     @Request() req: ExpressRequest,
+    @Res() res: Response,
     @Query("jsonpath") jsonpath?: string
-  ): Promise<ListingsListResponse> {
-    return this.listingsService.list(jsonpath, req.acceptsLanguages())
+  ) {
+    const body = await this.listingsService.list(jsonpath, req.acceptsLanguages())
+    setContentLanguageHeader(
+      res,
+      body.listings.map(({ languageCode }) => languageCode)
+    )
+    return res.send(body)
   }
 }

--- a/backend/core/src/listings/listings.controller.ts
+++ b/backend/core/src/listings/listings.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Query, Request, Res } from "@nestjs/common"
 import { ListingsService } from "./listings.service"
 import { Request as ExpressRequest, Response } from "express"
-import { getPreferredLanguages, setContentLanguageHeader } from "../lib/translations"
+import { setContentLanguageHeader } from "../lib/translations"
 
 @Controller()
 export class ListingsController {
@@ -13,7 +13,7 @@ export class ListingsController {
     @Res() res: Response,
     @Query("jsonpath") jsonpath?: string
   ) {
-    const body = await this.listingsService.list(jsonpath, getPreferredLanguages(req))
+    const body = await this.listingsService.list(jsonpath, req.acceptsLanguages())
     setContentLanguageHeader(
       res,
       body.listings.map(({ languageCode }) => languageCode)

--- a/backend/core/src/listings/listings.controller.ts
+++ b/backend/core/src/listings/listings.controller.ts
@@ -2,7 +2,6 @@ import { Controller, Get, Query, Request } from "@nestjs/common"
 import { ListingsService } from "./listings.service"
 import { ListingsListResponse } from "./listings.dto"
 import { Request as ExpressRequest } from "express"
-import { getPreferredLanguage } from "../lib/translations"
 
 @Controller()
 export class ListingsController {
@@ -13,7 +12,6 @@ export class ListingsController {
     @Request() req: ExpressRequest,
     @Query("jsonpath") jsonpath?: string
   ): Promise<ListingsListResponse> {
-    const languageCode = getPreferredLanguage(req)
-    return this.listingsService.list(jsonpath, languageCode)
+    return this.listingsService.list(jsonpath, req.acceptsLanguages())
   }
 }

--- a/backend/core/src/listings/listings.controller.ts
+++ b/backend/core/src/listings/listings.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Query, Request, Res } from "@nestjs/common"
 import { ListingsService } from "./listings.service"
 import { Request as ExpressRequest, Response } from "express"
-import { setContentLanguageHeader } from "../lib/translations"
+import { getPreferredLanguages, setContentLanguageHeader } from "../lib/translations"
 
 @Controller()
 export class ListingsController {
@@ -13,7 +13,7 @@ export class ListingsController {
     @Res() res: Response,
     @Query("jsonpath") jsonpath?: string
   ) {
-    const body = await this.listingsService.list(jsonpath, req.acceptsLanguages())
+    const body = await this.listingsService.list(jsonpath, getPreferredLanguages(req))
     setContentLanguageHeader(
       res,
       body.listings.map(({ languageCode }) => languageCode)

--- a/backend/core/src/listings/listings.controller.ts
+++ b/backend/core/src/listings/listings.controller.ts
@@ -1,13 +1,19 @@
-import { Controller, Get, Query } from "@nestjs/common"
+import { Controller, Get, Query, Request } from "@nestjs/common"
 import { ListingsService } from "./listings.service"
 import { ListingsListResponse } from "./listings.dto"
+import { Request as ExpressRequest } from "express"
+import { getPreferredLanguage } from "../lib/translations"
 
 @Controller()
 export class ListingsController {
   constructor(private readonly listingsService: ListingsService) {}
 
   @Get()
-  public async getAll(@Query("jsonpath") jsonpath?: string): Promise<ListingsListResponse> {
-    return this.listingsService.list(jsonpath)
+  public async getAll(
+    @Request() req: ExpressRequest,
+    @Query("jsonpath") jsonpath?: string
+  ): Promise<ListingsListResponse> {
+    const languageCode = getPreferredLanguage(req)
+    return this.listingsService.list(jsonpath, languageCode)
   }
 }

--- a/backend/core/src/listings/listings.module.ts
+++ b/backend/core/src/listings/listings.module.ts
@@ -6,9 +6,10 @@ import { Listing } from "../entity/listing.entity"
 import { Attachment } from "../entity/attachment.entity"
 import { Preference } from "../entity/preference.entity"
 import { Unit } from "../entity/unit.entity"
+import { ListingTranslation } from "../entity/listing-translation.entity"
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Listing, Attachment, Preference, Unit])],
+  imports: [TypeOrmModule.forFeature([Listing, Attachment, Preference, Unit, ListingTranslation])],
   providers: [ListingsService],
   exports: [ListingsService],
   controllers: [ListingsController],

--- a/backend/core/src/listings/listings.module.ts
+++ b/backend/core/src/listings/listings.module.ts
@@ -7,9 +7,19 @@ import { Attachment } from "../entity/attachment.entity"
 import { Preference } from "../entity/preference.entity"
 import { Unit } from "../entity/unit.entity"
 import { ListingTranslation } from "../entity/listing-translation.entity"
+import { PreferenceTranslation } from "../entity/preference-translation.entity"
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Listing, Attachment, Preference, Unit, ListingTranslation])],
+  imports: [
+    TypeOrmModule.forFeature([
+      Listing,
+      Attachment,
+      Preference,
+      Unit,
+      ListingTranslation,
+      PreferenceTranslation,
+    ]),
+  ],
   providers: [ListingsService],
   exports: [ListingsService],
   controllers: [ListingsController],

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -1,9 +1,10 @@
-import { getConnection } from "typeorm"
+import { Repository } from "typeorm"
 import { Injectable } from "@nestjs/common"
 import { amiCharts } from "../lib/ami_charts"
 import { transformUnits } from "../lib/unit_transformations"
 import { listingUrlSlug } from "../lib/url_helper"
 import jp from "jsonpath"
+import { InjectRepository } from "@nestjs/typeorm"
 
 import { ListingsListResponse } from "./listings.dto"
 import { Listing } from "../entity/listing.entity"
@@ -22,9 +23,10 @@ function transformListing(listing: Listing, languages?: string[]): Listing {
 
 @Injectable()
 export class ListingsService {
+  constructor(@InjectRepository(Listing) private readonly repo: Repository<Listing>) {}
   public async list(jsonpath?: string, languages?: string[]): Promise<ListingsListResponse> {
-    let listings = await getConnection()
-      .createQueryBuilder(Listing, "listing")
+    let listings = await this.repo
+      .createQueryBuilder("listing")
       .leftJoinAndSelect("listing.units", "units")
       .leftJoinAndSelect("listing.attachments", "attachments")
       .leftJoinAndSelect("listing.preferences", "preferences")

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -7,32 +7,16 @@ import jp from "jsonpath"
 
 import { ListingsListResponse } from "./listings.dto"
 import { Listing } from "../entity/listing.entity"
+import { translateEntity } from "../lib/translations"
 
 export enum ListingsResponseStatus {
   ok = "ok",
 }
 
-function translate(listing: Listing): Listing {
-  const [translation] = listing.translations
-  if (translation) {
-    Object.keys(translation)
-      .filter(
-        (key) =>
-          key !== "languageCode" &&
-          key in listing &&
-          translation[key] &&
-          translation[key].length > 0
-      )
-      .forEach((key) => (listing[key] = translation[key]))
-  }
-  delete listing.translations
-  return listing
-}
-
 function transformListing(listing: Listing): Listing {
   listing.unitsSummarized = transformUnits(listing.units, amiCharts)
   listing.urlSlug = listingUrlSlug(listing)
-  listing = translate(listing)
+  listing = translateEntity(listing)
   return listing
 }
 

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -8,7 +8,7 @@ import { InjectRepository } from "@nestjs/typeorm"
 
 import { ListingsListResponse } from "./listings.dto"
 import { Listing } from "../entity/listing.entity"
-import { translateEntity } from "../lib/translations"
+import { translateEntity, appendGenericVersionsOfLanguages } from "../lib/translations"
 
 export enum ListingsResponseStatus {
   ok = "ok",
@@ -34,7 +34,7 @@ export class ListingsService {
         "listing.translations",
         "translations",
         "translations.languageCode = ANY(:codes)",
-        { codes: languages }
+        { codes: appendGenericVersionsOfLanguages(languages) }
       )
       .getMany()
 

--- a/backend/core/src/migration/1597848346822-initial-migration.ts
+++ b/backend/core/src/migration/1597848346822-initial-migration.ts
@@ -1,7 +1,7 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class initialMigration1595856133952 implements MigrationInterface {
-    name = 'initialMigration1595856133952'
+export class initialMigration1597848346822 implements MigrationInterface {
+    name = 'initialMigration1597848346822'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "user_accounts" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "password_hash" character varying NOT NULL, "email" character varying NOT NULL, "first_name" character varying NOT NULL, "middle_name" character varying, "last_name" character varying NOT NULL, "dob" TIMESTAMP NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_125e915cf23ad1cfb43815ce59b" PRIMARY KEY ("id"))`);
@@ -9,6 +9,7 @@ export class initialMigration1595856133952 implements MigrationInterface {
         await queryRunner.query(`CREATE TABLE "preferences" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "ordinal" text, "title" text, "subtitle" text, "description" text, "links" jsonb, "listing_id" uuid, CONSTRAINT "PK_17f8855e4145192bbabd91a51be" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TYPE "attachments_type_enum" AS ENUM('1', '2')`);
         await queryRunner.query(`CREATE TABLE "attachments" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "label" text, "file_url" text, "type" "attachments_type_enum", "listing_id" uuid, CONSTRAINT "PK_5e1f050bcff31e3084a1d662412" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "listings_translations" ("listing_id" uuid NOT NULL, "language_code" citext NOT NULL, "accessibility" text, "amenities" text, "building_selection_criteria" text, "costs_not_included" text, "credit_history" text, "criminal_background" text, "leasing_agent_office_hours" text, "leasing_agent_title" text, "name" text, "neighborhood" text, "pet_policy" text, "program_rules" text, "rental_history" text, "required_documents" text, "smoking_policy" text, "unit_amenities" text, "what_to_expect" jsonb, CONSTRAINT "PK_ce950a8ec07770bb032b7c2f1a1" PRIMARY KEY ("listing_id", "language_code"))`);
         await queryRunner.query(`CREATE TYPE "listings_status_enum" AS ENUM('active', 'pending')`);
         await queryRunner.query(`CREATE TABLE "listings" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "accepting_applications_at_leasing_agent" boolean, "accepting_applications_by_po_box" boolean, "accepting_online_applications" boolean, "accepts_postmarked_applications" boolean, "accessibility" text, "amenities" text, "application_due_date" text, "application_open_date" text, "application_fee" text, "application_organization" text, "application_address" jsonb, "blank_paper_application_can_be_picked_up" boolean, "building_address" jsonb, "building_total_units" numeric, "building_selection_criteria" text, "costs_not_included" text, "credit_history" text, "criminal_background" text, "deposit_min" text, "deposit_max" text, "developer" text, "disable_units_accordion" boolean, "household_size_max" numeric, "household_size_min" numeric, "image_url" text, "leasing_agent_address" jsonb, "leasing_agent_email" text, "leasing_agent_name" text, "leasing_agent_office_hours" text, "leasing_agent_phone" text, "leasing_agent_title" text, "name" text, "neighborhood" text, "pet_policy" text, "postmarked_applications_received_by_date" text, "program_rules" text, "rental_history" text, "required_documents" text, "smoking_policy" text, "units_available" numeric, "unit_amenities" text, "waitlist_current_size" numeric, "waitlist_max_size" numeric, "what_to_expect" jsonb, "year_built" numeric, "status" "listings_status_enum" NOT NULL DEFAULT 'pending', CONSTRAINT "PK_520ecac6c99ec90bcf5a603cdcb" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "applications" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "application" jsonb, "user_id" uuid, "listing_id" uuid, CONSTRAINT "PK_938c0a27255637bde919591888f" PRIMARY KEY ("id"))`);
@@ -16,6 +17,7 @@ export class initialMigration1595856133952 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "units" ADD CONSTRAINT "FK_9aebcde52d6e054e5ac5d26228c" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
         await queryRunner.query(`ALTER TABLE "preferences" ADD CONSTRAINT "FK_91017f2182ec7b0dcd4abe68b5a" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
         await queryRunner.query(`ALTER TABLE "attachments" ADD CONSTRAINT "FK_4f28a952892a175dbb21d05d96d" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "listings_translations" ADD CONSTRAINT "FK_c9184df30660bba38bd77c0bf98" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "applications" ADD CONSTRAINT "FK_9e7594d5b474d9cbebba15c1ae7" FOREIGN KEY ("user_id") REFERENCES "user_accounts"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "applications" ADD CONSTRAINT "FK_cc9d65c58d8deb0ef5353e9037d" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`);
     }
@@ -23,6 +25,7 @@ export class initialMigration1595856133952 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "applications" DROP CONSTRAINT "FK_cc9d65c58d8deb0ef5353e9037d"`);
         await queryRunner.query(`ALTER TABLE "applications" DROP CONSTRAINT "FK_9e7594d5b474d9cbebba15c1ae7"`);
+        await queryRunner.query(`ALTER TABLE "listings_translations" DROP CONSTRAINT "FK_c9184df30660bba38bd77c0bf98"`);
         await queryRunner.query(`ALTER TABLE "attachments" DROP CONSTRAINT "FK_4f28a952892a175dbb21d05d96d"`);
         await queryRunner.query(`ALTER TABLE "preferences" DROP CONSTRAINT "FK_91017f2182ec7b0dcd4abe68b5a"`);
         await queryRunner.query(`ALTER TABLE "units" DROP CONSTRAINT "FK_9aebcde52d6e054e5ac5d26228c"`);
@@ -30,6 +33,7 @@ export class initialMigration1595856133952 implements MigrationInterface {
         await queryRunner.query(`DROP TABLE "applications"`);
         await queryRunner.query(`DROP TABLE "listings"`);
         await queryRunner.query(`DROP TYPE "listings_status_enum"`);
+        await queryRunner.query(`DROP TABLE "listings_translations"`);
         await queryRunner.query(`DROP TABLE "attachments"`);
         await queryRunner.query(`DROP TYPE "attachments_type_enum"`);
         await queryRunner.query(`DROP TABLE "preferences"`);

--- a/backend/core/src/migration/1597870741562-initial-migration.ts
+++ b/backend/core/src/migration/1597870741562-initial-migration.ts
@@ -1,11 +1,12 @@
 import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class initialMigration1597848346822 implements MigrationInterface {
-    name = 'initialMigration1597848346822'
+export class initialMigration1597870741562 implements MigrationInterface {
+    name = 'initialMigration1597870741562'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`CREATE TABLE "user_accounts" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "password_hash" character varying NOT NULL, "email" character varying NOT NULL, "first_name" character varying NOT NULL, "middle_name" character varying, "last_name" character varying NOT NULL, "dob" TIMESTAMP NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_125e915cf23ad1cfb43815ce59b" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "units" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "ami_percentage" text, "annual_income_min" text, "monthly_income_min" numeric(8,2), "floor" numeric, "annual_income_max" text, "max_occupancy" numeric, "min_occupancy" numeric, "monthly_rent" numeric(8,2), "num_bathrooms" numeric, "num_bedrooms" numeric, "number" text, "priority_type" text, "reserved_type" text, "sq_feet" numeric(8,2), "status" text, "unit_type" text, "created_at" date, "updated_at" date, "ami_chart_id" numeric, "monthly_rent_as_percent_of_income" numeric(8,2), "listing_id" uuid, CONSTRAINT "PK_5a8f2f064919b587d93936cb223" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE TABLE "preferences_translations" ("preference_id" uuid NOT NULL, "language_code" citext NOT NULL, "ordinal" text, "title" text, "subtitle" text, "description" text, "links" jsonb, CONSTRAINT "PK_8c4d6fcb3b1c177d4f09ceaba70" PRIMARY KEY ("preference_id", "language_code"))`);
         await queryRunner.query(`CREATE TABLE "preferences" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "ordinal" text, "title" text, "subtitle" text, "description" text, "links" jsonb, "listing_id" uuid, CONSTRAINT "PK_17f8855e4145192bbabd91a51be" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TYPE "attachments_type_enum" AS ENUM('1', '2')`);
         await queryRunner.query(`CREATE TABLE "attachments" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "label" text, "file_url" text, "type" "attachments_type_enum", "listing_id" uuid, CONSTRAINT "PK_5e1f050bcff31e3084a1d662412" PRIMARY KEY ("id"))`);
@@ -15,6 +16,7 @@ export class initialMigration1597848346822 implements MigrationInterface {
         await queryRunner.query(`CREATE TABLE "applications" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP NOT NULL DEFAULT now(), "updated_at" TIMESTAMP NOT NULL DEFAULT now(), "application" jsonb, "user_id" uuid, "listing_id" uuid, CONSTRAINT "PK_938c0a27255637bde919591888f" PRIMARY KEY ("id"))`);
         await queryRunner.query(`CREATE TABLE "revoked_tokens" ("token" character varying NOT NULL, "revoked_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_f38f625b4823c8903e819bfedd1" PRIMARY KEY ("token"))`);
         await queryRunner.query(`ALTER TABLE "units" ADD CONSTRAINT "FK_9aebcde52d6e054e5ac5d26228c" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE "preferences_translations" ADD CONSTRAINT "FK_3d434fd561f38cafd565177508e" FOREIGN KEY ("preference_id") REFERENCES "preferences"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "preferences" ADD CONSTRAINT "FK_91017f2182ec7b0dcd4abe68b5a" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
         await queryRunner.query(`ALTER TABLE "attachments" ADD CONSTRAINT "FK_4f28a952892a175dbb21d05d96d" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE CASCADE`);
         await queryRunner.query(`ALTER TABLE "listings_translations" ADD CONSTRAINT "FK_c9184df30660bba38bd77c0bf98" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
@@ -28,6 +30,7 @@ export class initialMigration1597848346822 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "listings_translations" DROP CONSTRAINT "FK_c9184df30660bba38bd77c0bf98"`);
         await queryRunner.query(`ALTER TABLE "attachments" DROP CONSTRAINT "FK_4f28a952892a175dbb21d05d96d"`);
         await queryRunner.query(`ALTER TABLE "preferences" DROP CONSTRAINT "FK_91017f2182ec7b0dcd4abe68b5a"`);
+        await queryRunner.query(`ALTER TABLE "preferences_translations" DROP CONSTRAINT "FK_3d434fd561f38cafd565177508e"`);
         await queryRunner.query(`ALTER TABLE "units" DROP CONSTRAINT "FK_9aebcde52d6e054e5ac5d26228c"`);
         await queryRunner.query(`DROP TABLE "revoked_tokens"`);
         await queryRunner.query(`DROP TABLE "applications"`);
@@ -37,6 +40,7 @@ export class initialMigration1597848346822 implements MigrationInterface {
         await queryRunner.query(`DROP TABLE "attachments"`);
         await queryRunner.query(`DROP TYPE "attachments_type_enum"`);
         await queryRunner.query(`DROP TABLE "preferences"`);
+        await queryRunner.query(`DROP TABLE "preferences_translations"`);
         await queryRunner.query(`DROP TABLE "units"`);
         await queryRunner.query(`DROP TABLE "user_accounts"`);
     }

--- a/backend/core/src/seeder/listings-seeder/listings-seeder.service.ts
+++ b/backend/core/src/seeder/listings-seeder/listings-seeder.service.ts
@@ -14,7 +14,7 @@ const subTypes = {
   attachments: Attachment,
   preferences: Preference,
 }
-type RelationTypes = keyof typeof subTypes
+export type RelationTypes = keyof typeof subTypes
 type RelationEntities = {
   [k in RelationTypes]?: ImportedJsonData
 }


### PR DESCRIPTION
This PR adds the ability to localize fields on individual records in the backend. Right now, translations are supported on `Listings` and `Preferences`, and are stored in the database in tables `listing_translations` and `preference_translations`. Each translation table contains a foreign key reference to the parent table, a language code (e.g. `"es"`) column, and all of the columns that make sense to translate on the parent record (basically all the `text` columns, although there are a few cases where we're using `text` columns essentially as enums, and we should probably use a smarter approach for those, rather than requiring identical translations throughout the database).

The desired language is specified on a request using the standard [`Accept-Language` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language). The backend looks through the list of languages, and uses the highest priority matching translation it can find. If no matching translations are found, it returns the original record unchanged. If a translation record _is_ found, but only has some fields filled out, the API merges existing translated fields with the underlying record as best it can. If languages are specified with locale strings (e.g. `en-US`), the backend tries first to match the language + locale combo, then tries to match just the language (`en` in this example), and then moves on to the next lower priority language.

This Listings controller now returns a `Content-Language` header based on translations performed on listings.

Additional changes:
- Added unit tests to the `ListingsService`
- Refactored the listings seed service to expose some utility functions which will be useful for database-less backend unit test mocks.

Closes #360