### PR TITLE
Add table image thumbnails and minimal flush styles

### DIFF
--- a/ui-components/__tests__/tables/MinimalTable.test.tsx
+++ b/ui-components/__tests__/tables/MinimalTable.test.tsx
@@ -33,4 +33,13 @@ describe("<MinimalTable>", () => {
     expect(getByText(data[1].relationship))
     expect(getByText(data[1].dob))
   })
+
+  it("supports flush column styling", () => {
+    const { container } = render(
+      <MinimalTable headers={headers} data={data} flushLeft flushRight />
+    )
+
+    expect(container.querySelector("table.is-flush-left")).toBeTruthy()
+    expect(container.querySelector("table.is-flush-right")).toBeTruthy()
+  })
 })

--- a/ui-components/__tests__/tables/StandardTable.test.tsx
+++ b/ui-components/__tests__/tables/StandardTable.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { render, cleanup } from "@testing-library/react"
-import { StandardTable } from "../../src/tables/StandardTable"
+import { StandardTable, TableThumbnail } from "../../src/tables/StandardTable"
 import { t } from "../../src/helpers/translator"
 
 afterEach(cleanup)
@@ -26,8 +26,16 @@ const data = [
 
 const headersWithImage = { image: "t.text", ...headers }
 const dataWithImage = [...data] as any
-dataWithImage[0].image = <img src="/images/listing.jpg" className="extra-image-class" />
-dataWithImage[1].image = <img src="/images/logo_glyph.svg" />
+dataWithImage[0].image = (
+  <TableThumbnail>
+    <img src="/images/listing.jpg" />
+  </TableThumbnail>
+)
+dataWithImage[1].image = (
+  <TableThumbnail>
+    <img src="/images/logo_glyph.svg" />
+  </TableThumbnail>
+)
 
 describe("<StandardTable>", () => {
   it("renders default state", () => {
@@ -43,7 +51,6 @@ describe("<StandardTable>", () => {
   it("renders with image thumbnails", () => {
     const { container } = render(<StandardTable headers={headersWithImage} data={dataWithImage} />)
     expect(container.getElementsByClassName("table__thumbnail").length).toBe(2)
-    expect(container.getElementsByClassName("extra-image-class").length).toBe(1)
   })
 
   it("renders with custom props", () => {

--- a/ui-components/__tests__/tables/StandardTable.test.tsx
+++ b/ui-components/__tests__/tables/StandardTable.test.tsx
@@ -24,6 +24,11 @@ const data = [
   },
 ]
 
+const headersWithImage = { image: "t.text", ...headers }
+const dataWithImage = [...data] as any
+dataWithImage[0].image = <img src="/images/listing.jpg" className="extra-image-class" />
+dataWithImage[1].image = <img src="/images/logo_glyph.svg" />
+
 describe("<StandardTable>", () => {
   it("renders default state", () => {
     const { getByText } = render(<StandardTable headers={headers} data={data} />)
@@ -34,6 +39,13 @@ describe("<StandardTable>", () => {
     expect(getByText(data[1].sqFeet))
     expect(getByText(data[1].numBathrooms))
   })
+
+  it("renders with image thumbnails", () => {
+    const { container } = render(<StandardTable headers={headersWithImage} data={dataWithImage} />)
+    expect(container.getElementsByClassName("table__thumbnail").length).toBe(2)
+    expect(container.getElementsByClassName("extra-image-class").length).toBe(1)
+  })
+
   it("renders with custom props", () => {
     const { getByText, container } = render(
       <StandardTable

--- a/ui-components/src/global/tables.scss
+++ b/ui-components/src/global/tables.scss
@@ -44,6 +44,22 @@ table {
       background: transparent;
     }
   }
+  &.is-flush-left {
+    thead tr th:first-of-type {
+      padding-left: 0 !important;
+    }
+    tr td:first-of-type {
+      padding-left: 0 !important;
+    }
+  }
+  &.is-flush-right {
+    thead tr th:last-of-type {
+      padding-right: 0 !important;
+    }
+    tr td:last-of-type {
+      padding-right: 0 !important;
+    }
+  }
 }
 
 table tr:nth-of-type(even) {
@@ -84,7 +100,6 @@ https://www.cssscript.com/pure-html5-css3-responsive-table-solution/ */
 
 @media screen and (max-width: 639px) {
   table.responsive-collapse {
-    
     thead {
       @apply hidden;
     }
@@ -94,11 +109,10 @@ https://www.cssscript.com/pure-html5-css3-responsive-table-solution/ */
       @apply mb-6;
     }
 
-    
     tr:nth-of-type(even) {
       background: inherit;
     }
-    
+
     td:nth-of-type(even) {
       @apply bg-primary-lighter;
     }
@@ -124,5 +138,17 @@ https://www.cssscript.com/pure-html5-css3-responsive-table-solution/ */
     @apply border-l-8;
     @apply border-solid;
     @apply border-accent-warm;
+  }
+}
+
+.table__thumbnail {
+  max-height: 80px;
+  max-width: 80x;
+  @apply -my-3;
+}
+
+table.td-plain {
+  .table__thumbnail {
+    @apply -my-1;
   }
 }

--- a/ui-components/src/global/tables.scss
+++ b/ui-components/src/global/tables.scss
@@ -141,14 +141,15 @@ https://www.cssscript.com/pure-html5-css3-responsive-table-solution/ */
   }
 }
 
-.table__thumbnail {
+.table__thumbnail img {
   max-height: 80px;
-  max-width: 80x;
+  max-width: 142px;
   @apply -my-3;
+  @apply inline-block;
 }
 
 table.td-plain {
-  .table__thumbnail {
+  .table__thumbnail img {
     @apply -my-1;
   }
 }

--- a/ui-components/src/tables/MinimalTable.stories.tsx
+++ b/ui-components/src/tables/MinimalTable.stories.tsx
@@ -34,3 +34,17 @@ while (i > 0) {
 }
 
 export const Default = () => <MinimalTable headers={headers} data={data} />
+
+const headersWithImage = { image: "Image", ...headers }
+const dataWithImage = [...data] as any
+dataWithImage[0].image = <img src="/images/listing.jpg" />
+dataWithImage[1].image = <img src="/images/logo_glyph.svg" />
+
+export const ImageCells = () => (
+  <MinimalTable
+    headers={headersWithImage}
+    data={dataWithImage}
+    flushLeft={true}
+    flushRight={true}
+  />
+)

--- a/ui-components/src/tables/MinimalTable.stories.tsx
+++ b/ui-components/src/tables/MinimalTable.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 
 import { MinimalTable } from "./MinimalTable"
+import { TableThumbnail } from "./StandardTable"
 
 export default {
   title: "Tables/MinimalTable",
@@ -37,8 +38,16 @@ export const Default = () => <MinimalTable headers={headers} data={data} />
 
 const headersWithImage = { image: "Image", ...headers }
 const dataWithImage = [...data] as any
-dataWithImage[0].image = <img src="/images/listing.jpg" />
-dataWithImage[1].image = <img src="/images/logo_glyph.svg" />
+dataWithImage[0].image = (
+  <TableThumbnail>
+    <img src="/images/listing.jpg" />
+  </TableThumbnail>
+)
+dataWithImage[1].image = (
+  <TableThumbnail>
+    <img src="/images/logo_glyph.svg" />
+  </TableThumbnail>
+)
 
 export const ImageCells = () => (
   <MinimalTable

--- a/ui-components/src/tables/MinimalTable.tsx
+++ b/ui-components/src/tables/MinimalTable.tsx
@@ -4,14 +4,20 @@ import { TableHeaders, StandardTable } from "./StandardTable"
 interface MinimalTableProps {
   headers: TableHeaders
   data: Record<string, React.ReactNode>[]
+  flushLeft?: boolean
+  flushRight?: boolean
 }
 
 const MinimalTable = (props: MinimalTableProps) => {
+  const tableClasses = ["td-plain", "th-plain"]
+  if (props.flushLeft) tableClasses.push("is-flush-left")
+  if (props.flushRight) tableClasses.push("is-flush-right")
+
   return (
     <StandardTable
       headers={props.headers}
       data={props.data}
-      tableClassName="td-plain th-plain"
+      tableClassName={tableClasses.join(" ")}
       cellClassName="px-5 py-3"
     />
   )

--- a/ui-components/src/tables/StandardTable.stories.tsx
+++ b/ui-components/src/tables/StandardTable.stories.tsx
@@ -34,3 +34,10 @@ while (i > 0) {
 }
 
 export const Default = () => <StandardTable headers={headers} data={data} />
+
+const headersWithImage = { image: "Image", ...headers }
+const dataWithImage = [...data] as any
+dataWithImage[0].image = <img src="/images/listing.jpg" />
+dataWithImage[1].image = <img src="/images/logo_glyph.svg" />
+
+export const ImageCells = () => <StandardTable headers={headersWithImage} data={dataWithImage} />

--- a/ui-components/src/tables/StandardTable.stories.tsx
+++ b/ui-components/src/tables/StandardTable.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { StandardTable } from "./StandardTable"
+import { StandardTable, TableThumbnail } from "./StandardTable"
 
 export default {
   title: "Tables/StandardTable",
@@ -37,7 +37,19 @@ export const Default = () => <StandardTable headers={headers} data={data} />
 
 const headersWithImage = { image: "Image", ...headers }
 const dataWithImage = [...data] as any
-dataWithImage[0].image = <img src="/images/listing.jpg" />
-dataWithImage[1].image = <img src="/images/logo_glyph.svg" />
+dataWithImage[0].image = (
+  <TableThumbnail>
+    <a href="#">
+      <img src="/images/listing.jpg" />
+    </a>
+  </TableThumbnail>
+)
+dataWithImage[1].image = (
+  <TableThumbnail>
+    <img src="/images/logo_glyph.svg" />
+  </TableThumbnail>
+)
 
-export const ImageCells = () => <StandardTable headers={headersWithImage} data={dataWithImage} />
+export const ImageCells = () => (
+  <StandardTable headers={headersWithImage} data={dataWithImage} responsiveCollapse />
+)

--- a/ui-components/src/tables/StandardTable.tsx
+++ b/ui-components/src/tables/StandardTable.tsx
@@ -42,6 +42,16 @@ export const StandardTable = (props: StandardTableProps) => {
   })
 
   const body = data.map((row: Record<string, React.ReactNode>, dataIndex) => {
+    // Inject thumbnail class into any images provided in the data
+    Object.entries(row).forEach(([key, node]) => {
+      if (React.isValidElement(node) && node?.type == "img") {
+        row[key] = React.cloneElement(node, {
+          ...node.props,
+          className: `${node.props.className} table__thumbnail`,
+        })
+      }
+    })
+
     const rowKey = row["id"]
       ? `row-${row["id"] as string}`
       : process.env.NODE_ENV === "test"

--- a/ui-components/src/tables/StandardTable.tsx
+++ b/ui-components/src/tables/StandardTable.tsx
@@ -25,6 +25,10 @@ export const Cell = (props: {
   </td>
 )
 
+export const TableThumbnail = (props: { children: React.ReactNode }) => {
+  return <span className="table__thumbnail">{props.children}</span>
+}
+
 export interface StandardTableProps {
   headers: TableHeaders
   data: Record<string, React.ReactNode>[]
@@ -42,16 +46,6 @@ export const StandardTable = (props: StandardTableProps) => {
   })
 
   const body = data.map((row: Record<string, React.ReactNode>, dataIndex) => {
-    // Inject thumbnail class into any images provided in the data
-    Object.entries(row).forEach(([key, node]) => {
-      if (React.isValidElement(node) && node?.type == "img") {
-        row[key] = React.cloneElement(node, {
-          ...node.props,
-          className: `${node.props.className} table__thumbnail`,
-        })
-      }
-    })
-
     const rowKey = row["id"]
       ? `row-${row["id"] as string}`
       : process.env.NODE_ENV === "test"


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1160 
- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

You can now wrap `img` tags in `TableThumbnail` values for `StandardTable` and `MinimalTable` components. They'll be displayed automatically as thumbnails. There's also `flushLeft` and `flushRight` props for `MinimalTable`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

- [x] Storybook

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
