### PR TITLE
Fix/cypress timeout

### DIFF
--- a/sites/public/cypress.json
+++ b/sites/public/cypress.json
@@ -2,6 +2,6 @@
   "baseUrl": "http://localhost:3000",
   "defaultCommandTimeout": 10000,
   "projectId": "bloom-public-reference",
-  "pageLoadTimeout": 20000
+  "pageLoadTimeout": 100000
 }
 

--- a/sites/public/cypress.json
+++ b/sites/public/cypress.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://localhost:3000",
   "defaultCommandTimeout": 10000,
-  "projectId": "bloom-public-reference"
+  "projectId": "bloom-public-reference",
+  "pageLoadTimeout": 20000
 }
 


### PR DESCRIPTION
Looks like in some situations, cypress on the CircleCI has a very long load time e.g. homepage.

Increased Cypress test to 100s.

