### PR TITLE
#1378 Use specific aria props in LocalizedLink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ All notable changes to this project will be documented in this file. The format 
     =======
   - Fix multiple unit rows in summaries, sorting issues ([#1306](https://github.com/bloom-housing/bloom/pull/1306)) (Emily Jablonski)
   - Fix partners application submission ([#1340](https://github.com/bloom-housing/bloom/pull/1340)) (Dominik Barcikowski)
-    > > > > > > > upstream/master
 
 - Changed:
 
@@ -73,6 +72,7 @@ All notable changes to this project will be documented in this file. The format 
 - Fixed:
 
   - Correct LinkButton and other styles in Storybook ([#1309](https://github.com/bloom-housing/bloom/pull/1309)) (Jared White & Jesse James Arnold)
+  - Fix aria reserved for future use warning ([#1378](https://github.com/bloom-housing/bloom/issues/1378)) (Andrea Egan)
 
 ## 1.0.0 / 2021-05-21
 

--- a/ui-components/src/config/NavigationContext.tsx
+++ b/ui-components/src/config/NavigationContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, FunctionComponent } from "react"
+import React, { AriaAttributes, createContext, FunctionComponent } from "react"
 import { UrlObject } from "url"
 
 type Url = UrlObject | string
@@ -6,7 +6,7 @@ type Url = UrlObject | string
 export interface LinkProps {
   href: string
   "aria-label"?: string
-  "aria-current"?: string
+  "aria-current"?: AriaAttributes["aria-current"]
   className?: string
   tabIndex?: number
 }

--- a/ui-components/src/config/NavigationContext.tsx
+++ b/ui-components/src/config/NavigationContext.tsx
@@ -5,7 +5,7 @@ type Url = UrlObject | string
 
 export interface LinkProps {
   href: string
-  aria?: Record<string, string>
+  ariaProps?: Record<string, string>
   className?: string
   tabIndex?: number
 }
@@ -35,7 +35,7 @@ export const NavigationContext = createContext<NavigationContextProps>({
         e.preventDefault()
         alert(`You clicked: ${props.href}`)
       }}
-      {...props.aria}
+      {...props.ariaProps}
     >
       {props.children}
     </a>

--- a/ui-components/src/config/NavigationContext.tsx
+++ b/ui-components/src/config/NavigationContext.tsx
@@ -5,7 +5,8 @@ type Url = UrlObject | string
 
 export interface LinkProps {
   href: string
-  ariaProps?: Record<string, string>
+  "aria-label"?: string
+  "aria-current"?: string
   className?: string
   tabIndex?: number
 }
@@ -35,7 +36,8 @@ export const NavigationContext = createContext<NavigationContextProps>({
         e.preventDefault()
         alert(`You clicked: ${props.href}`)
       }}
-      {...props.ariaProps}
+      {...(props["aria-label"] ? { "aria-label": props["aria-label"] } : {})}
+      {...(props["aria-current"] ? { "aria-current": props["aria-current"] } : {})}
     >
       {props.children}
     </a>

--- a/ui-components/src/headers/SiteHeader.tsx
+++ b/ui-components/src/headers/SiteHeader.tsx
@@ -69,7 +69,7 @@ const SiteHeader = (props: SiteHeaderProps) => {
       <LocalizedLink
         className={`navbar-item logo ${logoClass} ${getLogoWidthClass()}`}
         href="/"
-        aria={{ "aria-label": "homepage" }}
+        ariaProps={{ "aria-label": "homepage" }}
       >
         <div
           className={`logo__lockup ${getLogoWidthClass()} ${

--- a/ui-components/src/headers/SiteHeader.tsx
+++ b/ui-components/src/headers/SiteHeader.tsx
@@ -69,7 +69,7 @@ const SiteHeader = (props: SiteHeaderProps) => {
       <LocalizedLink
         className={`navbar-item logo ${logoClass} ${getLogoWidthClass()}`}
         href="/"
-        ariaProps={{ "aria-label": "homepage" }}
+        aria-label="homepage"
       >
         <div
           className={`logo__lockup ${getLogoWidthClass()} ${

--- a/ui-components/src/navigation/Breadcrumbs.tsx
+++ b/ui-components/src/navigation/Breadcrumbs.tsx
@@ -10,7 +10,7 @@ const BreadcrumbLink = (props: { href: string; children: React.ReactNode; curren
   <li>
     <LocalizedLink
       className={props.current ? "is-active" : undefined}
-      aria={props.current ? { "aria-current": "page" } : undefined}
+      ariaProps={props.current ? { "aria-current": "page" } : undefined}
       href={props.href}
     >
       {props.children}

--- a/ui-components/src/navigation/Breadcrumbs.tsx
+++ b/ui-components/src/navigation/Breadcrumbs.tsx
@@ -10,7 +10,7 @@ const BreadcrumbLink = (props: { href: string; children: React.ReactNode; curren
   <li>
     <LocalizedLink
       className={props.current ? "is-active" : undefined}
-      ariaProps={props.current ? { "aria-current": "page" } : undefined}
+      aria-current={props.current ? "page" : undefined}
       href={props.href}
     >
       {props.children}

--- a/ui-components/src/navigation/TabNav.tsx
+++ b/ui-components/src/navigation/TabNav.tsx
@@ -35,7 +35,7 @@ const TabNavItem = (props: TabNavItemProps) => {
     >
       <LocalizedLink
         className={props.current ? "is-active" : undefined}
-        ariaProps={props.current ? { "aria-current": "page" } : undefined}
+        aria-current={props.current ? "page" : undefined}
         href={props.href}
         tabIndex={props.current ? 0 : -1}
       >

--- a/ui-components/src/navigation/TabNav.tsx
+++ b/ui-components/src/navigation/TabNav.tsx
@@ -35,7 +35,7 @@ const TabNavItem = (props: TabNavItemProps) => {
     >
       <LocalizedLink
         className={props.current ? "is-active" : undefined}
-        aria={props.current ? { "aria-current": "page" } : undefined}
+        ariaProps={props.current ? { "aria-current": "page" } : undefined}
         href={props.href}
         tabIndex={props.current ? 0 : -1}
       >


### PR DESCRIPTION
## Issue

Addresses #1378 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

React has reserved the "aria" prop for future use. I renamed the aria prop on LocalizedLink to be `ariaProps` to avoid that naming collision, while preserving the ability to stuff that prop with any aria-related props. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [x] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Test that this works by verifying that the aria props are still being passed through to the link component as expected.

Spin up Storybook and:
- [ ] Check that the SiteHeader logo link still has the `aria-label="homepage"` prop
- [ ] Verify that the Breadcrumbs component still has the `aria-current="page"` prop on the third breadcrumb
- [ ] Verify that the "Tab-like Nav" component still has  the `aria-current="page"` prop on the active tab

## Checklist:

- [ ] My code follows the style guidelines of this project (**Not sure!**)
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view (**n/a**)
- [ ] I have reviewed the changes in a mobile view (**n/a**)
- [ ] I have commented my code, particularly in hard-to-understand areas (**n/a**)
- [ ] I have made corresponding changes to the documentation (**n/a**)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (**n/a**)
- [ ] New and existing unit tests pass locally with my changes 
- [ ] Any dependent changes have been merged and published in downstream modules (**n/a**)
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
