### PR TITLE
Use proper @types for markdown-to-jsx

### DIFF
--- a/apps/public-reference/package.json
+++ b/apps/public-reference/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "9.5.2",
+    "@types/markdown-to-jsx": "^6.11.2",
     "@types/node": "^12.12.54",
     "@types/react": "^16.9.47",
     "concurrently": "^5.3.0",

--- a/apps/public-reference/pages/applications/review/terms.tsx
+++ b/apps/public-reference/pages/applications/review/terms.tsx
@@ -69,7 +69,6 @@ export default () => {
         <form id="review-terms" className="mt-4" onSubmit={handleSubmit(onSubmit)}>
           <div className="form-card__pager-row">
             <Markdown options={{ disableParsingRawHTML: false }}>
-              {/* TODO */}
               {t("application.review.terms.text", { applicationDueDate: applicationDueDate })}
             </Markdown>
             <div className={`field mt-4 ${errors?.agree ? "error" : ""}`}>

--- a/apps/public-reference/types/mdx.d.ts
+++ b/apps/public-reference/types/mdx.d.ts
@@ -12,5 +12,3 @@ declare module "*.mdx" {
   let MDXComponent: (props) => JSX.Element
   export default MDXComponent
 }
-
-declare module "markdown-to-jsx"

--- a/shared/ui-components/package.json
+++ b/shared/ui-components/package.json
@@ -56,6 +56,7 @@
     "@bloom-housing/core": "^0.2.14",
     "@types/body-scroll-lock": "^2.6.1",
     "@types/jwt-decode": "^2.2.1",
+    "@types/markdown-to-jsx": "^6.11.2",
     "@types/node": "^12.12.54",
     "@types/node-polyglot": "^2.4.1",
     "@types/react-dom": "^16.9.5",

--- a/shared/ui-components/tailwind.config.js
+++ b/shared/ui-components/tailwind.config.js
@@ -3,6 +3,9 @@
 module.exports = {
   important: true,
   purge: false,
+  future: {
+    removeDeprecatedGapUtilities: true,
+  },
   theme: {
     screens: {
       sm: "640px",

--- a/shared/ui-components/types/markdown-to-jsx/index.d.ts
+++ b/shared/ui-components/types/markdown-to-jsx/index.d.ts
@@ -1,1 +1,0 @@
-declare module "markdown-to-jsx"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3950,7 +3950,7 @@
   dependencies:
     "@types/geojson" "*"
 
-"@types/markdown-to-jsx@^6.11.0":
+"@types/markdown-to-jsx@^6.11.0", "@types/markdown-to-jsx@^6.11.2":
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-6.11.2.tgz#05d1aaffbf15be7be12c70535fa4fed65cc7c64f"
   integrity sha512-ESuCu8Bk7jpTZ3YPdMW1+6wUj13F5N15vXfc7BuUAN0eCp0lrvVL9nzOTzoqvbRzXMciuqXr1KrHt3xQAhfwPA==


### PR DESCRIPTION
They finally landed a PR to fix @types/markdown-to-jsx, so I went ahead and switched over to it before we forgot. Unrelated, other than it's another minor build cleanup in ui-components, but I also enabled `removeDeprecatedGapUtilities` for tailwind, which is officially a 2.0 deprecation, but we're not using it currently and the warning message at startup/build was annoying.

fixes #347