### PR TITLE
Remove self package reference in ui-components

### DIFF
--- a/ui-components/src/blocks/AppStatusItem.tsx
+++ b/ui-components/src/blocks/AppStatusItem.tsx
@@ -3,7 +3,7 @@ import "./AppStatusItem.scss"
 import moment from "moment"
 import { Application, Listing } from "@bloom-housing/backend-core/types"
 import { LocalizedLink } from "../actions/LocalizedLink"
-import { t } from "@bloom-housing/ui-components"
+import { t } from "../helpers/translator"
 
 interface AppStatusItemProps {
   application: Application


### PR DESCRIPTION
While exploring creating a npm package fork, I ran into an issue where I couldn't change the @bloom-housing org name in package.json because there was an `@bloom-housing/ui-components` import from _within_ ui-components.

This seems like a mistake, so this change switches it to a local import instead. This might be something we can lint for?