### PR TITLE
Updated translations

### DIFF
--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -1,7 +1,7 @@
 {
   "config": {
     "routePrefix": "es"
-  },
+  }, 
   "account": {
     "accountSettings": "Configuraciones de la cuenta",
     "accountSettingsSubtitle": "Configuraciones de la cuenta, email y contraseña",
@@ -230,6 +230,10 @@
           "link": "http://domain.com"
         }
       },
+      "displacedTenant": {
+        "whichHouseholdMember": "¿Qué miembro del hogar solicita esta preferencia?",
+        "whatAddress": "¿De qué dirección fue desplazado el miembro del hogar?"
+      },
       "general": {
         "title": "En base a la información que usted ingresó, su hogar no ha solicitado ninguna preferencia de vivienda.",
         "preamble": "Estará en el grupo general de solicitantes."
@@ -332,7 +336,7 @@
     "timeout": {
       "text": "Para proteger su identidad, su sesión concluirá en un minuto debido a inactividad. Si decide no responder, perderá toda la información que no haya guardado.",
       "action": "Seguir trabajando",
-      "afterMessage": "Su seguridad es importante para nosotros. Concluimos su sesión debido a inactividad. Sírvase volver a iniciar sesión o empiece una nueva solicitud para continuar."
+      "afterMessage": "Su seguridad es importante para nosotros. Concluimos su sesión debido a inactividad. Sírvase iniciar una nueva solicitud para continuar."
     },
     "continueApplication": "Continuar la solicitud",
     "applicationNeverSubmitted": "Su solicitud nunca fue enviada",
@@ -458,6 +462,11 @@
     "householdSize": "Tamaño del hogar",
     "importantProgramRules": "Reglas importantes del programa",
     "includesPriorityUnits": "Incluye viviendas prioritarias para %{priorities}",
+    "lotteryResults": {
+      "completeResultsWillBePosted": "Los resultados de la lotería serán publicados pronto.",
+      "downloadResults": "Descargar resultados",
+      "header": "Resultados de la lotería"
+    },
     "maxIncomeMonth": "Ingresos máximos / Mes",
     "maxIncomeYear": "Ingresos máximos / Año",
     "moreBuildingSelectionCriteria": "Obtenga más información sobre los Criterios de Selección de Edificaciones",
@@ -721,7 +730,7 @@
     "seeRentalListings": "Ver viviendas en alquiler",
     "title": "Haga su solicitud de vivienda de precio accesible en",
     "seeMoreOpportunities": "Ver más oportunidades de alquiler y propiedad de vivienda",
-    "viewAdditionalHousing": "Ver detalles adicionales sobre la vivienda"
+    "viewAdditionalHousing": "Vea Oportunidades y recursos adicionales de vivienda"
   },
   "whatToExpect": {
     "label": "Lo que puede esperar",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -471,7 +471,7 @@
     "timeout": {
       "text": "To protect your identity, your session will expire in one minute due to inactivity. You will lose any unsaved information if you choose not to respond.",
       "action": "Continue working",
-      "afterMessage": "We care about your security. We ended your session due to inactivity. Please log in or start a new application to continue."
+      "afterMessage": "We care about your security. We ended your session due to inactivity. Please start a new application to continue."
     },
     "continueApplication": "Continue Application",
     "applicationNeverSubmitted": "Your application was never submitted",
@@ -665,7 +665,7 @@
     "importantProgramRules": "Important Program Rules",
     "includesPriorityUnits": "Includes Priority Units for %{priorities}",
     "lotteryResults": {
-      "completeResultsWillBePosted": "Complete lottery results will be posted on this date by %{hour}.",
+      "completeResultsWillBePosted": "Complete lottery results will be posted soon.",
       "downloadResults": "Download Results",
       "header": "Lottery Results"
     },
@@ -963,7 +963,7 @@
     "seeRentalListings": "See Rentals",
     "title": "Apply for affordable housing in",
     "seeMoreOpportunities": "See more rental and ownership housing opportunities",
-    "viewAdditionalHousing": "View Additional Housing Details"
+    "viewAdditionalHousing": "View Additional Housing Opportunities and Resources"
   },
   "whatToExpect": {
     "label": "What to Expect",

--- a/ui-components/src/locales/vi.json
+++ b/ui-components/src/locales/vi.json
@@ -6,7 +6,7 @@
     "haveAnAccount": "Quý vị đã có một tài khoản chưa?",
     "myApplications": "Đơn ghi danh của tôi",
     "myApplicationsSubtitle": "Xem ngày rút thăm và danh sách các bất động sản mà quý vị đã ghi danh"
-  },
+  }, 
   "application": {
     "form": {
       "general": {
@@ -227,6 +227,10 @@
           "link": "http://domain.com"
         }
       },
+      "displacedTenant": {
+        "whichHouseholdMember": "Thành viên hộ gia đình nào đang yêu cầu lựa chọn này?",
+        "whatAddress": "Địa chỉ mà thành viên hộ gia đình này đã chuyển khỏi là gì?"
+      },
       "general": {
         "title": "Dựa trên thông tin quý vị đã nhập, hộ gia đình của quý vị chưa yêu cầu bất kỳ lựa chọn ưu tiên nhà ở nào.",
         "preamble": "Quý vị sẽ thuộc nhóm các ứng viên chung."
@@ -329,7 +333,7 @@
     "timeout": {
       "text": "Để bảo vệ danh tính của quý vị, phiên truy cập của quý vị sẽ hết hạn sau một phút do không có hoạt động. Quý vị sẽ mất mọi thông tin chưa được lưu nếu quý vị lựa chọn không trả lời.",
       "action": "Tiếp tục làm đơn",
-      "afterMessage": "Chúng tôi quan tâm đến sự bảo mật của quý vị. Chúng tôi đã chấm dứt phiên truy cập của quý vị do không có hoạt động nào. Vui lòng đăng nhập hoặc bắt đầu làm một đơn ghi danh mới để tiếp tục."
+      "afterMessage": "Chúng tôi quan tâm đến sự bảo mật của quý vị. Chúng tôi đã chấm dứt phiên truy cập của quý vị do không có hoạt động nào. Vui lòng bắt đầu làm một đơn ghi danh mới để tiếp tục."
     },
     "continueApplication": "Tiếp tục làm Đơn ghi danh",
     "applicationNeverSubmitted": "Đơn ghi danh của quý vị chưa bao giờ được gửi",
@@ -458,6 +462,11 @@
     "householdSize": "Quy mô Hộ Gia đình",
     "importantProgramRules": "Các Quy tắc Quan trọng của Chương trình",
     "includesPriorityUnits": "Bao gồm các Căn nhà Ưu tiên cho %{priorities}",
+    "lotteryResults": {
+      "completeResultsWillBePosted": "Toàn bộ kết quả quay xổ số sẽ sớm được đăng.",
+      "downloadResults": "Tải xuống Kết quả",
+      "header": "Kết quả Xổ số"
+    },
     "maxIncomeMonth": "Thu nhập Tối đa / Tháng",
     "maxIncomeYear": "Thu nhập Tối đa / Năm",
     "moreBuildingSelectionCriteria": "Tìm hiểu thêm về Tiêu chí Lựa chọn Tòa nhà",
@@ -720,7 +729,7 @@
     "seeRentalListings": "Xem Thông tin Thuê nhà",
     "title": "Ghi danh nhà ở giá phải chăng tại",
     "seeMoreOpportunities": "Xem thêm cơ hội thuê nhà và sở hữu nhà ở",
-    "viewAdditionalHousing": "Xem Thông tin Chi tiết Bổ sung về Nhà ở"
+    "viewAdditionalHousing": "Xem Các Cơ hội Nhà ở và các Nguồn Hỗ trợ Bổ sung"
   },
   "whatToExpect": {
     "label": "Những điều Sẽ xảy ra",

--- a/ui-components/src/locales/zh.json
+++ b/ui-components/src/locales/zh.json
@@ -6,7 +6,7 @@
     "haveAnAccount": "已開立帳戶？",
     "myApplications": "我的申請",
     "myApplicationsSubtitle": "查看您已申請物業的抽簽日期和上市名單"
-  },
+  }, 
   "application": {
     "form": {
       "general": {
@@ -227,6 +227,10 @@
           "link": "http://domain.com"
         }
       },
+      "displacedTenant": {
+        "whichHouseholdMember": "哪一位家庭成員在使用此優先權？",
+        "whatAddress": "這位家庭成員是從哪個地址被迫搬遷？"
+      },
       "general": {
         "title": "根據您填寫的資料，您的家庭沒有要求任何住房優先權。",
         "preamble": "您將被分配到一般申請人組別。"
@@ -329,7 +333,7 @@
     "timeout": {
       "text": "為了保護您的身份，您的工作階段將因閒置而在一分鐘後到期。如果您選擇不回應，則將失去任何未經儲存的資料。",
       "action": "繼續進行",
-      "afterMessage": "我們關心您的網上安全。由於網頁閒置，我們已結束您的工作階段。請登入或開始新的申請以便繼續。"
+      "afterMessage": "我們關心您的網上安全。由於網頁閒置，我們已結束您的工作階段。請展開全新申請以便繼續。"
     },
     "continueApplication": "繼續申請程序",
     "applicationNeverSubmitted": "您的申請從未提交",
@@ -458,6 +462,11 @@
     "householdSize": "家庭人數",
     "importantProgramRules": "重要計劃規則",
     "includesPriorityUnits": "包括為 %{priorities} 提供的優先單位",
+    "lotteryResults": {
+      "completeResultsWillBePosted": "全部抽籤結果將很快發佈。",
+      "downloadResults": "下載結果",
+      "header": "抽籤結果"
+    },
     "maxIncomeMonth": "最高收入 / 月",
     "maxIncomeYear": "最高收入 / 年",
     "moreBuildingSelectionCriteria": "了解「樓宇選擇標準」詳情",
@@ -720,7 +729,7 @@
     "seeRentalListings": "查看租賃部分",
     "title": "申請此地的可負擔房屋：",
     "seeMoreOpportunities": "查看更多租賃和自購住房的機會",
-    "viewAdditionalHousing": "查看其他住房詳情"
+    "viewAdditionalHousing": "瀏覽其他住房機會和資源"
   },
   "whatToExpect": {
     "label": "預期事項",


### PR DESCRIPTION
Closes: #1073 

**Updated:**
"lottery_results" --> header under lotteryResults
"lottery_results_coming_soon" --> completeResultsWillBePosted under lotteryResults
"lottery_download" --> downloadResults under lotteryResults
"which_household_member" --> whichHouseholdMember under displacedTenant
"address_displaced" --> whatAddress under displacedTenant
"additional_resources" --> viewAdditionalHousing in welcome
"logged_out_error_no_account" --> afterMessage in timeout