### PR TITLE
Fix email confirmation when there is no email

### DIFF
--- a/backend/core/src/applications/applications.controller.ts
+++ b/backend/core/src/applications/applications.controller.ts
@@ -48,7 +48,9 @@ export class ApplicationsController {
   async create(@Body() applicationCreateDto: ApplicationCreateDto): Promise<Application> {
     const application = await this.applicationsService.create(applicationCreateDto)
     const listing = await this.listingsService.findOne(application.listing.id)
-    await this.emailService.confirmation(listing, application, applicationCreateDto.appUrl)
+    if (application.application.applicant.emailAddress) {
+      await this.emailService.confirmation(listing, application, applicationCreateDto.appUrl)
+    }
     return application
   }
 

--- a/backend/core/test/applications/applications.e2e-spec.ts
+++ b/backend/core/test/applications/applications.e2e-spec.ts
@@ -84,6 +84,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -105,6 +108,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -122,6 +128,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       user: {
         id: user1Id,
@@ -141,6 +150,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -161,6 +173,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -189,6 +204,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -213,6 +231,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -232,6 +253,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "new bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -253,6 +277,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }
@@ -272,6 +299,9 @@ describe("Applications", () => {
       },
       application: {
         foo: "new bar",
+        applicant: {
+          emailAddress: "test@example.com",
+        },
       },
       appUrl: "",
     }


### PR DESCRIPTION
Fixes a bug that @pbn4 found. While applying with no email, email confirmation was throwing an error.