### PR TITLE
fix: preference select text issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. The format 
 
   - Save application language in the choose-language step ([#1234](https://github.com/bloom-housing/bloom/pull/1234)) Dominik Barcikowski
   - Fixed broken Cypress tests on the CircleCI ([#1262](https://github.com/bloom-housing/bloom/pull/1262)) Dominik Barcikowski
+  - Fix repetition of select text on preferences ([#1270](https://github.com/bloom-housing/bloom/pull/1270)) (Emily Jablonski)
 
 - Changed:
 

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -1484,7 +1484,7 @@ export interface FormMetadata {
   hideGenericDecline?: boolean;
 
   /** */
-  customSelectText?: boolean
+  customSelectText?: string
 }
 
 export interface Preference {

--- a/sites/public/pages/applications/preferences/all.tsx
+++ b/sites/public/pages/applications/preferences/all.tsx
@@ -182,140 +182,139 @@ const ApplicationPreferencesAll = () => {
           </AlertBox>
         )}
 
+        <div className="form-card__group px-0 pb-0">
+          <p className="field-note">
+            {preferencesByPage[0]?.formMetadata.customSelectText ??
+              t("application.preferences.selectBelow")}
+          </p>
+        </div>
+
         <Form onSubmit={handleSubmit(onSubmit)}>
           <>
             {preferencesByPage?.map((preference, index) => {
               const noneOptionKey = `${PREFERENCES_NONE_FORM_PATH}.${preference.formMetadata.key}-none`
               return (
-                <>
-                  <div className="form-card__group px-0 pb-0">
-                    <p className="field-note">
-                      {preference.formMetadata.customSelectText ??
-                        t("application.preferences.selectBelow")}
-                    </p>
-                  </div>
-                  <div key={preference.id}>
-                    <div
-                      className={`form-card__group px-0 ${
-                        index + 1 !== preferencesByPage.length ? "border-b" : ""
-                      }`}
-                    >
-                      <fieldset>
-                        <legend className="field-label--caps mb-4">{preference.title}</legend>
-                        <p className="field-note mb-8">{preference.description}</p>
-                        {preference?.formMetadata?.options?.map((option) => {
-                          return (
-                            <div className="mb-5" key={option.key}>
-                              <div
-                                className={`mb-5 field ${
-                                  resolveObject(noneOptionKey, errors) ? "error" : ""
-                                }`}
-                              >
-                                <Field
-                                  id={getPreferenceOptionName(
-                                    preference.formMetadata.key,
-                                    option.key
-                                  )}
-                                  name={getPreferenceOptionName(
-                                    preference.formMetadata.key,
-                                    option.key
-                                  )}
-                                  type="checkbox"
-                                  label={t(
-                                    `application.preferences.${preference.formMetadata.key}.${option.key}.label`,
-                                    { county: listing?.countyCode }
-                                  )}
-                                  register={register}
-                                  inputProps={{
-                                    onChange: () => {
-                                      setTimeout(() => {
-                                        setValue(noneOptionKey, false)
-                                        void trigger(noneOptionKey)
-                                      }, 1)
-                                    },
-                                  }}
-                                />
-                              </div>
-
-                              {!(option.description === false) && (
-                                <div className="ml-8 -mt-3">
-                                  <ExpandableContent>
-                                    <p className="field-note mb-8">
-                                      {t(
-                                        `application.preferences.${preference.formMetadata.key}.${option.key}.description`,
-                                        { county: listing?.countyCode }
-                                      )}
-                                      <br />
-                                      {preference?.links?.map((link) => (
-                                        <a key={link.url} className="block pt-2" href={link.url}>
-                                          {link.title}
-                                        </a>
-                                      ))}
-                                    </p>
-                                  </ExpandableContent>
-                                </div>
-                              )}
-
-                              {watchPreferences[
-                                getPreferenceOptionName(preference.formMetadata.key, option.key)
-                              ] &&
-                                option.extraData?.map((extra) => (
-                                  <ExtraField
-                                    key={extra.key}
-                                    metaKey={preference.formMetadata.key}
-                                    optionKey={option.key}
-                                    extraKey={extra.key}
-                                    type={extra.type}
-                                    register={register}
-                                    errors={errors}
-                                    hhMembersOptions={hhMmembersOptions}
-                                  />
-                                ))}
+                <div key={preference.id}>
+                  <div
+                    className={`form-card__group px-0 ${
+                      index + 1 !== preferencesByPage.length ? "border-b" : ""
+                    }`}
+                  >
+                    <fieldset>
+                      <legend className="field-label--caps mb-4">{preference.title}</legend>
+                      <p className="field-note mb-8">{preference.description}</p>
+                      {preference?.formMetadata?.options?.map((option) => {
+                        return (
+                          <div className="mb-5" key={option.key}>
+                            <div
+                              className={`mb-5 field ${
+                                resolveObject(noneOptionKey, errors) ? "error" : ""
+                              }`}
+                            >
+                              <Field
+                                id={getPreferenceOptionName(
+                                  preference.formMetadata.key,
+                                  option.key
+                                )}
+                                name={getPreferenceOptionName(
+                                  preference.formMetadata.key,
+                                  option.key
+                                )}
+                                type="checkbox"
+                                label={t(
+                                  `application.preferences.${preference.formMetadata.key}.${option.key}.label`,
+                                  { county: listing?.countyCode }
+                                )}
+                                register={register}
+                                inputProps={{
+                                  onChange: () => {
+                                    setTimeout(() => {
+                                      setValue(noneOptionKey, false)
+                                      void trigger(noneOptionKey)
+                                    }, 1)
+                                  },
+                                }}
+                              />
                             </div>
-                          )
-                        })}
 
-                        {preference?.formMetadata && !preference.formMetadata.hideGenericDecline && (
-                          <div
-                            className={`mb-5 field ${
-                              resolveObject(noneOptionKey, errors) ? "error" : ""
-                            }`}
-                          >
-                            <Field
-                              id={noneOptionKey}
-                              name={noneOptionKey}
-                              type="checkbox"
-                              label={t("application.preferences.dontWant")}
-                              register={register}
-                              inputProps={{
-                                onChange: (e) => {
-                                  if (e.target.checked) {
-                                    setValue(noneOptionKey, true)
+                            {!(option.description === false) && (
+                              <div className="ml-8 -mt-3">
+                                <ExpandableContent>
+                                  <p className="field-note mb-8">
+                                    {t(
+                                      `application.preferences.${preference.formMetadata.key}.${option.key}.description`,
+                                      { county: listing?.countyCode }
+                                    )}
+                                    <br />
+                                    {preference?.links?.map((link) => (
+                                      <a key={link.url} className="block pt-2" href={link.url}>
+                                        {link.title}
+                                      </a>
+                                    ))}
+                                  </p>
+                                </ExpandableContent>
+                              </div>
+                            )}
 
-                                    uncheckPreference(
-                                      preference.formMetadata.key,
-                                      preference.formMetadata?.options
-                                    )
-                                    void trigger(noneOptionKey)
-                                  }
-                                },
-                              }}
-                              validation={{
-                                validate: {
-                                  somethingIsChecked: (value) =>
-                                    value ||
-                                    preferenceCheckboxIds[
-                                      preference.formMetadata.key
-                                    ].some((option) => getValues(option)),
-                                },
-                              }}
-                            />
+                            {watchPreferences[
+                              getPreferenceOptionName(preference.formMetadata.key, option.key)
+                            ] &&
+                              option.extraData?.map((extra) => (
+                                <ExtraField
+                                  key={extra.key}
+                                  metaKey={preference.formMetadata.key}
+                                  optionKey={option.key}
+                                  extraKey={extra.key}
+                                  type={extra.type}
+                                  register={register}
+                                  errors={errors}
+                                  hhMembersOptions={hhMmembersOptions}
+                                />
+                              ))}
                           </div>
-                        )}
-                      </fieldset>
-                    </div>
+                        )
+                      })}
+
+                      {preference?.formMetadata && !preference.formMetadata.hideGenericDecline && (
+                        <div
+                          className={`mb-5 field ${
+                            resolveObject(noneOptionKey, errors) ? "error" : ""
+                          }`}
+                        >
+                          <Field
+                            id={noneOptionKey}
+                            name={noneOptionKey}
+                            type="checkbox"
+                            label={t("application.preferences.dontWant")}
+                            register={register}
+                            inputProps={{
+                              onChange: (e) => {
+                                if (e.target.checked) {
+                                  setValue(noneOptionKey, true)
+
+                                  uncheckPreference(
+                                    preference.formMetadata.key,
+                                    preference.formMetadata?.options
+                                  )
+                                  void trigger(noneOptionKey)
+                                }
+                              },
+                            }}
+                            validation={{
+                              validate: {
+                                somethingIsChecked: (value) =>
+                                  value ||
+                                  preferenceCheckboxIds[
+                                    preference.formMetadata.key
+                                  ].some((option) => getValues(option)),
+                              },
+                            }}
+                          />
+                        </div>
+                      )}
+                    </fieldset>
                   </div>
-                </>
+                </div>
               )
             })}
 


### PR DESCRIPTION
# Pull Request Template

## Issue

No issue, made ad-hoc while testing and was super quick.

## Description

Yesterday I merged changes to allow custom select text on preferences and there was a bug. The select text would repeat itself before each individual preference instead of just once at the top. This fixes that! 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

You can test it out locally on the Triton 2-pref listing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
