### PR TITLE
Remove next router from LanguageNav component

### DIFF
--- a/ui-components/__tests__/navigation/LanguageNav.test.tsx
+++ b/ui-components/__tests__/navigation/LanguageNav.test.tsx
@@ -1,32 +1,47 @@
 import React from "react"
-import { render, cleanup } from "@testing-library/react"
-import { LanguageNav } from "../../src/navigation/LanguageNav"
-import * as useLanguageChange from "../../src/helpers/useLanguageChange"
+import { render, cleanup, fireEvent } from "@testing-library/react"
+import { LanguageNav, LangItem } from "../../src/navigation/LanguageNav"
+
+const ENGLISH_LANG_ITEM: LangItem = {
+  prefix: "",
+  label: "English",
+}
+
+const SPANISH_LANG_ITEM: LangItem = {
+  prefix: "es",
+  label: "Spanish",
+}
 
 afterEach(cleanup)
 
 describe("<LanguageNav>", () => {
   it("renders without error", () => {
-    const useLanguageChangeSpy = jest.spyOn(useLanguageChange, "useLanguageChange")
+    const onChangeLanguageSpy = jest.fn()
     const { getByText } = render(
       <LanguageNav
-        items={[
-          {
-            prefix: "",
-            label: "English",
-          },
-          {
-            prefix: "es",
-            label: "Spanish",
-          },
-        ]}
+        onChangeLanguage={onChangeLanguageSpy}
+        currentLanguagePrefix={SPANISH_LANG_ITEM.prefix}
+        items={[ENGLISH_LANG_ITEM, SPANISH_LANG_ITEM]}
       />
     )
-    expect(useLanguageChangeSpy).toHaveBeenCalledWith([
-      { label: "English", prefix: "" },
-      { label: "Spanish", prefix: "es" },
-    ])
+
+    expect(onChangeLanguageSpy).toHaveBeenCalledTimes(0)
     expect(getByText("English")).toBeTruthy()
     expect(getByText("Spanish")).toBeTruthy()
+  })
+
+  it("calls onChangeLanguage", () => {
+    const onChangeLanguageSpy = jest.fn()
+    const {  getByText } = render(
+      <LanguageNav
+        onChangeLanguage={onChangeLanguageSpy}
+        currentLanguagePrefix={SPANISH_LANG_ITEM.prefix}
+        items={[ENGLISH_LANG_ITEM, SPANISH_LANG_ITEM]}
+      />
+    )
+
+    fireEvent.click(getByText("English"))
+
+    expect(onChangeLanguageSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/ui-components/index.ts
+++ b/ui-components/index.ts
@@ -73,6 +73,7 @@ export * from "./src/lists/PreferencesList"
 
 /* Navigation */
 export * from "./src/navigation/FooterNav"
+export * from "./src/navigation/RoutedLanguageNav"
 export * from "./src/navigation/LanguageNav"
 export * from "./src/navigation/ProgressNav"
 export * from "./src/navigation/UserNav"

--- a/ui-components/src/headers/SiteHeader.tsx
+++ b/ui-components/src/headers/SiteHeader.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { LocalizedLink } from "../actions/LocalizedLink"
-import { LanguageNav, LangItem } from "../navigation/LanguageNav"
+import { LangItem } from "../navigation/LanguageNav"
+import { RoutedLanguageNav } from "../navigation/RoutedLanguageNav"
 
 export interface SiteHeaderProps {
   logoSrc: string
@@ -91,7 +92,7 @@ class SiteHeader extends React.Component<SiteHeaderProps, SiteHeaderState> {
   render() {
     return (
       <>
-        {this.props.languages && <LanguageNav items={this.props.languages} />}
+        {this.props.languages && <RoutedLanguageNav items={this.props.languages} />}
 
         {this.skipLink()}
         {this.noticeBar()}

--- a/ui-components/src/navigation/LanguageNav.stories.tsx
+++ b/ui-components/src/navigation/LanguageNav.stories.tsx
@@ -1,6 +1,16 @@
 import React from "react"
 
-import { LanguageNav } from "./LanguageNav"
+import { LanguageNav, LangItem } from "./LanguageNav"
+
+const ENGLISH_LANG_ITEM: LangItem = {
+  prefix: "",
+  label: "English",
+}
+
+const SPANISH_LANG_ITEM: LangItem = {
+  prefix: "es",
+  label: "Spanish",
+}
 
 export default {
   title: "LanguageNav",
@@ -8,14 +18,9 @@ export default {
 }
 
 export const Default = () => (
-  <LanguageNav items={[
-    {
-      prefix: "",
-      label: "English",
-    },
-    {
-      prefix: "es",
-      label: "Spanish",
-    },
-  ]}/>
+  <LanguageNav
+    onChangeLanguage={(_) => {}}
+    currentLanguagePrefix={SPANISH_LANG_ITEM.prefix}
+    items={[ENGLISH_LANG_ITEM, SPANISH_LANG_ITEM]}
+  />
 )

--- a/ui-components/src/navigation/LanguageNav.tsx
+++ b/ui-components/src/navigation/LanguageNav.tsx
@@ -1,7 +1,5 @@
 import * as React from "react"
 import "./LanguageNav.scss"
-import { t } from "../helpers/translator"
-import { useLanguageChange } from "../helpers/useLanguageChange"
 
 export type LangItem = {
   prefix: string
@@ -10,31 +8,28 @@ export type LangItem = {
 
 export interface LanguageNavProps {
   items: LangItem[]
+  onChangeLanguage: (selectedLanguage: LangItem) => void
+  currentLanguagePrefix: string
 }
 
-const LanguageNav = ({ items }: LanguageNavProps) => {
-  const routePrefix = t("config.routePrefix")
-  const changeLanguage = useLanguageChange(items)
-
-  return (
-    <div className="language-bar">
-      <div className="language-bar__inner">
-        <nav className="language-nav">
-          <ul className="language-nav__list">
-            {items?.map((item) => (
-              <li
-                key={item.prefix}
-                onClick={() => changeLanguage(item.prefix)}
-                className={routePrefix === item.prefix ? "is-active" : ""}
-              >
-                {item.label}
-              </li>
-            ))}
-          </ul>
-        </nav>
-      </div>
+const LanguageNav = ({ currentLanguagePrefix, items, onChangeLanguage }: LanguageNavProps) => (
+  <div className="language-bar">
+    <div className="language-bar__inner">
+      <nav className="language-nav">
+        <ul className="language-nav__list">
+          {items?.map((item) => (
+            <li
+              key={item.prefix}
+              onClick={() => onChangeLanguage(item)}
+              className={currentLanguagePrefix === item.prefix ? "is-active" : ""}
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      </nav>
     </div>
-  )
-}
+  </div>
+)
 
 export { LanguageNav as default, LanguageNav }

--- a/ui-components/src/navigation/RoutedLanguageNav.tsx
+++ b/ui-components/src/navigation/RoutedLanguageNav.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import "./LanguageNav.scss"
+import { LanguageNav, LangItem } from "./LanguageNav"
+import { useLanguageChange } from "../helpers/useLanguageChange"
+import { t } from "../helpers/translator"
+
+interface RoutedLanguageNavProps {
+  items: LangItem[]
+}
+
+const RoutedLanguageNav = ({ items }: RoutedLanguageNavProps) => {
+  const onLanguageChange = useLanguageChange(items)
+
+  return (
+    <LanguageNav
+      onChangeLanguage={(item) => onLanguageChange(item.prefix)}
+      currentLanguagePrefix={t("config.routePrefix")}
+      items={items}
+    />
+  )
+}
+
+export { RoutedLanguageNav as default, RoutedLanguageNav }


### PR DESCRIPTION
This is a duplicate of https://github.com/SFDigitalServices/bloom/pull/11

We're basing the branch off of the bloom-housing master branch to see if circleCI tests run

Currently the LanguageNav component does two things that make it not work in our webapp repo:
1.  The component relies on next-router to handle the language changes
2.  The component expects there to be a "config.prefix" translation string to determine the current locale route prefix

We can make the component more agnostic to the environment around it by passing an on click handler and prefix string in as props.

In this case, I made `<LanguageNav />` more general and created a more specific `<RoutedLanguageNav />` that populates the props in the next-routing way.

In the webapp repo we'll just call the more general `<LanguageNav />` directly.


