### PR TITLE
tests/ui-components new unit test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ yarn-error.log
 
 # VS code debugger config
 launch.json
+
+# Jest unit test coverage
+test-coverage/

--- a/ui-components/.jest/setup-tests.js
+++ b/ui-components/.jest/setup-tests.js
@@ -1,4 +1,5 @@
 import registerRequireContextHook from "babel-plugin-require-context-hook/register"
+import '@testing-library/jest-dom/extend-expect'
 
 import { configure } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"

--- a/ui-components/.jest/setup-tests.js
+++ b/ui-components/.jest/setup-tests.js
@@ -1,15 +1,14 @@
-import registerRequireContextHook from "babel-plugin-require-context-hook/register"
-import '@testing-library/jest-dom/extend-expect'
+import "@testing-library/jest-dom/extend-expect"
 
 import { configure } from "enzyme"
 import Adapter from "enzyme-adapter-react-16"
-
-// registerRequireContextHook()
+import { addTranslation } from "../src/helpers/translator"
+import general from "../src/locales/general.json"
 
 configure({ adapter: new Adapter() })
 
 // see: https://jestjs.io/docs/en/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
-window.matchMedia = jest.fn().mockImplementation(query => {
+window.matchMedia = jest.fn().mockImplementation((query) => {
   return {
     matches: false,
     media: query,
@@ -18,6 +17,8 @@ window.matchMedia = jest.fn().mockImplementation(query => {
     removeListener: jest.fn(), // deprecated
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn()
+    dispatchEvent: jest.fn(),
   }
 })
+
+addTranslation(general)

--- a/ui-components/__tests__/actions/Button.test.tsx
+++ b/ui-components/__tests__/actions/Button.test.tsx
@@ -1,17 +1,75 @@
 import React from "react"
-import { shallow } from "enzyme"
+import { render, cleanup, screen, fireEvent } from "@testing-library/react"
 import { Button } from "../../src/actions/Button"
 import { AppearanceSizeType } from "../../src/global/AppearanceTypes"
 
-const handleClick = (e: React.MouseEvent) => {
-  alert(`You clicked me! Event: ${e.type}`)
-}
+afterEach(cleanup)
 
-test("shows small button", () => {
-  const wrapper = shallow(
-    <Button size={AppearanceSizeType.small} onClick={handleClick}>
-      Small Button
-    </Button>
-  )
-  expect(wrapper.html()).toEqual('<button class="button is-small">Small Button</button>')
+describe("<Button>", () => {
+  it("calls onClick when clicked", () => {
+    const onClickSpy = jest.fn()
+    render(
+      <Button size={AppearanceSizeType.small} onClick={onClickSpy}>
+        Button Content
+      </Button>
+    )
+
+    expect(screen.getByText("Button Content")).not.toBeNull()
+    fireEvent.click(screen.getByText("Button Content"))
+    expect(onClickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("adds correct classes for an inline left icon", () => {
+    const onClickSpy = jest.fn()
+    const { container } = render(
+      <Button
+        size={AppearanceSizeType.small}
+        onClick={onClickSpy}
+        inlineIcon={"left"}
+        icon={`some-jsx`}
+      >
+        Button Content
+      </Button>
+    )
+
+    expect(screen.getByText("Button Content")).not.toBeNull()
+    expect(container.getElementsByClassName("inline-icon--left").length).toBe(1)
+  })
+
+  it("adds correct classes for an inline right icon", () => {
+    const onClickSpy = jest.fn()
+    const { container } = render(
+      <Button
+        size={AppearanceSizeType.small}
+        onClick={onClickSpy}
+        inlineIcon={"right"}
+        icon={`some-jsx`}
+      >
+        Button Content
+      </Button>
+    )
+
+    expect(screen.getByText("Button Content")).not.toBeNull()
+    expect(container.getElementsByClassName("inline-icon--right").length).toBe(1)
+  })
+
+  it("adds correct classes for extra optional styles", () => {
+    const onClickSpy = jest.fn()
+    const { container } = render(
+      <Button
+        size={AppearanceSizeType.small}
+        onClick={onClickSpy}
+        unstyled={true}
+        fullWidth={true}
+        className={"extra-special-extra-class"}
+      >
+        Button Content
+      </Button>
+    )
+
+    expect(screen.getByText("Button Content")).not.toBeNull()
+    expect(container.getElementsByClassName("is-unstyled").length).toBe(1)
+    expect(container.getElementsByClassName("is-fullwidth").length).toBe(1)
+    expect(container.getElementsByClassName("extra-special-extra-class").length).toBe(1)
+  })
 })

--- a/ui-components/__tests__/actions/Button.test.tsx
+++ b/ui-components/__tests__/actions/Button.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, screen, fireEvent } from "@testing-library/react"
+import { render, cleanup, fireEvent } from "@testing-library/react"
 import { Button } from "../../src/actions/Button"
 import { AppearanceSizeType } from "../../src/global/AppearanceTypes"
 
@@ -8,20 +8,20 @@ afterEach(cleanup)
 describe("<Button>", () => {
   it("calls onClick when clicked", () => {
     const onClickSpy = jest.fn()
-    render(
+    const { getByText } = render(
       <Button size={AppearanceSizeType.small} onClick={onClickSpy}>
         Button Content
       </Button>
     )
 
-    expect(screen.getByText("Button Content")).not.toBeNull()
-    fireEvent.click(screen.getByText("Button Content"))
+    expect(getByText("Button Content")).not.toBeNull()
+    fireEvent.click(getByText("Button Content"))
     expect(onClickSpy).toHaveBeenCalledTimes(1)
   })
 
   it("adds correct classes for an inline left icon", () => {
     const onClickSpy = jest.fn()
-    const { container } = render(
+    const { container, getByText } = render(
       <Button
         size={AppearanceSizeType.small}
         onClick={onClickSpy}
@@ -32,13 +32,13 @@ describe("<Button>", () => {
       </Button>
     )
 
-    expect(screen.getByText("Button Content")).not.toBeNull()
+    expect(getByText("Button Content")).not.toBeNull()
     expect(container.getElementsByClassName("inline-icon--left").length).toBe(1)
   })
 
   it("adds correct classes for an inline right icon", () => {
     const onClickSpy = jest.fn()
-    const { container } = render(
+    const { container, getByText } = render(
       <Button
         size={AppearanceSizeType.small}
         onClick={onClickSpy}
@@ -49,13 +49,13 @@ describe("<Button>", () => {
       </Button>
     )
 
-    expect(screen.getByText("Button Content")).not.toBeNull()
+    expect(getByText("Button Content")).not.toBeNull()
     expect(container.getElementsByClassName("inline-icon--right").length).toBe(1)
   })
 
   it("adds correct classes for extra optional styles", () => {
     const onClickSpy = jest.fn()
-    const { container } = render(
+    const { container, getByText } = render(
       <Button
         size={AppearanceSizeType.small}
         onClick={onClickSpy}
@@ -67,7 +67,7 @@ describe("<Button>", () => {
       </Button>
     )
 
-    expect(screen.getByText("Button Content")).not.toBeNull()
+    expect(getByText("Button Content")).not.toBeNull()
     expect(container.getElementsByClassName("is-unstyled").length).toBe(1)
     expect(container.getElementsByClassName("is-fullwidth").length).toBe(1)
     expect(container.getElementsByClassName("extra-special-extra-class").length).toBe(1)

--- a/ui-components/__tests__/actions/ExpandableText.test.tsx
+++ b/ui-components/__tests__/actions/ExpandableText.test.tsx
@@ -1,0 +1,62 @@
+import React from "react"
+import { render, cleanup, fireEvent } from "@testing-library/react"
+import { ExpandableText } from "../../src/actions/ExpandableText"
+
+afterEach(cleanup)
+
+describe("<ExpandableText>", () => {
+  it("renders full text if below max length", () => {
+    const content = "This is a sentence that has 42 characters!"
+    const { getByText, queryByText } = render(<ExpandableText>{content}</ExpandableText>)
+    expect(getByText(content)).not.toBeNull()
+    expect(queryByText("...")).toBeNull()
+  })
+
+  it("renders cutoff point if text is above max length", () => {
+    const content = "This is a sentence that has 42 characters!"
+    const { getByText } = render(<ExpandableText maxLength={30}>{content}</ExpandableText>)
+    expect(getByText(`${content.substring(0, 30)}...`)).not.toBeNull()
+  })
+
+  it("if cutoff point is a space, move cutoff point one index to the left", () => {
+    const content = "This is a sentence that has 42 characters!"
+    const { getByText } = render(<ExpandableText maxLength={8}>{content}</ExpandableText>)
+    expect(getByText(`${content.substring(0, 7)}...`)).not.toBeNull()
+  })
+
+  it("cuts off mid-word if the text has no spaces", () => {
+    const content = "Thissentencehasnospacesatall."
+    const { getByText } = render(<ExpandableText maxLength={8}>{content}</ExpandableText>)
+    expect(getByText(`${content.substring(0, 8)}...`)).not.toBeNull()
+  })
+
+  it("hitting the expand/contract button adds and removes the extra characters", () => {
+    const content = "This is a sentence that has 42 characters!"
+    const { getByText, queryByText } = render(
+      <ExpandableText maxLength={30}>{content}</ExpandableText>
+    )
+    expect(queryByText(content)).toBeNull()
+    expect(getByText(`${content.substring(0, 30)}...`)).not.toBeNull()
+
+    // Expand the text
+    const expandButton = getByText("More")
+    expect(expandButton).toBeTruthy()
+    fireEvent.click(expandButton)
+
+    // Assert text expanded
+    expect(queryByText(content)).not.toBeNull()
+    const expandButtonRemoved = queryByText("More")
+    expect(expandButtonRemoved).toBeNull()
+
+    // Contract the text
+    const contractButton = getByText("Less")
+    expect(contractButton).toBeTruthy()
+    fireEvent.click(contractButton)
+
+    // Assert text contracted
+    const contractButtonRemoved = queryByText("Less")
+    expect(contractButtonRemoved).toBeNull()
+    expect(queryByText(content)).toBeNull()
+    expect(getByText(`${content.substring(0, 30)}...`)).not.toBeNull()
+  })
+})

--- a/ui-components/__tests__/actions/LinkButton.test.tsx
+++ b/ui-components/__tests__/actions/LinkButton.test.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+import { render, cleanup, screen } from "@testing-library/react"
+import { LinkButton } from "../../src/actions/LinkButton"
+
+afterEach(cleanup)
+
+describe("<LinkButton>", () => {
+  it("correctly passes in a link", () => {
+    render(<LinkButton href="https://www.google.com">Button Content</LinkButton>)
+
+    expect(screen.getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
+      "https://www.google.com"
+    )
+  })
+})

--- a/ui-components/__tests__/actions/LinkButton.test.tsx
+++ b/ui-components/__tests__/actions/LinkButton.test.tsx
@@ -5,11 +5,31 @@ import { LinkButton } from "../../src/actions/LinkButton"
 afterEach(cleanup)
 
 describe("<LinkButton>", () => {
-  it("correctly passes in a link", () => {
+  it("correctly passes in an external link", () => {
     render(<LinkButton href="https://www.google.com">Button Content</LinkButton>)
 
     expect(screen.getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
       "https://www.google.com"
+    )
+  })
+
+  it("correctly passes in an internal link", () => {
+    render(<LinkButton href={`listing/id=1`}>Button Content</LinkButton>)
+
+    expect(screen.getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
+      "/listing/id=1"
+    )
+  })
+
+  it("correctly passes in an internal link with as prop", () => {
+    render(
+      <LinkButton href={`listing/id=1`} as={`/listing/1/listing-slug-abcdef`}>
+        Button Content
+      </LinkButton>
+    )
+
+    expect(screen.getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
+      "/listing/1/listing-slug-abcdef"
     )
   })
 })

--- a/ui-components/__tests__/actions/LinkButton.test.tsx
+++ b/ui-components/__tests__/actions/LinkButton.test.tsx
@@ -1,34 +1,34 @@
 import React from "react"
-import { render, cleanup, screen } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { LinkButton } from "../../src/actions/LinkButton"
 
 afterEach(cleanup)
 
 describe("<LinkButton>", () => {
   it("correctly passes in an external link", () => {
-    render(<LinkButton href="https://www.google.com">Button Content</LinkButton>)
+    const { getByText } = render(
+      <LinkButton href="https://www.google.com">Button Content</LinkButton>
+    )
 
-    expect(screen.getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
+    expect(getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
       "https://www.google.com"
     )
   })
 
   it("correctly passes in an internal link", () => {
-    render(<LinkButton href={`listing/id=1`}>Button Content</LinkButton>)
+    const { getByText } = render(<LinkButton href={`listing/id=1`}>Button Content</LinkButton>)
 
-    expect(screen.getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
-      "/listing/id=1"
-    )
+    expect(getByText("Button Content").closest("a")?.getAttribute("href")).toBe("/listing/id=1")
   })
 
   it("correctly passes in an internal link with as prop", () => {
-    render(
+    const { getByText } = render(
       <LinkButton href={`listing/id=1`} as={`/listing/1/listing-slug-abcdef`}>
         Button Content
       </LinkButton>
     )
 
-    expect(screen.getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
+    expect(getByText("Button Content").closest("a")?.getAttribute("href")).toBe(
       "/listing/1/listing-slug-abcdef"
     )
   })

--- a/ui-components/__tests__/actions/LocalizedLink.test.tsx
+++ b/ui-components/__tests__/actions/LocalizedLink.test.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { render, cleanup } from "@testing-library/react"
+import { LocalizedLink } from "../../src/actions/LocalizedLink"
+
+afterEach(cleanup)
+
+describe("<LocalizedLink>", () => {
+  it("correctly passes in an external link", () => {
+    const { getByText } = render(
+      <LocalizedLink href="https://www.google.com">Link Content</LocalizedLink>
+    )
+
+    expect(getByText("Link Content").closest("a")?.getAttribute("href")).toBe(
+      "https://www.google.com/"
+    )
+  })
+
+  it("correctly passes in an internal link", () => {
+    const { getByText } = render(<LocalizedLink href={`listing/id=1`}>Link Content</LocalizedLink>)
+
+    expect(getByText("Link Content").closest("a")?.getAttribute("href")).toBe("/listing/id=1")
+  })
+
+  it("correctly passes in an internal link with as prop", () => {
+    const { getByText } = render(
+      <LocalizedLink href={`listing/id=1`} as={`/listing/1/listing-slug-abcdef`}>
+        Link Content
+      </LocalizedLink>
+    )
+    expect(getByText("Link Content").closest("a")?.getAttribute("href")).toBe(
+      "/listing/1/listing-slug-abcdef"
+    )
+  })
+
+  it("correctly applies aria attributes", () => {
+    const { getByRole } = render(
+      <LocalizedLink href="https://www.google.com" aria={{ role: "text-box" }}>
+        Link Content
+      </LocalizedLink>
+    )
+
+    expect(getByRole("text-box")).toBeTruthy()
+  })
+})

--- a/ui-components/jest.config.js
+++ b/ui-components/jest.config.js
@@ -4,7 +4,6 @@
 process.env.TZ = "UTC"
 
 module.exports = {
-  collectCoverage: true,
   testRegex: "/*.test.tsx$",
   collectCoverageFrom: ["**/*.tsx", "!**/*.stories.tsx"],
   coverageReporters: ["lcov", "text"],

--- a/ui-components/jest.config.js
+++ b/ui-components/jest.config.js
@@ -4,6 +4,19 @@
 process.env.TZ = "UTC"
 
 module.exports = {
+  collectCoverage: true,
+  testRegex: "/*.test.tsx$",
+  collectCoverageFrom: ["**/*.tsx", "!**/*.stories.tsx"],
+  coverageReporters: ["lcov", "text"],
+  coverageDirectory: "test-coverage",
+  coverageThreshold: {
+    global: {
+      branches: 0,
+      functions: 0,
+      lines: 0,
+      statements: 0,
+    },
+  },
   preset: "ts-jest",
   globals: {
     "ts-jest": {

--- a/ui-components/package.json
+++ b/ui-components/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build-storybook": "build-storybook -c .storybook",
     "start": "start-storybook -s ./public",
-    "test": "jest ui-components"
+    "test": "jest",
+    "test:coverage": "jest --coverage --watchAll=false --testPathIgnorePatterns storyshots.test.tsx"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/ui-components/package.json
+++ b/ui-components/package.json
@@ -10,7 +10,8 @@
     "build-storybook": "build-storybook -c .storybook",
     "start": "start-storybook -s ./public",
     "test": "jest",
-    "test:coverage": "jest --coverage --watchAll=false --testPathIgnorePatterns storyshots.test.tsx"
+    "test:coverage": "jest --coverage --watchAll=false --testPathIgnorePatterns storyshots.test.tsx",
+    "prettier": "prettier --write \"**/*.tsx\""
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/ui-components/package.json
+++ b/ui-components/package.json
@@ -21,6 +21,8 @@
     "@storybook/addon-storyshots": "^6.0.26",
     "@storybook/addon-viewport": "^6.0.26",
     "@storybook/react": "^6.0.26",
+    "@testing-library/jest-dom": "^5.11.9",
+    "@testing-library/react": "^11.2.5",
     "@types/enzyme": "^3.10.7",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^26.0.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,6 +1937,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.12.13.tgz#53d09813b7c20d616caf258e9325550ff701c039"
+  integrity sha512-8fSpqYRETHATtNitsCXq8QQbKJP31/KnDl2Wz2Vtui9nKzjss2ysuZtyVsWjBtvkeEFo346gkwjYPab1hvrXkQ==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.11.2", "@babel/runtime@^7.0.0", "@babel/runtime@^7.2.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
@@ -4401,10 +4409,51 @@
     resolve-from "^5.0.0"
     store2 "^2.7.1"
 
+"@testing-library/dom@^7.28.1":
+  version "7.29.4"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.29.4.tgz#1647c2b478789621ead7a50614ad81ab5ae5b86c"
+  integrity sha512-CtrJRiSYEfbtNGtEsd78mk1n1v2TUbeABlNIcOCJdDfkN5/JTOwQEbbQpoSRxGqzcWPgStMvJ4mNolSuBRv1NA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/jest-dom@^5.11.9":
+  version "5.11.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.11.9.tgz#e6b3cd687021f89f261bd53cbe367041fbd3e975"
+  integrity sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+    "@types/testing-library__jest-dom" "^5.9.1"
+    aria-query "^4.2.2"
+    chalk "^3.0.0"
+    css "^3.0.0"
+    css.escape "^1.5.1"
+    lodash "^4.17.15"
+    redent "^3.0.0"
+
+"@testing-library/react@^11.2.5":
+  version "11.2.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
+  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
+  integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
 
 "@types/axios@^0.14.0":
   version "0.14.0"
@@ -4979,6 +5028,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/testing-library__jest-dom@^5.9.1":
+  version "5.9.5"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
+  integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+  dependencies:
+    "@types/jest" "*"
 
 "@types/uglify-js@*":
   version "3.9.3"
@@ -5704,6 +5760,14 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -7820,6 +7884,11 @@ core-js-compat@^3.8.0:
     browserslist "^4.15.0"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.3.tgz#10e9e3b2592ecaede4283e8f3ad7020811587c02"
+  integrity sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==
+
 core-js-pure@^3.0.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.1.tgz#23f84048f366fdfcf52d3fd1c68fec349177d119"
@@ -8088,7 +8157,7 @@ css-what@2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
 
-css.escape@^1.5.0:
+css.escape@^1.5.0, css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
@@ -8102,6 +8171,15 @@ css@^2.0.0:
     source-map "^0.6.1"
     source-map-resolve "^0.5.2"
     urix "^0.1.0"
+
+css@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css/-/css-3.0.0.tgz#4447a4d58fdd03367c516ca9f64ae365cee4aa5d"
+  integrity sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+  dependencies:
+    inherits "^2.0.4"
+    source-map "^0.6.1"
+    source-map-resolve "^0.6.0"
 
 csscolorparser@~1.0.3:
   version "1.0.3"
@@ -8598,6 +8676,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -13322,6 +13405,11 @@ lru-queue@0.1:
   dependencies:
     es5-ext "~0.10.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 macos-release@^2.2.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.4.1.tgz#64033d0ec6a5e6375155a74b1a1eba8e509820ac"
@@ -17686,6 +17774,14 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
+
+source-map-resolve@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.6.0.tgz#3d9df87e236b53f16d01e58150fc7711138e5ed2"
+  integrity sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+  dependencies:
+    atob "^2.1.2"
+    decode-uri-component "^0.2.0"
 
 source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"


### PR DESCRIPTION
In this PR I set up react-testing-library for ui-components, and write one test suite (actions) as an example. I didn't want to continue to write the rest of the unit tests in case the team doesn't agree with this implementation for any reason.

I personally have found functional unit tests like these to be more valuable than snapshot tests as you can pinpoint specific functional cases you want to test and automate them, vs updating static output changes in a snapshot & testing the functional bit manually. It's more obvious more quickly if you've broken something, and the test name should be a nice specific indicator as to what is broken, which is why I'd like to add them! :)

If you run `yarn test:coverage` it will run all but the snapshot tests and produce coverage reports that indicate exactly which lines and branches have been hit by the unit tests.

Coverage report for these tests:
src/actions                  |     100 |      100 |     100 |     100 |
     Button.tsx                  |     100 |      100 |     100 |     100 |
     ExpandableText.tsx   |     100 |      100 |     100 |     100 |
     LinkButton.tsx           |     100 |      100 |     100 |     100 |
     LocalizedLink.tsx      |     100 |      100 |     100 |     100 

Would love some input & everyone's blessing to move forward with the new test suite, super open to feedback.

![GIPHY](https://media.giphy.com/media/J93sVmfYBtsRi/giphy.gif)
  