### PR TITLE
reduce use of the word "lottery" when not needed

### DIFF
--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -260,7 +260,7 @@
       "title": "Your household may qualify for the following housing preferences.",
       "preamble": "If you qualify for this preference, you'll get a higher ranking.",
       "selectBelow": "If you have one of these housing preferences, select it below:",
-      "dontWant": "I don't want this lottery preference",
+      "dontWant": "I don't want this preference",
       "stillHaveOpportunity": "You'll still have the opportunity to claim other preferences.",
       "youHaveClaimed": "You have claimed:",
       "liveIn": {
@@ -274,8 +274,8 @@
         "link": "http://domain.com"
       },
       "general": {
-        "title": "Based on the information you have entered, your household has not claimed any housing lottery preferences.",
-        "preamble": "You will be in the general lottery."
+        "title": "Based on the information you have entered, your household has not claimed any housing preferences.",
+        "preamble": "You will be in the general pool of applicants."
       }
     },
     "review": {
@@ -369,7 +369,7 @@
       "viewOriginalListing": "View the original listing",
       "informationSubmittedTitle": "Here's the information you submitted.",
       "submitted": "Submitted: ",
-      "lotteryNumber": "Your lottery number",
+      "lotteryNumber": "Your confirmation number",
       "preferences": "Preferences",
       "generalLottery": "Based on information you have entered, your household has not claimed any housing lottery preferences. You will be in the general lottery.",
       "printCopy": "Print a copy for your records"
@@ -378,7 +378,7 @@
       "income": {
         "title": "Let's move to income.",
         "instruction1": "Add up your total gross (pre-tax) household income from wages, benefits and other sources from all household members.",
-        "instruction2": "You only need to provide an estimated total right now. The actual total will be calculated if you are selected in the lottery.",
+        "instruction2": "You only need to provide an estimated total right now. The actual total will be calculated if you are selected.",
         "prompt": "What is your household total pre-tax income?",
         "placeholder": "Total all of your income sources",
         "incomeError": "Please enter a valid number greater than 0.",
@@ -442,7 +442,7 @@
       "submitted": "Submitted"
     },
     "viewApplication": "View Application",
-    "yourLotteryNumber": "Your lottery number is"
+    "yourLotteryNumber": "Your confirmation number is"
   },
   "authentication": {
     "timeout": {
@@ -647,7 +647,7 @@
     "additionalInformationEnvelope": "Additional Information Envelope"
   },
   "lottery": {
-    "applicationsThatQualifyForPreference": "Applications that qualify for this preference will be given a higher priority in the lottery.",
+    "applicationsThatQualifyForPreference": "Applications that qualify for this preference will be given a higher priority.",
     "viewPreferenceList": "View Preference List"
   },
   "nav": {


### PR DESCRIPTION
Fixes #671.

Also fixes a bunch of other cases where I don't think we need to use the word "lottery" explicitly.