### PR TITLE
Fix CircleCi Redis typo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             DATABASE_URL: "postgres://bloom-ci@localhost:5432/bloom"
             # DB URL for the jest tests per ormconfig.test.ts
             TEST_DATABASE_URL: "postgres://bloom-ci@localhost:5432/bloom"
-            REDIS_TLS_URL: "rediss://localhost:6379/0"
+            REDIS_TLS_URL: "redis://localhost:6379/0"
             REDIS_URL: "redis://localhost:6379/0"
             REDIS_USE_TLS: "0"
   build-public:


### PR DESCRIPTION
It looks like master is broken after https://github.com/bloom-housing/bloom/pull/1103 was merged (it also looks like the tests were broken there as well, not sure why it was merged?) - I'm not sure how to fix these issues but we did notice a typo in the CircleCi config (it doesn't seem to have solved the issue)