### PR TITLE
Text tweaks to support applications pilot

### DIFF
--- a/apps/public-reference/pages/applications/household/members-info.tsx
+++ b/apps/public-reference/pages/applications/household/members-info.tsx
@@ -43,9 +43,6 @@ export default () => {
           <h2 className="form-card__title is-borderless mt-4">
             {t("application.household.membersInfo.title")}
           </h2>
-          <h2 className="form-card__title is-borderless mt-4">
-            {t("application.household.membersInfo.subTitle")}
-          </h2>
         </div>
 
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/apps/public-reference/pages/applications/household/preferred-units.tsx
+++ b/apps/public-reference/pages/applications/household/preferred-units.tsx
@@ -67,6 +67,7 @@ export default () => {
           <h2 className="form-card__title is-borderless">
             {t("application.household.preferredUnit.title")}
           </h2>
+          <p className="mt-4 field-note">{t("application.household.preferredUnit.subTitle")}</p>
         </div>
 
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -241,8 +241,7 @@
         "workInRegionNote": "This means they currently work in <REGION> at least 75% of theirs work hours."
       },
       "membersInfo": {
-        "title": "Before adding other people, make sure that they aren't named on any other application for this listing.",
-        "subTitle": "If you include someone who has already applied, all of your applications will be disqualified."
+        "title": "Before adding other people, make sure that they aren't named on any other application for this listing."
       },
       "primaryApplicant": "Primary Applicant"
     },

--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -216,6 +216,7 @@
       },
       "preferredUnit": {
         "title": "What unit sizes are you interested in?",
+        "subTitle": "Your selected unit type will be subject to availability.",
         "optionsLabel": "Check all that apply:",
         "options": {
           "studio": "Studio",


### PR DESCRIPTION
Addresses 2/3rds of #576 -- this should fix the first two text related issues, but I'll leave that open until we handle disabling of income validation.

@slowbot - The CSS might need adjustment in one or both cases, so feel free to change as needed.