### PR TITLE
use an SSL connection in prod and allow a self-signed cert for it

### DIFF
--- a/backend/core/ormconfig.ts
+++ b/backend/core/ormconfig.ts
@@ -23,6 +23,11 @@ const connectionInfo = process.env.DATABASE_URL
   ? { url: process.env.DATABASE_URL }
   : defaultConnectionForEnv[env]
 
+// Require an SSL connection to the DB in production, and allow self-signed
+if (process.env.NODE_ENV === "production") {
+  connectionInfo.ssl = { rejectUnauthorized: false }
+}
+
 // Unfortunately, we need to use CommonJS/AMD style exports rather than ES6-style modules for this due to how
 // TypeORM expects the config to be available.
 export = {


### PR DESCRIPTION
Heroku production plans are set up to require SSL, which is a Good Thing for security, but we need to turn it on.