### PR TITLE
Temporarily bump max-warnings up for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     }
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": "eslint --max-warnings 0"
+    "*.{js,ts,tsx}": "eslint --max-warnings 100"
   }
 }


### PR DESCRIPTION
~~I'm still a little foggy why husky seems to be linting everything, not just newly-staged files when trying to commit in VSCode, but at any rate I'm bumping allowed warnings up to 100 until we can fix the existing warnings we have in the codebase.~~