### PR TITLE
add ami charts from housingbayarea for testing ease

### DIFF
--- a/backend/core/ami_charts/AlamedaCountyLIHTC2020.json
+++ b/backend/core/ami_charts/AlamedaCountyLIHTC2020.json
@@ -1,0 +1,122 @@
+[
+  {
+    "householdSize": 1,
+    "income": 27420,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 2,
+    "income": 31320,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 3,
+    "income": 35250,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 4,
+    "income": 39150,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 5,
+    "income": 42300,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 6,
+    "income": 45420,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 7,
+    "income": 48570,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 8,
+    "income": 51700,
+    "percentOfAmi": 30
+  },
+  {
+    "householdSize": 1,
+    "income": 45700,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 2,
+    "income": 52200,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 3,
+    "income": 58750,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 4,
+    "income": 65250,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 5,
+    "income": 70500,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 6,
+    "income": 75700,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 7,
+    "income": 80950,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 8,
+    "income": 86150,
+    "percentOfAmi": 50
+  },
+  {
+    "householdSize": 1,
+    "income": 54840,
+    "percentOfAmi": 60
+  },
+  {
+    "householdSize": 2,
+    "income": 62640,
+    "percentOfAmi": 60
+  },
+  {
+    "householdSize": 3,
+    "income": 70500,
+    "percentOfAmi": 60
+  },
+  {
+    "householdSize": 4,
+    "income": 78300,
+    "percentOfAmi": 60
+  },
+  {
+    "householdSize": 5,
+    "income": 84600,
+    "percentOfAmi": 60
+  },
+  {
+    "householdSize": 6,
+    "income": 90840,
+    "percentOfAmi": 60
+  },
+  {
+    "householdSize": 7,
+    "income": 97140,
+    "percentOfAmi": 60
+  },
+  {
+    "householdSize": 8,
+    "income": 103380,
+    "percentOfAmi": 60
+  }
+]

--- a/backend/core/ami_charts/AlamedaCountyTCAC2019.json
+++ b/backend/core/ami_charts/AlamedaCountyTCAC2019.json
@@ -1,0 +1,122 @@
+[
+  {
+    "percentOfAmi": 80,
+    "householdSize": 1,
+    "income": 69000
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 2,
+    "income": 78850
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 3,
+    "income": 88700
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 4,
+    "income": 98550
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 5,
+    "income": 106450
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 6,
+    "income": 115040
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 7,
+    "income": 122960
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 8,
+    "income": 130800
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 1,
+    "income": 52080
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 2,
+    "income": 59520
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 3,
+    "income": 66960
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 4,
+    "income": 74340
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 5,
+    "income": 80340
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 6,
+    "income": 86280
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 7,
+    "income": 92220
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 8,
+    "income": 98160
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 1,
+    "income": 26040
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 2,
+    "income": 29760
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 3,
+    "income": 33480
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 4,
+    "income": 37170
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 5,
+    "income": 40170
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 6,
+    "income": 43140
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 7,
+    "income": 46110
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 8,
+    "income": 49080
+  }
+]

--- a/backend/core/ami_charts/OaklandFremontHUD2020.json
+++ b/backend/core/ami_charts/OaklandFremontHUD2020.json
@@ -1,0 +1,42 @@
+[
+  {
+    "percentOfAmi": 50,
+    "householdSize": 1,
+    "income": 45700
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 2,
+    "income": 52200
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 3,
+    "income": 58750
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 4,
+    "income": 65250
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 5,
+    "income": 70500
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 6,
+    "income": 75700
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 7,
+    "income": 80950
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 7,
+    "income": 86150
+  }
+]

--- a/backend/core/ami_charts/SanMateoCountyTCAC2019.json
+++ b/backend/core/ami_charts/SanMateoCountyTCAC2019.json
@@ -1,0 +1,12 @@
+[
+  {
+    "percentOfAmi": 60,
+    "householdSize": 1,
+    "income": 71170
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 1,
+    "income": 56450
+  }
+]

--- a/backend/core/ami_charts/SanMateoCountyTCAC2020.json
+++ b/backend/core/ami_charts/SanMateoCountyTCAC2020.json
@@ -1,0 +1,237 @@
+[
+    {
+        "percentOfAmi": "30",
+        "householdSize": 1,
+        "income": "36540"
+    },
+    {
+        "percentOfAmi": "30",
+        "householdSize": 2,
+        "income": "41760"
+    },
+    {
+        "percentOfAmi": "30",
+        "householdSize": 3,
+        "income": "46980"
+    },
+    {
+        "percentOfAmi": "30",
+        "householdSize": 4,
+        "income": "52200"
+    },
+    {
+        "percentOfAmi": "30",
+        "householdSize": 5,
+        "income": "56400"
+    },
+    {
+        "percentOfAmi": "30",
+        "householdSize": 6,
+        "income": "60570"
+    },
+    {
+        "percentOfAmi": "30",
+        "householdSize": 7,
+        "income": "64740"
+    },
+    {
+        "percentOfAmi": "30",
+        "householdSize": 8,
+        "income": "68910"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 1,
+        "income": "60900"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 2,
+        "income": "69600"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 3,
+        "income": "78300"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 4,
+        "income": "87000"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 5,
+        "income": "94000"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 6,
+        "income": "100950"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 7,
+        "income": "107900"
+    },
+    {
+        "percentOfAmi": "50",
+        "householdSize": 8,
+        "income": "114850"
+    },
+    {
+        "percentOfAmi": "60",
+        "householdSize": 1,
+        "income": "73080"
+    },
+    {
+        "percentOfAmi": "60",
+        "householdSize": 2,
+        "income": "83520"
+    },
+    {
+        "percentOfAmi": "60",
+        "householdSize": 3,
+        "income": "93960"
+    },
+    {
+        "percentOfAmi": "60",
+        "householdSize": 4,
+        "income": "104400"
+    },
+    {
+        "percentOfAmi": "60",
+        "householdSize": 5,
+        "income": "112800"
+    },
+    {
+        "percentOfAmi": "60",
+        "householdSize": 6,
+        "income": "121140"
+    },
+    {
+        "percentOfAmi": "60",
+        "householdSize": 7,
+        "income": "129480"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 1,
+        "income": "97440"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 2,
+        "income": "111360"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 3,
+        "income": "125280"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 4,
+        "income": "139200"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 5,
+        "income": "150400"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 6,
+        "income": "161520"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 7,
+        "income": "172640"
+    },
+    {
+        "percentOfAmi": "80",
+        "householdSize": 8,
+        "income": "183760"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 1,
+        "income": "121800"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 2,
+        "income": "139200"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 3,
+        "income": "156600"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 4,
+        "income": "174000"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 5,
+        "income": "188000"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 6,
+        "income": "201900"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 7,
+        "income": "215800"
+    },
+    {
+        "percentOfAmi": "100",
+        "householdSize": 8,
+        "income": "229700"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 1,
+        "income": "146160"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 2,
+        "income": "167040"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 3,
+        "income": "187920"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 4,
+        "income": "208800"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 5,
+        "income": "225600"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 6,
+        "income": "242280"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 7,
+        "income": "258960"
+    },
+    {
+        "percentOfAmi": "120",
+        "householdSize": 8,
+        "income": "275640"
+    }
+]

--- a/backend/core/ami_charts/SanMateoHUD2020.json
+++ b/backend/core/ami_charts/SanMateoHUD2020.json
@@ -1,0 +1,107 @@
+[
+  {
+    "percentOfAmi": 120,
+    "householdSize": 1,
+    "income": 120200
+  },
+  {
+    "percentOfAmi": 120,
+    "householdSize": 2,
+    "income": 137350
+  },
+  {
+    "percentOfAmi": 120,
+    "householdSize": 3,
+    "income": 154550
+  },
+  {
+    "percentOfAmi": 120,
+    "householdSize": 4,
+    "income": 171700
+  },
+  {
+    "percentOfAmi": 120,
+    "householdSize": 5,
+    "income": 185450
+  },
+  {
+    "percentOfAmi": 120,
+    "householdSize": 6,
+    "income": 199150
+  },
+  {
+    "percentOfAmi": 120,
+    "householdSize": 7,
+    "income": 212900
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 1,
+    "income": 97600
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 2,
+    "income": 111550
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 3,
+    "income": 125500
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 4,
+    "income": 139400
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 5,
+    "income": 150600
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 6,
+    "income": 161750
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 7,
+    "income": 172900
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 1,
+    "income": 60900
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 2,
+    "income": 69600
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 3,
+    "income": 78300
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 4,
+    "income": 87000
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 5,
+    "income": 94000
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 6,
+    "income": 100950
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 7,
+    "income": 107900
+  }
+]

--- a/backend/core/src/lib/ami_charts.ts
+++ b/backend/core/src/lib/ami_charts.ts
@@ -2,10 +2,22 @@ import sanMateoHUD2019 from "../../ami_charts/SanMateoHUD2019.json"
 import sanMateoHOME2019 from "../../ami_charts/SanMateoHOME2019.json"
 import sanMateoHERASpecial2019 from "../../ami_charts/SanMateoHERASpecial2019.json"
 import sanJoseTCAC2019 from "../../ami_charts/SanJoseTCAC2019.json"
+import AlamedaCountyTCAC2019 from "../../ami_charts/AlamedaCountyTCAC2019.json"
+import SanMateoCountyTCAC2019 from "../../ami_charts/SanMateoCountyTCAC2019.json"
+import sanMateoHUD2020 from "../../ami_charts/SanMateoHUD2020.json"
+import SanMateoCountyTCAC2020 from "../../ami_charts/SanMateoCountyTCAC2020.json"
+import AlamedaCountyLIHTC2020 from "../../ami_charts/AlamedaCountyLIHTC2020.json"
+import OaklandFremontHUD2020 from "../../ami_charts/OaklandFremontHUD2020.json"
 
 export const amiCharts = {
   1: sanMateoHUD2019,
   2: sanMateoHOME2019,
   3: sanMateoHERASpecial2019,
   4: sanJoseTCAC2019,
+  5: AlamedaCountyTCAC2019,
+  6: SanMateoCountyTCAC2019,
+  7: sanMateoHUD2020,
+  8: SanMateoCountyTCAC2020,
+  9: AlamedaCountyLIHTC2020,
+  10: OaklandFremontHUD2020,
 }


### PR DESCRIPTION
This adds the active AMI charts from housingbayarea to backend/core, so they're all available for test listings to use.