### PR TITLE
Fix/alternate email

### DIFF
--- a/backend/core/src/applications/entities/alternate-contact.entity.ts
+++ b/backend/core/src/applications/entities/alternate-contact.entity.ts
@@ -58,7 +58,7 @@ export class AlternateContact extends AbstractEntity {
 
   @Column({ type: "text", nullable: true })
   @Expose()
-  @IsOptional({ groups: [ValidationsGroupsEnum.partners] })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @IsEmail({}, { groups: [ValidationsGroupsEnum.default] })
   emailAddress?: string | null

--- a/sites/public/pages/applications/contact/alternate-contact-contact.tsx
+++ b/sites/public/pages/applications/contact/alternate-contact-contact.tsx
@@ -32,7 +32,7 @@ export default () => {
   })
   const onSubmit = (data) => {
     application.alternateContact.phoneNumber = data.phoneNumber
-    application.alternateContact.emailAddress = data.emailAddress
+    application.alternateContact.emailAddress = data.emailAddress || null
     application.alternateContact.mailingAddress.street = data.mailingAddress.street
     application.alternateContact.mailingAddress.state = data.mailingAddress.state
     application.alternateContact.mailingAddress.zipCode = data.mailingAddress.zipCode
@@ -101,7 +101,7 @@ export default () => {
               label={t("application.alternateContact.contact.emailAddressFormLabel")}
               readerOnly={true}
               placeholder={t("application.alternateContact.contact.emailAddressFormPlaceHolder")}
-              defaultValue={application.alternateContact.emailAddress}
+              defaultValue={application.alternateContact.emailAddress || null}
               register={register}
             />
           </div>

--- a/ui-components/src/helpers/blankApplication.ts
+++ b/ui-components/src/helpers/blankApplication.ts
@@ -20,7 +20,7 @@ export const blankApplication = () => {
       birthMonth: "",
       birthDay: "",
       birthYear: "",
-      emailAddress: "",
+      emailAddress: null,
       noEmail: false,
       phoneNumber: "",
       phoneNumberType: "",
@@ -75,7 +75,7 @@ export const blankApplication = () => {
       lastName: "",
       agency: "",
       phoneNumber: "",
-      emailAddress: "",
+      emailAddress: null,
       mailingAddress: {
         street: "",
         city: "",


### PR DESCRIPTION
Closes: #996

The problem was when a user does not fill the email field. In the backend, after validators update, we expect null for empty email string.

- Made alternate contact as optional for both (public & partners), because in the public frontend this field is not required
- Updated default email value to null, instead of ""