### PR TITLE
Fix/preference extradata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,10 @@ All notable changes to this project will be documented in this file. The format 
 
 - Fixed:
 
-  - Save application language in the choose-language step ([#1234](https://github.com/bloom-housing/bloom/pull/1234)) Dominik Barcikowski
-  - Fixed broken Cypress tests on the CircleCI ([#1262](https://github.com/bloom-housing/bloom/pull/1262)) Dominik Barcikowski
+  - Save application language in the choose-language step ([#1234](https://github.com/bloom-housing/bloom/pull/1234)) (Dominik Barcikowski)
+  - Fixed broken Cypress tests on the CircleCI ([#1262](https://github.com/bloom-housing/bloom/pull/1262)) (Dominik Barcikowski)
   - Fix repetition of select text on preferences ([#1270](https://github.com/bloom-housing/bloom/pull/1270)) (Emily Jablonski)
+  - Fix aplication submission and broken test ([#1270](https://github.com/bloom-housing/bloom/pull/1282)) (Dominik Barcikowski)
 
 - Changed:
 

--- a/sites/public/cypress/fixtures/applicationConfigFilled.json
+++ b/sites/public/cypress/fixtures/applicationConfigFilled.json
@@ -135,11 +135,13 @@
          "options": [
             {
                "key": "live",
-               "checked": true
+               "checked": true,
+               "extraData": []
             },
             {
                "key": "work",
-               "checked": true
+               "checked": true,
+               "extraData": []
             }
          ]
       }

--- a/sites/public/cypress/integration/pages/application/preferences/all.spec.ts
+++ b/sites/public/cypress/integration/pages/application/preferences/all.spec.ts
@@ -134,10 +134,12 @@ describe("applications/preferences/all", function () {
             {
               key: "live",
               checked: true,
+              extraData: [],
             },
             {
               key: "work",
               checked: true,
+              extraData: [],
             },
           ],
         },

--- a/sites/public/cypress/integration/pages/application/review/terms.spec.ts
+++ b/sites/public/cypress/integration/pages/application/review/terms.spec.ts
@@ -21,16 +21,16 @@ describe("applications/review/terms", function () {
   })
 
   // Broken on master, addressed by PR #1155
-  // it("Should redirect to the next step", function () {
-  //   cy.getByID("agree").check()
+  it("Should redirect to the next step", function () {
+    cy.getByID("agree").check()
 
-  //   submitApplication()
+    submitApplication()
 
-  //   cy.checkErrorAlert("not.exist")
-  //   cy.checkErrorMessages("not.exist")
+    cy.checkErrorAlert("not.exist")
+    cy.checkErrorMessages("not.exist")
 
-  //   cy.location("pathname").should("include", "applications/review/confirmation")
+    cy.location("pathname").should("include", "applications/review/confirmation")
 
-  //   cy.getByID("confirmationId").should("be.visible").and("not.be.empty")
-  // })
+    cy.getByID("confirmationId").should("be.visible").and("not.be.empty")
+  })
 })

--- a/ui-components/src/helpers/preferences.tsx
+++ b/ui-components/src/helpers/preferences.tsx
@@ -280,6 +280,8 @@ export const mapPreferencesToApi = (data: Record<string, any>) => {
         })
 
         Object.assign(response, { extraData })
+      } else {
+        Object.assign(response, { extraData: [] })
       }
 
       return response


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses # (issue)
- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

When you try to submit an application, you'll see an error in the /terms step and finally, there is no way to submit an application.

It occurs because function `mapPreferencesToApi` doesn't provide an empty `extraData` property when there are no extraData in a single preference - it's required after backend update.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Check the CircleCI tests and/or manually submit an application.

- [x] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
