### PR TITLE
Fixed paper app submission error if there are no preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file. The format 
   - Fix aplication submission and broken test ([#1270](https://github.com/bloom-housing/bloom/pull/1282)) (Dominik Barcikowski)
   - Fix broken application search in Partners ([#1301](https://github.com/bloom-housing/bloom/pull/1301)) (Dominik Barcikowski)
   - Fix multiple unit rows in summaries, sorting issues ([#1306](https://github.com/bloom-housing/bloom/pull/1306)) (Emily Jablonski)
+  - Fix partners application submission ([#1340](https://github.com/bloom-housing/bloom/pull/1340)) (Dominik Barcikowski)
 
 - Changed:
 

--- a/ui-components/src/helpers/preferences.tsx
+++ b/ui-components/src/helpers/preferences.tsx
@@ -238,7 +238,10 @@ export const FormAddress = ({
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const mapPreferencesToApi = (data: Record<string, any>) => {
+  if (!data.application?.preferences) return []
+
   const CLAIMED_KEY = "claimed"
+
   const preferencesFormData = data.application.preferences.options
 
   const keys = Object.keys(preferencesFormData)


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses # (issue)
- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

I noticed, for Test listing with 0 preferences - paper application form doesn't work. That's because 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Choose `Test listing(0 pref)`, then try to submit an application.

- [x] Desktop View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
