### PR TITLE
Add additionalApplicationSubmissionNotes migration

### DIFF
--- a/backend/core/src/listings/dto/listing.dto.ts
+++ b/backend/core/src/listings/dto/listing.dto.ts
@@ -44,11 +44,6 @@ export class ListingDto extends OmitType(Listing, [
   "result",
 ] as const) {
   @Expose()
-  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsString({ groups: [ValidationsGroupsEnum.default] })
-  additionalApplicationSubmissionNotes?: string | null
-
-  @Expose()
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => PreferenceDto)
@@ -333,11 +328,6 @@ export class ListingCreateDto extends OmitType(ListingDto, [
   "result",
 ] as const) {
   @Expose()
-  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsString({ groups: [ValidationsGroupsEnum.default] })
-  additionalApplicationSubmissionNotes?: string | null
-
-  @Expose()
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => PreferenceCreateDto)
@@ -532,11 +522,6 @@ export class ListingUpdateDto extends OmitType(ListingDto, [
   @IsDate({ groups: [ValidationsGroupsEnum.default] })
   @Type(() => Date)
   updatedAt?: Date
-
-  @Expose()
-  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsString({ groups: [ValidationsGroupsEnum.default] })
-  additionalApplicationSubmissionNotes?: string | null
 
   @Expose()
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/src/listings/entities/listing.entity.ts
+++ b/backend/core/src/listings/entities/listing.entity.ts
@@ -65,6 +65,7 @@ class Listing extends BaseEntity {
   @Type(() => Date)
   updatedAt: Date
 
+  @Column({ type: "text", nullable: true })
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsString({ groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/src/migration/1625041988613-add-additional-notes-column-to-listing.ts
+++ b/backend/core/src/migration/1625041988613-add-additional-notes-column-to-listing.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class addAdditionalNotesColumnToListing1625041988613 implements MigrationInterface {
+    name = 'addAdditionalNotesColumnToListing1625041988613'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "listings" ADD "additional_application_submission_notes" text`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "listings" DROP COLUMN "additional_application_submission_notes"`);
+    }
+
+}


### PR DESCRIPTION
Adds migration for Listing.additionalApplicationSubmissionNotes and removes field definition from DTO (it's inherited from Listing and does not require changes (?)).

NOTE: No template because it targets another PR