### PR TITLE
fix: storybook images not appearing in public build

### DIFF
--- a/ui-components/package.json
+++ b/ui-components/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "private": false,
   "scripts": {
-    "build-storybook": "build-storybook -c .storybook",
+    "build-storybook": "build-storybook -c .storybook -s ./public",
     "start": "start-storybook -s ./public",
     "test": "jest -w 1",
     "test:coverage": "jest -w 1 --coverage --watchAll=false",


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #820 
- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Images and Icons (specifically within the Icon story) were not appearing at our public Storybook (https://storybook.bloom.exygy.dev/). The issue ended up being that we just weren't indicating where our assets were supposed to live.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

This was tested locally by first removing the current storybook build (lives at storybook-static), and then from within ui-components, building storybook with `yarn build-storybook` and serving it locally with `npx http-server ./storybook-static`. Can confirm no images appear on master with these steps, but they do on this branch. If you ever end up switching between master and this branch locally to test it out, you might also want to clear your browser's cache in between.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have assigned reviewers
