### PR TITLE
Disabled login flow elements

### DIFF
--- a/apps/public-reference/layouts/application.tsx
+++ b/apps/public-reference/layouts/application.tsx
@@ -37,7 +37,7 @@ const Layout = (props) => {
               {t("nav.getAssistance")}
             </LocalizedLink>
           )}
-          <UserNav signedIn={!!profile} signOut={signOut}>
+          {/* <UserNav signedIn={!!profile} signOut={signOut}>
             <LocalizedLink href="/account/dashboard" className="navbar-item">
               {t("nav.myDashboard")}
             </LocalizedLink>
@@ -47,7 +47,7 @@ const Layout = (props) => {
             <LocalizedLink href="/account/settings" className="navbar-item">
               {t("nav.accountSettings")}
             </LocalizedLink>
-          </UserNav>
+          </UserNav> */}
         </SiteHeader>
         <main id="main-content">{props.children}</main>
       </div>

--- a/apps/public-reference/pages/applications/household/preferred-units.tsx
+++ b/apps/public-reference/pages/applications/household/preferred-units.tsx
@@ -95,11 +95,11 @@ export default () => {
             </div>
           </div>
 
-          <div className="p-8 text-center">
+          {/* <div className="p-8 text-center">
             <Link href="/">
               <a className="lined text-tiny">{t("application.form.general.saveAndFinishLater")}</a>
             </Link>
-          </div>
+          </div> */}
         </Form>
       </FormCard>
     </FormsLayout>

--- a/apps/public-reference/pages/applications/review/confirmation.tsx
+++ b/apps/public-reference/pages/applications/review/confirmation.tsx
@@ -62,7 +62,7 @@ export default () => {
           )}
         </div>
 
-        <div className="form-card__group">
+        {/* <div className="form-card__group">
           <h3 className="form-card__paragraph-title">
             {t("application.review.confirmation.createAccountTitle")}
           </h3>
@@ -70,10 +70,10 @@ export default () => {
           <p className="field-note mt-1">
             {t("application.review.confirmation.createAccountParagraph")}
           </p>
-        </div>
+        </div> */}
 
         <div className="form-card__pager">
-          <div className="form-card__pager-row primary">
+          {/* <div className="form-card__pager-row primary">
             <Button
               filled={true}
               onClick={() => {
@@ -82,13 +82,13 @@ export default () => {
             >
               {t("application.form.general.createAccount")}
             </Button>
-          </div>
+          </div> */}
 
-          <div className="form-card__pager-row py-6">
+          {/* <div className="form-card__pager-row py-6">
             <a className="lined text-tiny" href="/">
               {t("application.review.confirmation.imdone")}
             </a>
-          </div>
+          </div> */}
 
           <div className="form-card__pager-row py-6">
             <Link href="/listings">

--- a/apps/public-reference/pages/applications/review/demographics.tsx
+++ b/apps/public-reference/pages/applications/review/demographics.tsx
@@ -157,11 +157,11 @@ const Demographics = () => {
             </div>
           </div>
 
-          <div className="p-8 text-center">
+          {/* <div className="p-8 text-center">
             <Link href="/">
               <a className="lined text-tiny">{t("application.form.general.saveAndFinishLater")}</a>
             </Link>
-          </div>
+          </div> */}
         </Form>
       </FormCard>
     </FormsLayout>

--- a/apps/public-reference/pages/applications/start/choose-language.tsx
+++ b/apps/public-reference/pages/applications/start/choose-language.tsx
@@ -109,7 +109,7 @@ export default () => {
             </div>
           </Form>
 
-          <div className="form-card__pager-row primary px-4 border-t border-gray-450">
+          {/* <div className="form-card__pager-row primary px-4 border-t border-gray-450">
             <h2 className="form-card__title w-full border-none pt-0 mt-0">
               {t("application.chooseLanguage.haveAnAccount")}
             </h2>
@@ -121,7 +121,7 @@ export default () => {
                 {t("nav.signIn")}
               </LinkButton>
             </div>
-          </div>
+          </div> */}
         </div>
       </FormCard>
     </FormsLayout>


### PR DESCRIPTION
Issue: #589 

Disabled:

"Sign In" link in main navigation
"Already have an account" section on start/choose-language
"Save and finish later" on applications/household/preferred-units and applications/review/demographics
"Create Account" screen on /applications/review/confirmation