### PR TITLE
fix: bmr translation issue

### DIFF
--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -61,7 +61,8 @@ const hmiData = (units: Units, byUnitType: UnitSummary[], amiPercentages: string
   //    year) per household size.
   if (amiValues.length > 1) {
     amiValues.forEach((percent) => {
-      hmiHeaders[`ami${percent}`] = `${percent}% AMI Units`
+      // Pass translation with its respective argument with format `key,argumentName:argumentValue`
+      hmiHeaders[`ami${percent}`] = `listings.percentAMIUnit,percent:${percent}`
     })
 
     new Array(maxHousehold).fill(maxHousehold).forEach((item, i) => {

--- a/sites/public/pages/listing.tsx
+++ b/sites/public/pages/listing.tsx
@@ -98,8 +98,8 @@ export default class extends Component<ListingProps> {
 
     const occupancyDescription = getOccupancyDescription(listing)
     const occupancyHeaders = {
-      unitType: t("t.unitType"),
-      occupancy: t("t.occupancy"),
+      unitType: "t.unitType",
+      occupancy: "t.occupancy",
     }
     const occupancyData = occupancyTable(listing)
 

--- a/ui-components/__tests__/helpers/getTranslationWithArguments.test.ts
+++ b/ui-components/__tests__/helpers/getTranslationWithArguments.test.ts
@@ -1,0 +1,20 @@
+import { cleanup } from "@testing-library/react"
+import { getTranslationWithArguments } from "../../src/helpers/getTranslationWithArguments"
+
+afterEach(cleanup)
+
+describe("getTranslationWithArguments", () => {
+  it("should return a translated string with no arguments", () => {
+    expect(getTranslationWithArguments("t.yes")).toBe("Yes")
+  })
+  it("should return a translated string with one argument", () => {
+    expect(getTranslationWithArguments("listings.percentAMIUnit,percent:20")).toBe("20% AMI Unit")
+  })
+  it("should return a translated string with two (or more) arguments", () => {
+    expect(
+      getTranslationWithArguments(
+        "listings.reservedUnitsForWhoAre,communityType:Community Type,reservedType:Reserved Type"
+      )
+    ).toBe("Reserved for Community Type who are Reserved Type")
+  })
+})

--- a/ui-components/index.ts
+++ b/ui-components/index.ts
@@ -64,6 +64,7 @@ export * from "./src/helpers/formatIncome"
 export * from "./src/helpers/validators"
 export * from "./src/helpers/blankApplication"
 export * from "./src/helpers/formatYesNoLabel"
+export * from "./src/helpers/getTranslationWithArguments"
 export * from "./src/helpers/preferences"
 export * from "./src/helpers/resolveObject"
 

--- a/ui-components/src/helpers/getTranslationWithArguments.ts
+++ b/ui-components/src/helpers/getTranslationWithArguments.ts
@@ -1,0 +1,14 @@
+import { t } from "../.."
+
+// translationKey must be in the format `key,argumentName:argumentValue,argumentName:argumentValue`
+// any number of arguments can be passed, returns a fully translated string
+export const getTranslationWithArguments = (translationKey: string) => {
+  if (translationKey.indexOf(",") >= 0) {
+    const [key, ...stringArguments] = translationKey.split(",")
+    const argumentsObject = stringArguments.reduce((obj, arg) => {
+      const [key, value] = arg.split(":")
+      return { ...obj, [key]: value }
+    }, {})
+    return t(key, argumentsObject)
+  } else return t(translationKey)
+}

--- a/ui-components/src/helpers/getTranslationWithArguments.ts
+++ b/ui-components/src/helpers/getTranslationWithArguments.ts
@@ -1,4 +1,4 @@
-import { t } from "../.."
+import { t } from "./translator"
 
 // translationKey must be in the format `key,argumentName:argumentValue,argumentName:argumentValue`
 // any number of arguments can be passed, returns a fully translated string

--- a/ui-components/src/tables/StandardTable.tsx
+++ b/ui-components/src/tables/StandardTable.tsx
@@ -36,9 +36,18 @@ export interface StandardTableProps {
 export const StandardTable = (props: StandardTableProps) => {
   const { headers, data, cellClassName } = props
 
+  // Translation strings are optionally passed in with arguments with format `key,argumentName:argumentValue`
+  const getTranslatedHeader = (headerKey: string) => {
+    if (headerKey.indexOf(",") >= 0) {
+      const translation = headerKey.split(",")
+      const argument = translation[1].split(":")
+      return t(translation[0], { [argument[0]]: argument[1] })
+    } else return t(headerKey)
+  }
+
   const headerLabels = Object.values(headers).map((header, index) => {
     const uniqKey = process.env.NODE_ENV === "test" ? `header-${index}` : nanoid()
-    return <HeaderCell key={uniqKey}>{t(header)}</HeaderCell>
+    return <HeaderCell key={uniqKey}>{getTranslatedHeader(header)}</HeaderCell>
   })
 
   const body = data.map((row: Record<string, React.ReactNode>, dataIndex) => {
@@ -51,7 +60,11 @@ export const StandardTable = (props: StandardTableProps) => {
       const uniqKey = process.env.NODE_ENV === "test" ? `standardcol-${colIndex}` : nanoid()
       const cell = row[colKey]
       return (
-        <Cell key={uniqKey} headerLabel={t(headers[colKey])} className={cellClassName}>
+        <Cell
+          key={uniqKey}
+          headerLabel={getTranslatedHeader(headers[colKey])}
+          className={cellClassName}
+        >
           {cell}
         </Cell>
       )

--- a/ui-components/src/tables/StandardTable.tsx
+++ b/ui-components/src/tables/StandardTable.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { nanoid } from "nanoid"
-import { t } from "../.."
+import { getTranslationWithArguments } from "../helpers/getTranslationWithArguments"
 
 export interface TableHeaders {
   [key: string]: string
@@ -36,18 +36,9 @@ export interface StandardTableProps {
 export const StandardTable = (props: StandardTableProps) => {
   const { headers, data, cellClassName } = props
 
-  // Translation strings are optionally passed in with arguments with format `key,argumentName:argumentValue`
-  const getTranslatedHeader = (headerKey: string) => {
-    if (headerKey.indexOf(",") >= 0) {
-      const translation = headerKey.split(",")
-      const argument = translation[1].split(":")
-      return t(translation[0], { [argument[0]]: argument[1] })
-    } else return t(headerKey)
-  }
-
   const headerLabels = Object.values(headers).map((header, index) => {
     const uniqKey = process.env.NODE_ENV === "test" ? `header-${index}` : nanoid()
-    return <HeaderCell key={uniqKey}>{getTranslatedHeader(header)}</HeaderCell>
+    return <HeaderCell key={uniqKey}>{getTranslationWithArguments(header)}</HeaderCell>
   })
 
   const body = data.map((row: Record<string, React.ReactNode>, dataIndex) => {
@@ -62,7 +53,7 @@ export const StandardTable = (props: StandardTableProps) => {
       return (
         <Cell
           key={uniqKey}
-          headerLabel={getTranslatedHeader(headers[colKey])}
+          headerLabel={getTranslationWithArguments(headers[colKey])}
           className={cellClassName}
         >
           {cell}


### PR DESCRIPTION
Addresses #1065 

When a listing had `bmrProgramChart` set to true, the console was reporting to translation errors.
The issue was that `unit-transformations` was sometimes passing a translation key (i.e. `t.key`) and sometimes (in the case of BMR) passing an english string (i.e. `20% AMI units`). This produced the console errors because `StandardTable` was passing every incoming string as if it were a key, so there were "missing keys". So it was both untranslated, and not a key.

The tricky part about this fix is that `X% AMI Units` can't just be passed as a key as it has an argument, and I didn't see a precedent for that anywhere. Following the format `t.key,argumentName:argumentValue` I'm allowing the headers of `StandardTable` to be passed header key strings that include optional argument information so that the string can still be translated.

Below is a screenshot of it working properly, passing "Unit Type" as just the key and parsing "20% AMI Unit" with its argument. No console errors are produced and it's all translated. To test this locally you may need to import a listing with `bmrProgramChart` set to true.
<img width="583" alt="Screen Shot 2021-05-04 at 12 31 33 PM" src="https://user-images.githubusercontent.com/65367387/117038295-b1b61600-acc4-11eb-9ee8-265755c0a723.png">
