### PR TITLE
Fix age validation for DOBField

### DIFF
--- a/shared/ui-components/src/forms/DOBField.tsx
+++ b/shared/ui-components/src/forms/DOBField.tsx
@@ -25,7 +25,8 @@ const DOBField = (props: DOBFieldProps) => {
   const validateAge = (value: string) => {
     return (
       parseInt(value) > 1900 &&
-      moment(`${birthMonth}.${birthDay}.${value}`) < moment().subtract(atAge ? 18 : 0, "years")
+      moment(`${birthMonth}/${birthDay}/${value}`, "MM/DD/YYYY") <
+        moment().subtract(atAge ? 18 : 0, "years")
     )
   }
 


### PR DESCRIPTION
Age/year validation was broken in Safari but worked in Chromium-based browsers. This fix ensures it works consistently.