### PR TITLE
fix: waitlist open showing for every listing

### DIFF
--- a/backend/core/client.ts
+++ b/backend/core/client.ts
@@ -1766,6 +1766,9 @@ export interface Listing {
 
   /**  */
   applicationConfig?: object;
+
+  /** */
+  showWaitlist?: boolean
 }
 
 export interface PreferenceCreate {

--- a/backend/core/src/listings/dto/listing.dto.ts
+++ b/backend/core/src/listings/dto/listing.dto.ts
@@ -73,6 +73,7 @@ export class ListingCreateDto extends OmitType(ListingDto, [
   "leasingAgentAddress",
   "leasingAgents",
   "urlSlug",
+  "showWaitlist",
 ] as const) {
   @Expose()
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })
@@ -123,6 +124,7 @@ export class ListingUpdateDto extends OmitType(ListingDto, [
   "leasingAgentAddress",
   "urlSlug",
   "leasingAgents",
+  "showWaitlist",
 ] as const) {
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/src/listings/entities/listing.entity.ts
+++ b/backend/core/src/listings/entities/listing.entity.ts
@@ -338,6 +338,17 @@ class Listing extends BaseEntity {
   @IsEnum(CountyCode, { groups: [ValidationsGroupsEnum.default] })
   @ApiProperty({ enum: CountyCode, enumName: "CountyCode" })
   countyCode: CountyCode
+
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  get showWaitlist(): boolean {
+    return (
+      this.waitlistMaxSize !== null &&
+      this.waitlistCurrentSize !== null &&
+      this.waitlistCurrentSize < this.waitlistMaxSize
+    )
+  }
 }
 
 export { Listing as default, Listing }

--- a/backend/core/src/seeds/listings.ts
+++ b/backend/core/src/seeds/listings.ts
@@ -41,6 +41,7 @@ export interface ListingSeed {
     | "assets"
     | "preferences"
     | "leasingAgents"
+    | "showWaitlist"
   >
   leasingAgents: UserCreateDto[]
 }
@@ -74,7 +75,7 @@ export async function seedListing(app: INestApplicationContext, seed: ListingSee
   })
   await unitsRepo.save(unitsToBeCreated)
 
-  const listingCreateDto: Omit<ListingCreateDto, keyof BaseEntity | "urlSlug"> = {
+  const listingCreateDto: Omit<ListingCreateDto, keyof BaseEntity | "urlSlug" | "showWaitlist"> = {
     ...seed.listing,
     property,
     leasingAgents: leasingAgents,

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -2018,6 +2018,9 @@ export interface Listing {
 
   /**  */
   applicationConfig?: object;
+
+  /** */
+  showWaitlist?: boolean;
 }
 
 export interface PreferenceCreate {

--- a/ui-components/src/page_components/listing/ListingsList.tsx
+++ b/ui-components/src/page_components/listing/ListingsList.tsx
@@ -51,7 +51,11 @@ const ListingsList = (props: ListingsProps) => {
           />
         </div>
         <div className="listings-row_content">
-          <h4 className="listings-row_title">{t("listings.waitlist.open")}</h4>
+          {listing.waitlistMaxSize !== null &&
+            listing.waitlistCurrentSize !== null &&
+            listing.waitlistCurrentSize < listing.waitlistMaxSize && (
+              <h4 className="listings-row_title">{t("listings.waitlist.open")}</h4>
+            )}
           <div className="listings-row_table">
             {unitSummaries && (
               <GroupedTable

--- a/ui-components/src/page_components/listing/ListingsList.tsx
+++ b/ui-components/src/page_components/listing/ListingsList.tsx
@@ -51,11 +51,9 @@ const ListingsList = (props: ListingsProps) => {
           />
         </div>
         <div className="listings-row_content">
-          {listing.waitlistMaxSize !== null &&
-            listing.waitlistCurrentSize !== null &&
-            listing.waitlistCurrentSize < listing.waitlistMaxSize && (
-              <h4 className="listings-row_title">{t("listings.waitlist.open")}</h4>
-            )}
+          {listing.showWaitlist && (
+            <h4 className="listings-row_title">{t("listings.waitlist.open")}</h4>
+          )}
           <div className="listings-row_table">
             {unitSummaries && (
               <GroupedTable


### PR DESCRIPTION
# Pull Request Template

## Issue

No pre-existing issue
- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

`Open Waitlist` was showing on the listings overview page for every listing regardless of whether or not it had a waitlist. New logic flow is if there is a current size and max size of a waitlist, and there are spots, show `Open Waitlist` otherwise nothing. You can see the bug here on staging: https://ala.bloom.exygy.dev/listings

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Checked out the /listings page on both desktop and mobile. I locally have listings with and without a waitlist.
- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
