### PR TITLE
Let the counselor page render if no props.

### DIFF
--- a/sites/public/pages/housing-counselors.tsx
+++ b/sites/public/pages/housing-counselors.tsx
@@ -35,7 +35,7 @@ export default class extends Component<HousingCounselorsProps> {
           subtitle={t("housingCounselors.subtitle")}
         />
         <section>
-          {this.props.counselors.map((c) => {
+          {this.props.counselors?.map((c) => {
             return (
               <article
                 key={c.name}
@@ -46,7 +46,7 @@ export default class extends Component<HousingCounselorsProps> {
               </article>
             )
           })}
-          {this.props.counselors.length == 0 && (
+          {this.props.counselors?.length == 0 && (
             <article className="flex-row flex-wrap max-w-5xl m-auto py-8 border-b-2">
               <p>{t("t.noneFound")}</p>
             </article>


### PR DESCRIPTION
## Issue

Addresses CityOfDetroit/bloom#171

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [x] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

If the getInitialProps fails, the page will fail to render. So make the
rendering optional so that at least the empty page will be able to be
displayed. Needed to get Detroit's cypress tests passing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Use the sfgov default for HOUSING_COUNSELOR_SERVICE_URL in .env. Then go to `localhost:3000/housing-counselors`.

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
