### PR TITLE
Set default values for the demographics form

### DIFF
--- a/apps/public-reference/pages/applications/review/demographics.tsx
+++ b/apps/public-reference/pages/applications/review/demographics.tsx
@@ -31,7 +31,14 @@ const Demographics = () => {
 
   /* Form Handler */
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit } = useForm()
+  const { register, handleSubmit } = useForm({
+    defaultValues: {
+      ethnicity: application.demographics.ethnicity,
+      race: application.demographics.race,
+      gender: application.demographics.gender,
+      sexualOrientation: application.demographics.sexualOrientation,
+    },
+  })
 
   const onSubmit = (data) => {
     const { ethnicity, race, gender, sexualOrientation, howDidYouHear } = data
@@ -52,13 +59,14 @@ const Demographics = () => {
     return howDidYouHear?.map((item) => ({
       id: item.id,
       label: t(`application.review.demographics.howDidYouHearOptions.${item.id}`),
-      defaultChecked: item.checked,
+      defaultChecked: item.checked || application.demographics.howDidYouHear.includes(item.id),
       register,
     }))
-  }, [register])
+  }, [register, application])
 
   return (
     <FormsLayout>
+      {console.log(application)}
       <FormCard header={listing?.name}>
         <ProgressNav
           currentPageSection={currentPageSection}


### PR DESCRIPTION
Closes #818 

Demographics form is persisted, but it was an issue with initial values (only in frontend side, context still had saved values).