### PR TITLE
fix/broken Cypress tests on master

### DIFF
--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -21,7 +21,7 @@ const newListingSeed = (): ListingSeed => {
 
 const seedListings = async (app: INestApplicationContext) => {
   let listingSeed = newListingSeed()
-  //Listing1 (2pref)
+  listingSeed.listing.name = "Triton (2pref)"
   const listing1 = await seedListing(app, listingSeed)
   const userService = app.get<UserService>(UserService)
   await Promise.all([
@@ -30,8 +30,9 @@ const seedListings = async (app: INestApplicationContext) => {
     }),
   ])
 
-  // Listing 2 (1pref)
+  // Listing 2
   listingSeed = newListingSeed()
+  listingSeed.listing.name = "Test listing (1pref)"
   listingSeed.preferences = [
     {
       ordinal: 1,
@@ -62,8 +63,8 @@ const seedListings = async (app: INestApplicationContext) => {
   ]
   const listing2 = await seedListing(app, listingSeed)
 
-  // Listing 3 (0pref)
   listingSeed = newListingSeed()
+  listingSeed.listing.name = "Test listing (0pref)"
   listingSeed.leasingAgents = [
     {
       ...listingSeed.leasingAgents[0],

--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -21,7 +21,7 @@ const newListingSeed = (): ListingSeed => {
 
 const seedListings = async (app: INestApplicationContext) => {
   let listingSeed = newListingSeed()
-  listingSeed.listing.name = "Triton (2pref)"
+  //Listing1 (2pref)
   const listing1 = await seedListing(app, listingSeed)
   const userService = app.get<UserService>(UserService)
   await Promise.all([
@@ -30,9 +30,8 @@ const seedListings = async (app: INestApplicationContext) => {
     }),
   ])
 
-  // Listing 2
+  // Listing 2 (1pref)
   listingSeed = newListingSeed()
-  listingSeed.listing.name = "Test listing (1pref)"
   listingSeed.preferences = [
     {
       ordinal: 1,
@@ -63,8 +62,8 @@ const seedListings = async (app: INestApplicationContext) => {
   ]
   const listing2 = await seedListing(app, listingSeed)
 
+  // Listing 3 (0pref)
   listingSeed = newListingSeed()
-  listingSeed.listing.name = "Test listing (0pref)"
   listingSeed.leasingAgents = [
     {
       ...listingSeed.leasingAgents[0],

--- a/sites/public/cypress/integration/navigation.ts
+++ b/sites/public/cypress/integration/navigation.ts
@@ -24,7 +24,7 @@ describe("Navigating around the site", () => {
 
         // Check that the URL got re-written with a URL slug
         cy.location().should((loc) => {
-          expect(loc.pathname).to.contain("the_triton_55_triton_park_lane_foster_city_ca")
+          expect(loc.pathname).to.contain("triton_55_triton_park_lane_foster_city_ca")
         })
       })
   })

--- a/sites/public/cypress/integration/navigation.ts
+++ b/sites/public/cypress/integration/navigation.ts
@@ -24,7 +24,7 @@ describe("Navigating around the site", () => {
 
         // Check that the URL got re-written with a URL slug
         cy.location().should((loc) => {
-          expect(loc.pathname).to.contain("triton_55_triton_park_lane_foster_city_ca")
+          expect(loc.pathname).to.contain("triton_2_pref_55_triton_park_lane_foster_city_ca")
         })
       })
   })
@@ -34,7 +34,7 @@ describe("Navigating around the site", () => {
     cy.get("article.listings-row a")
       .first()
       .then(function ($a) {
-        cy.visit(`${$a.prop("href")}/the_triton_55_triton_park_lane_foster_city_ca`)
+        cy.visit(`${$a.prop("href")}/triton_2_pref_55_triton_park_lane_foster_city_ca`)
         // Check that the listing page sidebar apply section text is present on the page
         cy.contains("Apply Online")
       })

--- a/sites/public/cypress/integration/navigation.ts
+++ b/sites/public/cypress/integration/navigation.ts
@@ -24,7 +24,7 @@ describe("Navigating around the site", () => {
 
         // Check that the URL got re-written with a URL slug
         cy.location().should((loc) => {
-          expect(loc.pathname).to.contain("the_triton_55_triton_park_lane_foster_city_ca")
+          expect(loc.pathname).to.contain("triton_55_triton_park_lane_foster_city_ca")
         })
       })
   })
@@ -34,7 +34,7 @@ describe("Navigating around the site", () => {
     cy.get("article.listings-row a")
       .first()
       .then(function ($a) {
-        cy.visit(`${$a.prop("href")}/the_triton_55_triton_park_lane_foster_city_ca`)
+        cy.visit(`${$a.prop("href")}/triton_55_triton_park_lane_foster_city_ca`)
         // Check that the listing page sidebar apply section text is present on the page
         cy.contains("Apply Online")
       })

--- a/sites/public/cypress/integration/navigation.ts
+++ b/sites/public/cypress/integration/navigation.ts
@@ -24,7 +24,7 @@ describe("Navigating around the site", () => {
 
         // Check that the URL got re-written with a URL slug
         cy.location().should((loc) => {
-          expect(loc.pathname).to.contain("triton_55_triton_park_lane_foster_city_ca")
+          expect(loc.pathname).to.contain("the_triton_55_triton_park_lane_foster_city_ca")
         })
       })
   })

--- a/sites/public/cypress/integration/navigation.ts
+++ b/sites/public/cypress/integration/navigation.ts
@@ -34,7 +34,7 @@ describe("Navigating around the site", () => {
     cy.get("article.listings-row a")
       .first()
       .then(function ($a) {
-        cy.visit(`${$a.prop("href")}/triton_55_triton_park_lane_foster_city_ca`)
+        cy.visit(`${$a.prop("href")}/the_triton_55_triton_park_lane_foster_city_ca`)
         // Check that the listing page sidebar apply section text is present on the page
         cy.contains("Apply Online")
       })


### PR DESCRIPTION
The navigation suite was broken by this PR https://github.com/bloom-housing/bloom/pull/1124 (It's not flake, the suite is failing consistently / broken after the change - looks like changing the listing name changes the URL slug)