### PR TITLE
Fixed infinity loop

### DIFF
--- a/apps/public-reference/pages/applications/start/choose-language.tsx
+++ b/apps/public-reference/pages/applications/start/choose-language.tsx
@@ -39,7 +39,9 @@ export default () => {
   const listingId = router.query.listingId
 
   useEffect(() => {
-    void loadListing(listingId, setListing, conductor, context)
+    if (!context.listing) {
+      void loadListing(listingId, setListing, conductor, context)
+    }
   }, [conductor, context, listingId])
 
   const currentPageSection = 1


### PR DESCRIPTION
I noticed an infinity loop in the choose-language step, fixed by adding condition (if listing is null).