### PR TITLE
Feature/application details cleanup

### DIFF
--- a/apps/partners-reference/pages/applications/[applicationId].tsx
+++ b/apps/partners-reference/pages/applications/[applicationId].tsx
@@ -19,6 +19,7 @@ enum AddressColsType {
   "residence" = "residence",
   "mailing" = "mailing",
   "work" = "work",
+  "alternateAddress" = "alternateAddress",
 }
 
 export default function ApplicationsList() {
@@ -120,6 +121,12 @@ export default function ApplicationsList() {
           } else {
             address[item] = t("t.n/a")
           }
+        }
+
+        if (type === AddressColsType.alternateAddress) {
+          address[item] = application.alternateContact.mailingAddress[item]
+            ? application.alternateContact.mailingAddress[item]
+            : t("t.n/a")
         }
       })
 
@@ -339,48 +346,55 @@ export default function ApplicationsList() {
                   className="bg-primary-lighter"
                   title={t("application.alternateContact.type.label")}
                   inset
+                  grid={false}
                 >
-                  <GridCell>
-                    <ViewItem label={t("application.name.firstName")}>
-                      {application.alternateContact.firstName}
-                    </ViewItem>
-                  </GridCell>
-
-                  <GridCell>
-                    <ViewItem label={t("application.name.lastName")}>
-                      {application.alternateContact.lastName}
-                    </ViewItem>
-                  </GridCell>
-
-                  <GridCell>
-                    <ViewItem label={t("t.relationship")}>
-                      {t(
-                        `application.alternateContact.type.options.${application.alternateContact.type}`
-                      )}
-                    </ViewItem>
-                  </GridCell>
-
-                  {
+                  <GridSection columns={3}>
                     <GridCell>
-                      <ViewItem label={t("application.details.agency")}>
-                        {application.alternateContact.agency?.length
-                          ? application.alternateContact.agency
-                          : t("t.none")}
+                      <ViewItem label={t("application.name.firstName")}>
+                        {application.alternateContact.firstName}
                       </ViewItem>
                     </GridCell>
-                  }
 
-                  <GridCell>
-                    <ViewItem label={t("t.email")}>
-                      {application.alternateContact.emailAddress}
-                    </ViewItem>
-                  </GridCell>
+                    <GridCell>
+                      <ViewItem label={t("application.name.lastName")}>
+                        {application.alternateContact.lastName}
+                      </ViewItem>
+                    </GridCell>
 
-                  <GridCell>
-                    <ViewItem label={t("t.phone")}>
-                      {application.alternateContact.phoneNumber}
-                    </ViewItem>
-                  </GridCell>
+                    <GridCell>
+                      <ViewItem label={t("t.relationship")}>
+                        {t(
+                          `application.alternateContact.type.options.${application.alternateContact.type}`
+                        )}
+                      </ViewItem>
+                    </GridCell>
+
+                    {
+                      <GridCell>
+                        <ViewItem label={t("application.details.agency")}>
+                          {application.alternateContact.agency?.length
+                            ? application.alternateContact.agency
+                            : t("t.none")}
+                        </ViewItem>
+                      </GridCell>
+                    }
+
+                    <GridCell>
+                      <ViewItem label={t("t.email")}>
+                        {application.alternateContact.emailAddress}
+                      </ViewItem>
+                    </GridCell>
+
+                    <GridCell>
+                      <ViewItem label={t("t.phone")}>
+                        {application.alternateContact.phoneNumber}
+                      </ViewItem>
+                    </GridCell>
+                  </GridSection>
+
+                  <GridSection subtitle={t("application.contact.address")} columns={4}>
+                    {addressCols(AddressColsType.alternateAddress)}
+                  </GridSection>
                 </GridSection>
               )}
 
@@ -444,6 +458,18 @@ export default function ApplicationsList() {
               <GridCell>
                 <ViewItem label={t("application.details.vouchers")}>
                   {application.incomeVouchers ? t("t.yes") : t("t.no")}
+                </ViewItem>
+              </GridCell>
+            </GridSection>
+
+            <GridSection
+              className="bg-primary-lighter"
+              title={t("application.review.terms.title")}
+              inset
+            >
+              <GridCell>
+                <ViewItem label={t("application.details.signatureOnTerms")}>
+                  {application.acceptedTerms ? t("t.yes") : t("t.no")}
                 </ViewItem>
               </GridCell>
             </GridSection>

--- a/apps/partners-reference/pages/applications/[applicationId].tsx
+++ b/apps/partners-reference/pages/applications/[applicationId].tsx
@@ -484,7 +484,15 @@ export default function ApplicationsList() {
             >
               <GridCell>
                 <ViewItem label={t("application.details.signatureOnTerms")}>
-                  {application.acceptedTerms ? t("t.yes") : t("t.no")}
+                  {(() => {
+                    if (typeof application.acceptedTerms == "undefined") {
+                      return t("t.n/a")
+                    } else if (application.acceptedTerms) {
+                      return t("t.yes")
+                    } else {
+                      return t("t.no")
+                    }
+                  })()}
                 </ViewItem>
               </GridCell>
             </GridSection>

--- a/apps/partners-reference/pages/applications/[applicationId].tsx
+++ b/apps/partners-reference/pages/applications/[applicationId].tsx
@@ -124,11 +124,11 @@ export default function ApplicationsList() {
 
       return (
         <>
-          <GridCell span={2}>
+          <GridCell>
             <ViewItem label={t("application.contact.streetAddress")}>{address.street}</ViewItem>
           </GridCell>
 
-          <GridCell>
+          <GridCell span={2}>
             <ViewItem label={t("application.contact.apt")}>{address.street2}</ViewItem>
           </GridCell>
 
@@ -250,7 +250,9 @@ export default function ApplicationsList() {
 
                 <GridCell>
                   <ViewItem label={t("application.name.middleName")}>
-                    {application.applicant.middleName}
+                    {application.applicant.middleName
+                      ? application.applicant.middleName
+                      : t("t.n/a")}
                   </ViewItem>
                 </GridCell>
 
@@ -373,7 +375,9 @@ export default function ApplicationsList() {
 
                     <GridCell>
                       <ViewItem label={t("t.email")}>
-                        {application.alternateContact.emailAddress}
+                        {application.alternateContact.emailAddress
+                          ? application.alternateContact.emailAddress
+                          : t("t.n/a")}
                       </ViewItem>
                     </GridCell>
 

--- a/apps/partners-reference/pages/applications/[applicationId].tsx
+++ b/apps/partners-reference/pages/applications/[applicationId].tsx
@@ -11,9 +11,11 @@ import {
   GridCell,
   MinimalTable,
   InlineButton,
+  formatIncome,
 } from "@bloom-housing/ui-components"
 import { useSingleApplicationData } from "../../lib/hooks"
 import Layout from "../../layouts/application"
+import { IncomePeriod } from "@bloom-housing/core"
 
 enum AddressColsType {
   "residence" = "residence",
@@ -51,16 +53,6 @@ export default function ApplicationsList() {
 
     return momentDate.format("MMMM DD, YYYY")
   }, [applicationDto])
-
-  const annualIncome = useMemo(() => {
-    if (!application) return null
-
-    const { income, incomePeriod } = application
-    const numericIncome = parseFloat(income)
-
-    const annual = incomePeriod === "perMonth" ? numericIncome * 12 : numericIncome
-    return `${annual.toFixed(2)}`
-  }, [application])
 
   const householdMembersHeaders = {
     name: t("t.name"),
@@ -416,6 +408,7 @@ export default function ApplicationsList() {
               className="bg-primary-lighter"
               title={t("application.review.householdDetails")}
               inset
+              columns={3}
             >
               <GridCell>
                 <ViewItem label={t("application.details.adaPriorities")}>
@@ -453,8 +446,29 @@ export default function ApplicationsList() {
               inset
             >
               <GridCell>
-                <ViewItem label={t("application.details.annualIncome")}>{annualIncome}</ViewItem>
+                <ViewItem label={t("application.details.annualIncome")}>
+                  {application.incomePeriod === "perYear"
+                    ? formatIncome(
+                        parseFloat(application.income),
+                        application.incomePeriod,
+                        IncomePeriod.perYear
+                      )
+                    : t("t.n/a")}
+                </ViewItem>
               </GridCell>
+
+              <GridCell>
+                <ViewItem label={t("application.details.monthlyIncome")}>
+                  {application.incomePeriod === "perMonth"
+                    ? formatIncome(
+                        parseFloat(application.income),
+                        application.incomePeriod,
+                        IncomePeriod.perMonth
+                      )
+                    : t("t.n/a")}
+                </ViewItem>
+              </GridCell>
+
               <GridCell>
                 <ViewItem label={t("application.details.vouchers")}>
                   {application.incomeVouchers ? t("t.yes") : t("t.no")}
@@ -466,6 +480,7 @@ export default function ApplicationsList() {
               className="bg-primary-lighter"
               title={t("application.review.terms.title")}
               inset
+              grid={false}
             >
               <GridCell>
                 <ViewItem label={t("application.details.signatureOnTerms")}>

--- a/apps/partners-reference/pages/applications/[applicationId].tsx
+++ b/apps/partners-reference/pages/applications/[applicationId].tsx
@@ -124,11 +124,11 @@ export default function ApplicationsList() {
 
       return (
         <>
-          <GridCell>
+          <GridCell span={2}>
             <ViewItem label={t("application.contact.streetAddress")}>{address.street}</ViewItem>
           </GridCell>
 
-          <GridCell span={3}>
+          <GridCell>
             <ViewItem label={t("application.contact.apt")}>{address.street2}</ViewItem>
           </GridCell>
 
@@ -318,15 +318,15 @@ export default function ApplicationsList() {
                 </GridCell>
               </GridSection>
 
-              <GridSection subtitle={t("application.details.residenceAddress")} columns={4}>
+              <GridSection subtitle={t("application.details.residenceAddress")} columns={3}>
                 {addressCols(AddressColsType.residence)}
               </GridSection>
 
-              <GridSection subtitle={t("application.contact.mailingAddress")} columns={4}>
+              <GridSection subtitle={t("application.contact.mailingAddress")} columns={3}>
                 {addressCols(AddressColsType.mailing)}
               </GridSection>
 
-              <GridSection subtitle={t("application.contact.workAddress")} columns={4}>
+              <GridSection subtitle={t("application.contact.workAddress")} columns={3}>
                 {addressCols(AddressColsType.work)}
               </GridSection>
             </GridSection>
@@ -384,7 +384,7 @@ export default function ApplicationsList() {
                     </GridCell>
                   </GridSection>
 
-                  <GridSection subtitle={t("application.contact.address")} columns={4}>
+                  <GridSection subtitle={t("application.contact.address")} columns={3}>
                     {addressCols(AddressColsType.alternateAddress)}
                   </GridSection>
                 </GridSection>

--- a/shared/ui-components/index.ts
+++ b/shared/ui-components/index.ts
@@ -58,6 +58,7 @@ export * from "./src/helpers/tableSummaries"
 export * from "./src/helpers/translator"
 export * from "./src/helpers/useLanguageChange"
 export * from "./src/helpers/debounce"
+export * from "./src/helpers/formatIncome"
 
 /* Icons */
 export * from "./src/icons/HeaderBadge"

--- a/shared/ui-components/src/helpers/formatIncome.ts
+++ b/shared/ui-components/src/helpers/formatIncome.ts
@@ -1,0 +1,20 @@
+import { IncomePeriod } from "@bloom-housing/core"
+
+export function formatIncome(value: number, period: IncomePeriod, returnType: IncomePeriod) {
+  const usd = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+
+  const monthIncomeNumber = period === "perYear" ? value / 12 : value
+  const yearIncomeNumber = period === "perMonth" ? value * 12 : value
+
+  const perMonth = usd.format(monthIncomeNumber)
+  const perYear = usd.format(yearIncomeNumber)
+
+  if (returnType === "perMonth") return perMonth
+
+  return perYear
+}

--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -26,6 +26,7 @@
       "liveOrWorkIn": "Live or Work in",
       "householdIncome": "Declared Household Income",
       "annualIncome": "Annual Income",
+      "monthlyIncome": "Monthly Income",
       "vouchers": "Housing Voucher or Subsidy",
       "preferredContact": "Preferred Contact",
       "residenceAddress": "Residence Address",

--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -29,6 +29,7 @@
       "vouchers": "Housing Voucher or Subsidy",
       "preferredContact": "Preferred Contact",
       "residenceAddress": "Residence Address",
+      "workInRegion": "Work in Region",
       "submissionType": {
         "electronical": "Electronical",
         "paper": "Paper"
@@ -761,6 +762,7 @@
     "menu": "Menu",
     "minimumIncome": "Minimum Income",
     "month": "Month",
+    "n/a": "n/a",
     "name": "Name",
     "neighborhood": "Neighborhood",
     "next": "Next",

--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -30,6 +30,7 @@
       "preferredContact": "Preferred Contact",
       "residenceAddress": "Residence Address",
       "workInRegion": "Work in Region",
+      "signatureOnTerms": "Signature on Terms of Agreement",
       "submissionType": {
         "electronical": "Electronical",
         "paper": "Paper"

--- a/shared/ui-components/src/locales/general.json
+++ b/shared/ui-components/src/locales/general.json
@@ -16,7 +16,7 @@
       "number": "Application Number",
       "type": "Application Submission Type",
       "submittedDate": "Application Submitted Date",
-      "timeDate": "Application Time Date",
+      "timeDate": "Application Submitted Time",
       "language": "Application Language",
       "totalSize": "Total Household Size",
       "submittedBy": "Submitted By",


### PR DESCRIPTION
Closes: #850 

@slowbot I'm not sure:

- Alternate contact address fields are optional in the application form (so a user can type e.g only city), should we show available data and for missing just "n/a"?

- What about applications that don't have terms agreement data (we added this field 2-3 weeks ago)?