### PR TITLE
Make unitsSummarized a Transform field within Listing (#259)

### DIFF
--- a/backend/core/src/listings/dto/listing.dto.ts
+++ b/backend/core/src/listings/dto/listing.dto.ts
@@ -309,12 +309,19 @@ export class ListingDto extends OmitType(Listing, [
   yearBuilt?: number | null
 
   @Expose()
-  @ApiProperty({ type: UnitsSummarized })
-  get unitsSummarized(): UnitsSummarized | undefined {
-    if (Array.isArray(this.units) && this.units.length > 0) {
-      return transformUnits(this.units as Unit[])
-    }
-  }
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => UnitsSummarized)
+  @Transform(
+    (value, obj: Listing) => {
+      const units = obj.property.units
+      if (Array.isArray(units) && units.length > 0) {
+        return transformUnits(units)
+      }
+    },
+    { toClassOnly: true }
+  )
+  unitsSummarized: UnitsSummarized | undefined
 }
 
 export class ListingCreateDto extends OmitType(ListingDto, [


### PR DESCRIPTION
## Description

This change addresses a serialization bug we ran into (https://github.com/CityOfDetroit/bloom/issues/183); TLDR serializing the response to `GET /listings` was dropping the `unitsSummarized` field.

The core difference that I believe is responsible: the Detroit response to that request is a `PaginatedListingsDto` (which wraps an array of `ListingDto`s), whereas the Exygy response is just an array of `ListingDto`s. I wasn't able to figure out why serialization was dropping `unitsSummarized` in our case, but I did discover that relying on the `Transform` decorator instead of using a getter method fixed this issue. And using `Transform` in this way seems to also match what is done for the `units` field in the `ListingDto` already. 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

I tested this using the existing `backend/core` tests.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
