### PR TITLE
add AlamedaCountyTCAC2020 AMI chart to ease testing real listings

### DIFF
--- a/backend/core/ami_charts/AlamedaCountyTCAC2020.json
+++ b/backend/core/ami_charts/AlamedaCountyTCAC2020.json
@@ -1,0 +1,162 @@
+[
+  {
+    "percentOfAmi": 80,
+    "householdSize": 1,
+    "income": 73100
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 2,
+    "income": 83550
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 3,
+    "income": 94000
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 4,
+    "income": 104400
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 5,
+    "income": 112800
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 6,
+    "income": 121150
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 7,
+    "income": 129500
+  },
+  {
+    "percentOfAmi": 80,
+    "householdSize": 8,
+    "income": 137850
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 1,
+    "income": 54840
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 2,
+    "income": 62640
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 3,
+    "income": 70500
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 4,
+    "income": 78300
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 5,
+    "income": 84600
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 6,
+    "income": 90840
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 7,
+    "income": 97140
+  },
+  {
+    "percentOfAmi": 60,
+    "householdSize": 8,
+    "income": 103380
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 1,
+    "income": 45700
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 2,
+    "income": 52200
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 3,
+    "income": 58750
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 4,
+    "income": 65250
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 5,
+    "income": 70500
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 6,
+    "income": 75700
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 7,
+    "income": 80950
+  },
+  {
+    "percentOfAmi": 50,
+    "householdSize": 8,
+    "income": 86500
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 1,
+    "income": 27450
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 2,
+    "income": 31350
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 3,
+    "income": 35250
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 4,
+    "income": 39150
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 5,
+    "income": 42300
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 6,
+    "income": 45450
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 7,
+    "income": 48550
+  },
+  {
+    "percentOfAmi": 30,
+    "householdSize": 8,
+    "income": 51700
+  }
+]

--- a/backend/core/src/lib/ami_charts.ts
+++ b/backend/core/src/lib/ami_charts.ts
@@ -8,6 +8,7 @@ import sanMateoHUD2020 from "../../ami_charts/SanMateoHUD2020.json"
 import SanMateoCountyTCAC2020 from "../../ami_charts/SanMateoCountyTCAC2020.json"
 import AlamedaCountyLIHTC2020 from "../../ami_charts/AlamedaCountyLIHTC2020.json"
 import OaklandFremontHUD2020 from "../../ami_charts/OaklandFremontHUD2020.json"
+import AlamedaCountyTCAC2020 from "../../ami_charts/AlamedaCountyTCAC2020.json"
 
 export const amiCharts = {
   1: sanMateoHUD2019,
@@ -20,4 +21,5 @@ export const amiCharts = {
   8: SanMateoCountyTCAC2020,
   9: AlamedaCountyLIHTC2020,
   10: OaklandFremontHUD2020,
+  11: AlamedaCountyTCAC2020,
 }


### PR DESCRIPTION
This just copies the AlamedaCountyTCAC2020 AMI chart over from housingbayarea, so that we can load listings that reference it easily for testing.