### PR TITLE
WIP: First cut at applicationConfig

### DIFF
--- a/apps/public-reference/lib/AppSubmissionContext.ts
+++ b/apps/public-reference/lib/AppSubmissionContext.ts
@@ -1,6 +1,50 @@
 import React from "react"
 import ApplicationConductor from "./ApplicationConductor"
 
+export function applicationConfig() {
+  // Note: this whole function will eventually be replaced with one that reads this from the backend.
+  return {
+    listing: {}, // TODO: actual listing object
+    status: "TODO: ENUM GOES HERE",
+    languages: ["en", "es"],
+    steps: [
+      {
+        name: "Choose Language", // not user-facing, only shows in partners; user text from the step itself
+        url: "/applications/start/choose-language",
+        skipIf: { condition: "userIsLoggedIn()", skipTo: "/applications/start/what-to-expect" },
+        nextUrl: "/applications/start/what-to-expect",
+      },
+      {
+        name: "What To Expect",
+        url: "/applications/start/what-to-expect",
+        nextUrl: "/applications/contact/name",
+      },
+      {
+        name: "Primary Applicant Name",
+        url: "/applications/contact/name",
+        nextUrl: "/applications/start/address",
+      },
+      // [...]
+      {
+        name: "Senior Building Preference",
+        url: "/applications/preferences/senior",
+        props: { minAge: 65 },
+        // this isn't conditional because the config object is on a per-listing basis
+        nextUrl: "/applications/preferences/livework",
+      },
+      {
+        name: "Live/Work Preference",
+        url: "/applications/preferences/livework",
+        skipIf: {
+          condition: "application.applicant.address.city != 'Correctville'",
+          skipTo: "/applications/start/what-to-expect",
+        },
+        nextUrl: "/applications/start/what-to-expect",
+      },
+    ],
+  }
+}
+
 export const blankApplication = () => {
   return {
     loaded: false,


### PR DESCRIPTION
(see #453 for context)

Ok, this is my first very rough cut at an applicationConfig object, which was just getting a little too long to put in issue comments. I will not be upset if the code itself never makes it anywhere.

Some notes (in addition to the inline file comments):

- I took James's skip_step idea and refactored it up to the conductor so the steps themselves don't have any of that logic in them, which I think is the goal. Hopefully I didn't mangle the intent of the idea.

- I think we may want all form steps to end up submitting back to the same URL across the board, representing the conductor/config component logic. That would provide a central place for the form content to be both saved (as it is now from `ApplicationConductor.sync()`) but also to put the conductor in charge of evaluating any conditionals and then sending the user to the correct next step.

- Trying to get the conditional logic completely embedded in JSON seems both difficult to do elegantly and I'm not sure it buys us that much. It's currently in there as a hybrid approach, but I don't love it.

- I still think being able to pass the equivalent of props into a given screen is important, for example the age limit in my example here. It might even be a more complex object like an AMI chart. It definitely doesn't have to be props per se -- I defer to basically everyone else on what the best way to pass the data in is, but I do think we're better off pushing the right data into the screen rather than embedding the logic in the screen to know where to go read it from. I might be being too idealistic on this point, and I guess if we just make the config available to the screen component and let it read from that context, it's not the end of the world.

- I was thinking about nextjs-like ways to handle the routing and still have the conductor really be able to evaluate things on every click, and one idea I had was that we could have a url like `/application/{configId}/step/{stepName}` and then have `/application/*` always resolve to the conductor which did the right thing based on the inputs, sort of like the listing page based on the listingId. I'm wholly unconvinced that's the right approach, but it seemed at least worth talking about.