### PR TITLE
1331/hide eligibility header if no sections present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. The format 
   - Fix units availability ([#1397](https://github.com/bloom-housing/bloom/issues/1397))
 
 - Added:
+
   - Added "closed" to ListingStatus enum
   - Added Transform to ListingStatus field to return closed if applicationDueDate is in the past
   - Added "ohaFormat" to CSV exporter (includes OHA and HOPWA preferences) ([#1292](https://github.com/bloom-housing/bloom/pull/1292)) (Michał Plebański)
@@ -79,6 +80,7 @@ All notable changes to this project will be documented in this file. The format 
   - Fix broken application search in Partners ([#1301](https://github.com/bloom-housing/bloom/pull/1301)) (Dominik Barcikowski)
   - Fix multiple unit rows in summaries, sorting issues ([#1306](https://github.com/bloom-housing/bloom/pull/1306)) (Emily Jablonski)
   - Fix partners application submission ([#1340](https://github.com/bloom-housing/bloom/pull/1340)) (Dominik Barcikowski)
+  - Hide Additional Eligibility header if no sections present ([#1457](https://github.com/bloom-housing/bloom/pull/1457)) (Emily Jablonski)
 
 - Changed:
 

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -251,35 +251,40 @@ export const ListingView = (props: ListingProps) => {
 
             {preferencesSection}
 
-            <ListSection
-              title={t("listings.sections.additionalEligibilityTitle")}
-              subtitle={t("listings.sections.additionalEligibilitySubtitle")}
-            >
-              <>
-                {listing.creditHistory && (
-                  <InfoCard title={t("listings.creditHistory")}>
-                    <ExpandableText className="text-sm text-gray-700">
-                      {listing.creditHistory}
-                    </ExpandableText>
-                  </InfoCard>
-                )}
-                {listing.rentalHistory && (
-                  <InfoCard title={t("listings.rentalHistory")}>
-                    <ExpandableText className="text-sm text-gray-700">
-                      {listing.rentalHistory}
-                    </ExpandableText>
-                  </InfoCard>
-                )}
-                {listing.criminalBackground && (
-                  <InfoCard title={t("listings.criminalBackground")}>
-                    <ExpandableText className="text-sm text-gray-700">
-                      {listing.criminalBackground}
-                    </ExpandableText>
-                  </InfoCard>
-                )}
-                {buildingSelectionCriteria}
-              </>
-            </ListSection>
+            {(listing.creditHistory ||
+              listing.rentalHistory ||
+              listing.criminalBackground ||
+              buildingSelectionCriteria) && (
+              <ListSection
+                title={t("listings.sections.additionalEligibilityTitle")}
+                subtitle={t("listings.sections.additionalEligibilitySubtitle")}
+              >
+                <>
+                  {listing.creditHistory && (
+                    <InfoCard title={t("listings.creditHistory")}>
+                      <ExpandableText className="text-sm text-gray-700">
+                        {listing.creditHistory}
+                      </ExpandableText>
+                    </InfoCard>
+                  )}
+                  {listing.rentalHistory && (
+                    <InfoCard title={t("listings.rentalHistory")}>
+                      <ExpandableText className="text-sm text-gray-700">
+                        {listing.rentalHistory}
+                      </ExpandableText>
+                    </InfoCard>
+                  )}
+                  {listing.criminalBackground && (
+                    <InfoCard title={t("listings.criminalBackground")}>
+                      <ExpandableText className="text-sm text-gray-700">
+                        {listing.criminalBackground}
+                      </ExpandableText>
+                    </InfoCard>
+                  )}
+                  {buildingSelectionCriteria}
+                </>
+              </ListSection>
+            )}
           </ul>
         </ListingDetailItem>
 


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1331
- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Hides eligibility header if none of the sections are present.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Create a new listing in partners with none of the fields and ensure the header doesn't show.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
