### PR TITLE
Use correct listingId when redirecting from Sign In

### DIFF
--- a/sites/public/lib/hooks.ts
+++ b/sites/public/lib/hooks.ts
@@ -1,16 +1,19 @@
 import { useContext, useEffect } from "react"
 import { useRouter } from "next/router"
 import { AppSubmissionContext } from "./AppSubmissionContext"
+import { ParsedUrlQuery } from "querystring"
 
 export const useRedirectToPrevPage = (defaultPath = "/") => {
   const router = useRouter()
 
-  return (queryParams: Record<string, any> = {}) => {
+  return (queryParams: ParsedUrlQuery = {}) => {
     const redirectUrl = router.query.redirectUrl
+    const redirectParams = { ...queryParams }
+    if (router.query.listingId) redirectParams.listingId = router.query.listingId
 
     return router.push({
       pathname: redirectUrl && typeof redirectUrl === "string" ? redirectUrl : defaultPath,
-      query: queryParams,
+      query: redirectParams,
     })
   }
 }

--- a/sites/public/pages/applications/start/choose-language.tsx
+++ b/sites/public/pages/applications/start/choose-language.tsx
@@ -125,7 +125,9 @@ export default () => {
               <p className="my-6">{t("application.chooseLanguage.signInSaveTime")}</p>
 
               <div>
-                <LinkButton href="/sign-in?redirectUrl=/applications/start/choose-language">
+                <LinkButton
+                  href={`/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listingId?.toString()}`}
+                >
                   {t("nav.signIn")}
                 </LinkButton>
               </div>


### PR DESCRIPTION
This is a fix following up on #1111 to ensure the user is redirected to the correct listing after signing in.