### PR TITLE
Make additional eligibility sections optional

### DIFF
--- a/sites/public/pages/listing.tsx
+++ b/sites/public/pages/listing.tsx
@@ -282,21 +282,27 @@ export default class extends Component<ListingProps> {
                   subtitle={t("listings.sections.additionalEligibilitySubtitle")}
                 >
                   <>
-                    <InfoCard title={t("listings.creditHistory")}>
-                      <ExpandableText className="text-sm text-gray-700">
-                        {listing.creditHistory}
-                      </ExpandableText>
-                    </InfoCard>
-                    <InfoCard title={t("listings.rentalHistory")}>
-                      <ExpandableText className="text-sm text-gray-700">
-                        {listing.rentalHistory}
-                      </ExpandableText>
-                    </InfoCard>
-                    <InfoCard title={t("listings.criminalBackground")}>
-                      <ExpandableText className="text-sm text-gray-700">
-                        {listing.criminalBackground}
-                      </ExpandableText>
-                    </InfoCard>
+                    {listing.creditHistory && (
+                      <InfoCard title={t("listings.creditHistory")}>
+                        <ExpandableText className="text-sm text-gray-700">
+                          {listing.creditHistory}
+                        </ExpandableText>
+                      </InfoCard>
+                    )}
+                    {listing.rentalHistory && (
+                      <InfoCard title={t("listings.rentalHistory")}>
+                        <ExpandableText className="text-sm text-gray-700">
+                          {listing.rentalHistory}
+                        </ExpandableText>
+                      </InfoCard>
+                    )}
+                    {listing.criminalBackground && (
+                      <InfoCard title={t("listings.criminalBackground")}>
+                        <ExpandableText className="text-sm text-gray-700">
+                          {listing.criminalBackground}
+                        </ExpandableText>
+                      </InfoCard>
+                    )}
                     {buildingSelectionCriteria}
                   </>
                 </ListSection>


### PR DESCRIPTION
Following QA on the Nova listing and their ask to remove the credit history and rental history sections for lack of language, this PR makes all three of the additional eligibility sections optional (previously it required an empty string and the headers would still appear). Ran this past Kathy 👍 