### PR TITLE
fix household maximum income translations on mobile view

### DIFF
--- a/sites/public/pages/listing.tsx
+++ b/sites/public/pages/listing.tsx
@@ -80,7 +80,13 @@ export default class extends Component<ListingProps> {
         return percentInt
       })
       .sort()
-    const hmiHeaders = listing.property.unitsSummarized.hmi.columns as TableHeaders
+
+    const deriveHmiHeaders = listing.property.unitsSummarized.hmi.columns as TableHeaders
+    const hmiHeaders = {}
+    for (const [key, value] of Object.entries(deriveHmiHeaders)) {
+      hmiHeaders[key] = t(value)
+    }
+
     const hmiData = listing.property.unitsSummarized.hmi.rows.map((row) => {
       return { ...row, householdSize: <strong>{row["householdSize"]}</strong> }
     })


### PR DESCRIPTION
Household Maximum Income translations weren't being resolved in Mobile view  
 Issue:
![Screen Shot 2021-03-29 at 4 54 12 PM](https://user-images.githubusercontent.com/58486174/112913911-9b0e1500-90af-11eb-8b07-3793faf80be7.png)


After Fix:
![Screen Shot 2021-03-29 at 4 54 55 PM](https://user-images.githubusercontent.com/58486174/112913941-a9f4c780-90af-11eb-9228-7e9f447979e9.png)
