### PR TITLE
Clean up aside block styling and add missing mobile blocks

### DIFF
--- a/sites/public/pages/listing.tsx
+++ b/sites/public/pages/listing.tsx
@@ -196,10 +196,6 @@ export default class extends Component<ListingProps> {
             </div>
           </header>
 
-          <div className="w-full md:w-2/3 mt-3 md:hidden bg-primary-light block text-center md:mx-3">
-            <ApplicationStatus listing={listing} />
-          </div>
-
           <div className="w-full md:w-2/3 md:mt-6 md:mb-6 md:px-3 md:pr-8">
             {amiValues.length > 1 &&
               amiValues.map((percent) => {
@@ -233,11 +229,15 @@ export default class extends Component<ListingProps> {
               />
             )}
           </div>
-          <div className="w-full md:w-2/3 md:mt-3 md:hidden md:mx-3">
-            <ApplicationSection
-              listing={listing}
-              internalFormRoute="/applications/start/choose-language"
-            />
+          <div className="w-full md:w-2/3 md:mt-3 md:hidden md:mx-3 border-gray-400 border-b">
+            <ApplicationStatus listing={listing} />
+            <div className="mx-4">
+              <DownloadLotteryResults event={lotteryResults} />
+              <ApplicationSection
+                listing={listing}
+                internalFormRoute="/applications/start/choose-language"
+              />
+            </div>
           </div>
           <ListingDetails>
             <ListingDetailItem
@@ -316,6 +316,12 @@ export default class extends Component<ListingProps> {
                     internalFormRoute="/applications/start/choose-language"
                   />
                 </div>
+
+                {openHouseEvents && (
+                  <div className="mb-2 md:hidden">
+                    <OpenHouseEvent events={openHouseEvents} />
+                  </div>
+                )}
                 {lotterySection}
                 <WhatToExpect listing={listing} />
                 <LeasingAgent listing={listing} />

--- a/ui-components/src/global/blocks.scss
+++ b/ui-components/src/global/blocks.scss
@@ -53,9 +53,38 @@ details.disclosure {
 }
 
 .aside-block {
-  @apply border-b;
   @apply border-gray-400;
   @apply p-5;
+  @apply pb-2;
+  @apply -mx-4;
+
+  &.is-tinted {
+    @apply bg-primary-lighter;
+    @apply border-t;
+  }
+  &:not(.is-tinted) + &.is-tinted {
+    @apply mt-3;
+  }
+
+  &.is-tinted,
+  &:last-of-type {
+    @apply pb-5;
+  }
+
+  @screen md {
+    @apply border-b;
+    @apply pb-5;
+    @apply mx-0;
+
+    &.is-tinted {
+      @apply mt-0;
+    }
+
+    &:not(.is-tinted) + &.is-tinted {
+      @apply border-t-0;
+      @apply mt-0;
+    }
+  }
 }
 
 .aside-block__divider {

--- a/ui-components/src/page_components/listing/listing_sidebar/ApplicationSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/ApplicationSection.tsx
@@ -28,7 +28,7 @@ const ApplicationSection = (props: ApplicationSectionProps) => {
   return (
     <div>
       {showWaitlist(listing) && (
-        <section className="aside-block bg-primary-lighter border-t">
+        <section className="aside-block is-tinted">
           <Waitlist listing={listing} />
         </section>
       )}

--- a/ui-components/src/page_components/listing/listing_sidebar/ApplicationSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/ApplicationSection.tsx
@@ -26,14 +26,14 @@ const ApplicationSection = (props: ApplicationSectionProps) => {
   if (nowTime > dueDate) return null
 
   return (
-    <div>
+    <>
       {showWaitlist(listing) && (
         <section className="aside-block is-tinted">
           <Waitlist listing={listing} />
         </section>
       )}
       <Apply listing={listing} internalFormRoute={props.internalFormRoute} />
-    </div>
+    </>
   )
 }
 

--- a/ui-components/src/page_components/listing/listing_sidebar/Apply.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/Apply.tsx
@@ -135,7 +135,7 @@ const Apply = (props: ApplyProps) => {
         ApplicationMethodType.POBox,
         ApplicationMethodType.LeasingAgent,
       ]) && (
-        <section className="aside-block bg-gray-100">
+        <section className="aside-block is-tinted bg-gray-100">
           <NumberedHeader num={2} text={t("listings.apply.submitAPaperApplication")} />
           {hasMethod(listing.applicationMethods, ApplicationMethodType.POBox) && (
             <>

--- a/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
@@ -19,7 +19,7 @@ const LeasingAgent = (props: LeasingAgentProps) => {
   const phoneNumber = `tel:${listing.leasingAgentPhone.replace(/[-()]/g, "")}`
 
   return (
-    <section className="aside-block border-b-0 -mx-4 -mb-4 md:mx-0 md:mb-0 md:border-b">
+    <section className="aside-block">
       <h4 className="text-caps-underline">{t("leasingAgent.contact")}</h4>
 
       <p className="text-xl">{listing.leasingAgentName}</p>

--- a/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/WhatToExpect.tsx
@@ -28,7 +28,7 @@ const WhatToExpect = (props: WhatToExpectProps) => {
       : t("whatToExpect.bePreparedIfChosen")
 
   return (
-    <section className="aside-block -mx-4 pt-0 md:mx-0 md:pt-4">
+    <section className="aside-block">
       <h4 className="text-caps-underline">{t("whatToExpect.label")}</h4>
       <p className="text-tiny text-gray-800">{applicantsWillBeContacted}</p>
       <details className="disclosure">

--- a/ui-components/src/page_components/listing/listing_sidebar/events/DownloadLotteryResults.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/DownloadLotteryResults.tsx
@@ -8,7 +8,7 @@ const DownloadLotteryResults = (props: { event: ListingEvent }) => {
   return (
     <>
       {event && event.url && (
-        <section className="aside-block -mx-4 pt-0 md:mx-0 md:pt-4 text-center">
+        <section className="aside-block text-center">
           <h2 className="text-caps pb-4">{t("listings.lotteryResults.header")}</h2>
           <p className="uppercase text-gray-800 text-tiny font-semibold pb-4">
             {moment(event.startTime).format("MMMM D, YYYY")}

--- a/ui-components/src/page_components/listing/listing_sidebar/events/LotteryResultsEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/LotteryResultsEvent.tsx
@@ -6,7 +6,7 @@ import moment from "moment"
 const LotteryResultsEvent = (props: { event: ListingEvent }) => {
   const { event } = props
   return (
-    <section className="aside-block -mx-4 pt-0 md:mx-0 md:pt-4">
+    <section className="aside-block">
       <h4 className="text-caps-underline">{t("listings.lotteryResults.header")}</h4>
       <p className="text text-gray-800 pb-3 flex justify-between items-center">
         <span className="inline-block">{moment(props.event.startTime).format("MMMM D, YYYY")}</span>

--- a/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
@@ -5,7 +5,7 @@ import { t } from "../../../../helpers/translator"
 
 const OpenHouseEvent = (props: { events: ListingEvent[] }) => {
   return (
-    <section className="aside-block is-tinted">
+    <section className="aside-block">
       <h4 className="text-caps-tiny">{t("listings.openHouseEvent.header")}</h4>
       {props.events.map((openHouseEvent, index) => (
         <div key={`openHouses-${index}`}>

--- a/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/OpenHouseEvent.tsx
@@ -5,7 +5,7 @@ import { t } from "../../../../helpers/translator"
 
 const OpenHouseEvent = (props: { events: ListingEvent[] }) => {
   return (
-    <section className="aside-block bg-primary-lighter border-t">
+    <section className="aside-block is-tinted">
       <h4 className="text-caps-tiny">{t("listings.openHouseEvent.header")}</h4>
       {props.events.map((openHouseEvent, index) => (
         <div key={`openHouses-${index}`}>

--- a/ui-components/src/page_components/listing/listing_sidebar/events/PublicLotteryEvent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/PublicLotteryEvent.tsx
@@ -6,7 +6,7 @@ import { EventDateSection } from "./EventDateSection"
 const PublicLotteryEvent = (props: { event: ListingEvent }) => {
   const { event } = props
   return (
-    <section className="aside-block -mx-4 pt-0 md:mx-0 md:pt-4">
+    <section className="aside-block">
       <h4 className="text-caps-underline">{t("listings.publicLottery.header")}</h4>
       <EventDateSection event={props.event} />
       {event.url && (


### PR DESCRIPTION
This supersedes #1088. Resolves #1084 

---

## Desired order from Jesse:

**Desktop**
- Unit Table

Sidebar:
- Due Date
- Open House
- Waitlist
- How to Apply / Post Lottery: Download Results
- Lottery Date
- What to Expect
- Contact Leasing Agent

**Mobile**
- Unit Table
- Due Date
- Waitlist
- How to Apply / Post Lottery: Download Results

Process Accordion:
- Open House
- Lottery Date
- What to Expect
- Contact Leasing Agent