### PR TITLE
Fix modal ariaDescription on My Applications page + fix tests

### DIFF
--- a/apps/partners-reference/layouts/application.tsx
+++ b/apps/partners-reference/layouts/application.tsx
@@ -16,7 +16,12 @@ const Layout = (props) => (
     <Head>
       <title>{t("nav.siteTitle")}</title>
     </Head>
-    <SiteHeader logoSrc="/images/logo_glyph.svg" notice="" title={t("nav.siteTitle")}>
+    <SiteHeader
+      skip={t("nav.skip")}
+      logoSrc="/images/logo_glyph.svg"
+      notice=""
+      title={t("nav.siteTitle")}
+    >
       <LocalizedLink href="/properties" className="navbar-item">
         {t("nav.properties")}
       </LocalizedLink>

--- a/apps/public-reference/cypress/integration/navigation.ts
+++ b/apps/public-reference/cypress/integration/navigation.ts
@@ -14,23 +14,25 @@ describe("Navigating around the site", () => {
   })
 
   it("Loads a listing page directly by id", () => {
-    cy.visit("/listing/Uvbk5qurpB2WI9V6WnNdH")
+    cy.visit("/listing/a41641e6-2772-4e18-af8c-b16c1973e976")
 
     // Check that the listing page sidebar apply section text is present on the page
-    cy.contains("Get a Paper Application")
+    cy.contains("Apply Online")
 
     // Check that the URL got re-written with a URL slug
     cy.location("pathname").should(
       "eq",
-      "/listing/Uvbk5qurpB2WI9V6WnNdH/archer_studios_98_archer_street_san_jose_ca"
+      "/listing/a41641e6-2772-4e18-af8c-b16c1973e976/the_triton_55_triton_park_lane_foster_city_ca"
     )
   })
 
   it("Loads a listing page directly with a full url", () => {
-    cy.visit("/listing/Uvbk5qurpB2WI9V6WnNdH/archer_studios_98_archer_street_san_jose_ca")
+    cy.visit(
+      "/listing/a41641e6-2772-4e18-af8c-b16c1973e976/the_triton_55_triton_park_lane_foster_city_ca"
+    )
 
     // Check that the listing page sidebar apply section text is present on the page
-    cy.contains("Get a Paper Application")
+    cy.contains("Apply Online")
   })
 
   it("Loads a non-listing-related page directly", () => {

--- a/apps/public-reference/package.json
+++ b/apps/public-reference/package.json
@@ -11,7 +11,7 @@
     "test": "concurrently \"yarn dev\" \"cypress open\"",
     "export": "next export",
     "start": "next start",
-    "dev:listings": "cd ../../services/listings && yarn dev",
+    "dev:listings": "cd ../../backend/core && yarn dev",
     "dev:server-wait": "wait-on \"http://localhost:${PORT:-3100}/\" && yarn dev",
     "dev:all": "concurrently \"yarn dev:listings\" \"yarn dev:server-wait\""
   },

--- a/apps/public-reference/pages/account/applications.tsx
+++ b/apps/public-reference/pages/account/applications.tsx
@@ -68,6 +68,7 @@ export default () => {
         <Modal
           open={deletingApplication}
           title={t("application.deleteThisApplication")}
+          ariaDescription={t("application.deleteThisApplication")}
           actions={modalActions}
           fullScreen
         ></Modal>

--- a/shared/ui-components/src/cards/__snapshots__/ImageCard.stories.storyshot
+++ b/shared/ui-components/src/cards/__snapshots__/ImageCard.stories.storyshot
@@ -54,6 +54,7 @@ exports[`Storyshots Cards/ImageCard With Link 1`] = `
   >
     <LocalizedLink
       as="/listings"
+      className="block"
       href="/listings"
     >
       <Link
@@ -61,6 +62,7 @@ exports[`Storyshots Cards/ImageCard With Link 1`] = `
         href="/listings"
       >
         <a
+          className="block"
           href="/listings"
           onClick={[Function]}
           onMouseEnter={[Function]}

--- a/shared/ui-components/src/headers/SiteHeader/SiteHeader.tsx
+++ b/shared/ui-components/src/headers/SiteHeader/SiteHeader.tsx
@@ -37,7 +37,9 @@ class SiteHeader extends React.Component<SiteHeaderProps, SiteHeaderState> {
 
   skipLink() {
     return (
-      <a href="#main-content" className="navbar__skip-link">{this.props.skip}</a>
+      <a href="#main-content" className="navbar__skip-link">
+        {this.props.skip}
+      </a>
     )
   }
 

--- a/shared/ui-components/src/headers/SiteHeader/__snapshots__/SiteHeader.stories.storyshot
+++ b/shared/ui-components/src/headers/SiteHeader/__snapshots__/SiteHeader.stories.storyshot
@@ -6,6 +6,10 @@ exports[`Storyshots Headers/SiteHeader Standard 1`] = `
   notice="This is a preview of our new website. We're just getting started. We'd love to get your feedback."
   title="Site Title Here"
 >
+  <a
+    className="navbar__skip-link"
+    href="#main-content"
+  />
   <div
     className="navbar-notice"
   >
@@ -100,6 +104,10 @@ exports[`Storyshots Headers/SiteHeader With Dropdown And Button 1`] = `
   notice="This is a preview of our new website. We're just getting started. We'd love to get your feedback."
   title="Site Title Here"
 >
+  <a
+    className="navbar__skip-link"
+    href="#main-content"
+  />
   <div
     className="navbar-notice"
   >

--- a/yarn.lock
+++ b/yarn.lock
@@ -3681,6 +3681,11 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/body-scroll-lock@^2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@types/body-scroll-lock/-/body-scroll-lock-2.6.1.tgz#0dbd2b6ad2f4cfcece7102d6cf8630ce95508ee0"
+  integrity sha512-PPFm/2A6LfKmSpvMg58gHtSqwwMChbcKKGhSCRIhY4MyFzhY8moAN6HrTCpOeZQUqkFdTFfMqr7njeqGLKt72Q==
+
 "@types/braces@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
@@ -5682,6 +5687,11 @@ body-parser@1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
+body-scroll-lock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-3.0.3.tgz#221d87435bcfb50e27ab5d4508735f622aed11a2"
+  integrity sha512-EUryImgD6Gv87HOjJB/yB2WIGECiZMhmcUK+DrqVRFDDa64xR+FsK0LgvLPnBxZDTxIl+W80/KJ8i6gp2IwOHQ==
+
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
@@ -7600,6 +7610,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.0.0.tgz#c0318b9e539a5256ca780dd9575c9345af05b8ed"
+  integrity sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg==
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -8997,6 +9012,11 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+focus-lock@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
+  integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -14899,6 +14919,13 @@ react-accessible-accordion@^3.3.3:
   resolved "https://registry.yarnpkg.com/react-accessible-accordion/-/react-accessible-accordion-3.3.3.tgz#387a3f4ab1840b5b6dff9f1f16544f658d5c8e12"
   integrity sha512-I1Niy21IIyXIzcDuIlTnnN3k8bUux7puq60eyNuwf+lhvftnocn7hLhAz2NycXrZOqBClqi50YBqXlnbOTNrjQ==
 
+react-clientside-effect@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
+  integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 react-color@^2.17.0:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.18.1.tgz#2cda8cc8e06a9e2c52ad391a30ddad31972472f4"
@@ -15016,6 +15043,18 @@ react-fast-compare@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-focus-lock@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.4.1.tgz#e842cc93da736b5c5d331799012544295cbcee4f"
+  integrity sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.7.0"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.2"
+    use-callback-ref "^1.2.1"
+    use-sidecar "^1.0.1"
 
 react-from-dom@^0.4.2:
   version "0.4.2"
@@ -17602,7 +17641,7 @@ tslib@>=1.9.0, tslib@^2.0.0, tslib@^2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -17983,6 +18022,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-callback-ref@^1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.4.tgz#d86d1577bfd0b955b6e04aaf5971025f406bea3c"
+  integrity sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==
+
 use-composed-ref@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.0.0.tgz#bb13e8f4a0b873632cde4940abeb88b92d03023a"
@@ -18001,6 +18045,14 @@ use-latest@^1.0.0:
   integrity sha512-gF04d0ZMV3AMB8Q7HtfkAWe+oq1tFXP6dZKwBHQF5nVXtGsh2oAYeeqma5ZzxtlpOcW8Ro/tLcfmEodjDeqtuw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
+
+use-sidecar@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.3.tgz#17a4e567d4830c0c0ee100040e85a7fe68611e0f"
+  integrity sha512-ygJwGUBeQfWgDls7uTrlEDzJUUR67L8Rm14v/KfFtYCdHhtjHZx1Krb3DIQl3/Q5dJGfXLEQ02RY8BdNBv87SQ==
+  dependencies:
+    detect-node-es "^1.0.0"
+    tslib "^1.9.3"
 
 use-subscription@1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Quick PR to add the now-required ariaDescription to the Modal component on the My Applications page. I just reused the same string that we're using for the modal title, but there's probably a better best practice per: https://www.w3.org/TR/wai-aria-practices-1.1/#alertdialog

This also fixes a number of test failures that snuck in from the last few PRs merged -- one each for public build, public cypress, and partners build (which still has an open issue I'll fix in a different PR). 