### PR TITLE
1581 - Update buttons/pages visibility depending on a user role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+### Frontend
+
+- Added:
+
+  - Update buttons / pages visibility depending on a user role ([#1609](https://github.com/bloom-housing/bloom/pull/1609)) (Dominik Barcikowski)
+
 ## v1.0.5 08/03/2021
 
 - Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Frontend
 
 - Added:
+
   - Update buttons / pages visibility depending on a user role ([#1609](https://github.com/bloom-housing/bloom/pull/1609)) (Dominik Barcikowski)
 
 - Fixed:

--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,5 @@
 {
-  "packages": [
-    "sites/public",
-    "sites/partners",
-    "backend/core",
-    "ui-components"
-  ],
+  "packages": ["sites/public", "sites/partners", "backend/core", "ui-components"],
   "version": "1.0.5",
   "npmClient": "yarn",
   "useWorkspaces": true

--- a/sites/partners/next.config.js
+++ b/sites/partners/next.config.js
@@ -42,7 +42,6 @@ module.exports = withCSS(
             idleTimeout: process.env.IDLE_TIMEOUT,
             showDuplicates: process.env.SHOW_DUPLICATES === "TRUE",
             publicBaseUrl: process.env.PUBLIC_BASE_URL,
-            showLMLinks: process.env.SHOW_LM_LINKS === "TRUE",
             cloudinaryCloudName: process.env.CLOUDINARY_CLOUD_NAME,
             cloudinaryKey: process.env.CLOUDINARY_KEY,
             cloudinarySignedPreset: process.env.CLOUDINARY_SIGNED_PRESET,

--- a/sites/partners/pages/index.tsx
+++ b/sites/partners/pages/index.tsx
@@ -20,6 +20,7 @@ import { MetaTags } from "../src/MetaTags"
 export default function ListingsList() {
   const { profile } = useContext(AuthContext)
   const leasingAgentInListings = profile.leasingAgentInListings?.map((item) => item.id)
+  const isAdmin = profile.roles.includes(UserRole.admin)
   class formatLinkCell {
     link: HTMLAnchorElement
 
@@ -80,7 +81,7 @@ export default function ListingsList() {
     const columns = [
       {
         headerName: t("listings.applications"),
-        field: process.env.showLMLinks ? "applicationCount" : "name",
+        field: isAdmin ? "applicationCount" : "name",
         sortable: false,
         filter: false,
         resizable: true,
@@ -119,7 +120,7 @@ export default function ListingsList() {
         valueFormatter: ({ value }) => t(`listings.${value}`),
       },
     ]
-    if (process.env.showLMLinks) {
+    if (isAdmin) {
       columns.unshift({
         headerName: t("listings.listingName"),
         field: "name",
@@ -130,7 +131,7 @@ export default function ListingsList() {
       })
     }
     return columns
-  }, [])
+  }, [isAdmin])
 
   const { listingDtos, listingsLoading, listingsError } = useListingsData()
   // filter listings to show items depends on user role
@@ -166,7 +167,7 @@ export default function ListingsList() {
             <div className="flex justify-between">
               <div className="w-56"></div>
               <div className="flex-row">
-                {process.env.showLMLinks && (
+                {isAdmin && (
                   <LocalizedLink href={`/listings/add`}>
                     <Button className="mx-1" onClick={() => false}>
                       {t("listings.addListing")}

--- a/sites/partners/pages/listings/[id]/edit.tsx
+++ b/sites/partners/pages/listings/[id]/edit.tsx
@@ -31,7 +31,7 @@ const EditListing = () => {
 
   return (
     <ListingContext.Provider value={listingDto}>
-      <ListingGuard listingId={listingId}>
+      <ListingGuard>
         <Layout>
           <Head>
             <title>{t("nav.siteTitlePartners")}</title>

--- a/sites/partners/pages/listings/[id]/edit.tsx
+++ b/sites/partners/pages/listings/[id]/edit.tsx
@@ -7,6 +7,7 @@ import PaperListingForm from "../../../src/listings/PaperListingForm"
 import { useSingleListingData } from "../../../lib/hooks"
 import { ListingContext } from "../../../src/listings/ListingContext"
 import { MetaTags } from "../../../src/MetaTags"
+import ListingGuard from '../../../src/ListingGuard'
 
 const EditListing = () => {
   const metaDescription = ""
@@ -30,31 +31,33 @@ const EditListing = () => {
 
   return (
     <ListingContext.Provider value={listingDto}>
-      <Layout>
-        <Head>
-          <title>{t("nav.siteTitlePartners")}</title>
-        </Head>
+      <ListingGuard listingId={listingId}>
+        <Layout>
+          <Head>
+            <title>{t("nav.siteTitlePartners")}</title>
+          </Head>
 
-        <MetaTags
-          title={t("nav.siteTitlePartners")}
-          image={metaImage}
-          description={metaDescription}
-        />
+          <MetaTags
+            title={t("nav.siteTitlePartners")}
+            image={metaImage}
+            description={metaDescription}
+          />
 
-        <PageHeader
-          title={
-            <>
-              <p className="font-sans font-semibold uppercase text-3xl">
-                {t("t.edit")}: {listingDto.name}
-              </p>
+          <PageHeader
+            title={
+              <>
+                <p className="font-sans font-semibold uppercase text-3xl">
+                  {t("t.edit")}: {listingDto.name}
+                </p>
 
-              <p className="font-sans text-base mt-1">{listingDto.id}</p>
-            </>
-          }
-        />
+                <p className="font-sans text-base mt-1">{listingDto.id}</p>
+              </>
+            }
+          />
 
-        <PaperListingForm listing={listingDto} editMode />
-      </Layout>
+          <PaperListingForm listing={listingDto} editMode />
+        </Layout>
+      </ListingGuard>
     </ListingContext.Provider>
   )
 }

--- a/sites/partners/pages/listings/[id]/index.tsx
+++ b/sites/partners/pages/listings/[id]/index.tsx
@@ -70,7 +70,7 @@ export default function ApplicationsList() {
 
   return (
     <ListingContext.Provider value={listingDto}>
-      <ListingGuard listingId={listingId}>
+      <ListingGuard>
         <>
           <Layout>
           <Head>

--- a/sites/partners/pages/listings/[id]/index.tsx
+++ b/sites/partners/pages/listings/[id]/index.tsx
@@ -13,6 +13,7 @@ import {
 import { ListingStatus } from "@bloom-housing/backend-core/types"
 import { useSingleListingData } from "../../../lib/hooks"
 
+import ListingGuard from '../../../src/ListingGuard'
 import Layout from "../../../layouts"
 import Aside from "../../../src/listings/Aside"
 import { ListingContext } from "../../../src/listings/ListingContext"
@@ -69,76 +70,81 @@ export default function ApplicationsList() {
 
   return (
     <ListingContext.Provider value={listingDto}>
-      <Layout>
-        <Head>
-          <title>{t("nav.siteTitlePartners")}</title>
-        </Head>
+      <ListingGuard listingId={listingId}>
+        <>
+          <Layout>
+          <Head>
+            <title>{t("nav.siteTitlePartners")}</title>
+          </Head>
 
-        <PageHeader
-          className="relative"
-          title={
-            <>
-              <p className="font-sans font-semibold uppercase text-3xl">{listingDto.name}</p>
+          <PageHeader
+            className="relative"
+            title={
+              <>
+                <p className="font-sans font-semibold uppercase text-3xl">{listingDto.name}</p>
 
-              <p className="font-sans text-base mt-1">{listingDto.id}</p>
-            </>
-          }
-        >
-          <div className="flex top-4 right-4 absolute z-50 flex-col items-center">
-            <SiteAlert type="success" timeout={5000} dismissable />
-          </div>
-        </PageHeader>
-        <section className="border-t bg-white">
-          <div className="flex flex-row w-full mx-auto max-w-screen-xl justify-between px-5 items-center my-3">
-            <Button inlineIcon="left" icon="arrowBack" onClick={() => router.push("/")}>
-              {t("t.back")}
-            </Button>
+                <p className="font-sans text-base mt-1">{listingDto.id}</p>
+              </>
+            }
+          >
+            <div className="flex top-4 right-4 absolute z-50 flex-col items-center">
+              <SiteAlert type="success" timeout={5000} dismissable />
+            </div>
+          </PageHeader>
+          <section className="border-t bg-white">
+            <div className="flex flex-row w-full mx-auto max-w-screen-xl justify-between px-5 items-center my-3">
+              <Button inlineIcon="left" icon="arrowBack" onClick={() => router.push("/")}>
+                {t("t.back")}
+              </Button>
 
-            <div className="status-bar__status md:pl-4 md:w-3/12">{listingStatus}</div>
-          </div>
-        </section>
+              <div className="status-bar__status md:pl-4 md:w-3/12">{listingStatus}</div>
+            </div>
+          </section>
 
-        <section className="bg-primary-lighter">
-          <div className="mx-auto px-5 mt-5 max-w-screen-xl">
-            {errorAlert && (
-              <AlertBox
-                className="mb-5"
-                onClose={() => setErrorAlert(false)}
-                closeable
-                type="alert"
-              >
-                {t("authentication.signIn.errorGenericMessage")}
-              </AlertBox>
-            )}
+          <section className="bg-primary-lighter">
+            <div className="mx-auto px-5 mt-5 max-w-screen-xl">
+              {errorAlert && (
+                <AlertBox
+                  className="mb-5"
+                  onClose={() => setErrorAlert(false)}
+                  closeable
+                  type="alert"
+                >
+                  {t("authentication.signIn.errorGenericMessage")}
+                </AlertBox>
+              )}
 
-            <div className="flex flex-row flex-wrap ">
-              <div className="info-card md:w-9/12">
-                <DetailListingData />
-                <DetailListingIntro />
-                <DetailListingPhoto />
-                <DetailBuildingDetails />
-                <DetailCommunityType />
-                <DetailUnits setUnitDrawer={setUnitDrawer} />
-                <DetailPreferences />
-                <DetailAdditionalFees />
-                <DetailBuildingFeatures />
-                <DetailAdditionalEligibility />
-                <DetailAdditionalDetails />
-                <DetailRankingsAndResults />
-                <DetailLeasingAgent />
-                <DetailApplicationAddress />
-                <DetailApplicationDates />
-              </div>
+              <div className="flex flex-row flex-wrap ">
+                <div className="info-card md:w-9/12">
+                  <DetailListingData />
+                  <DetailListingIntro />
+                  <DetailListingPhoto />
+                  <DetailBuildingDetails />
+                  <DetailCommunityType />
+                  <DetailUnits setUnitDrawer={setUnitDrawer} />
+                  <DetailPreferences />
+                  <DetailAdditionalFees />
+                  <DetailBuildingFeatures />
+                  <DetailAdditionalEligibility />
+                  <DetailAdditionalDetails />
+                  <DetailRankingsAndResults />
+                  <DetailLeasingAgent />
+                  <DetailApplicationAddress />
+                  <DetailApplicationDates />
+                </div>
 
-              <div className="md:w-3/12 pl-6">
-                <Aside type="details" />
+                <div className="md:w-3/12 pl-6">
+                  <Aside type="details" />
+                </div>
               </div>
             </div>
-          </div>
-        </section>
-      </Layout>
+          </section>
+        </Layout>
 
-      <DetailUnitDrawer unit={unitDrawer} setUnitDrawer={setUnitDrawer} />
+        <DetailUnitDrawer unit={unitDrawer} setUnitDrawer={setUnitDrawer} />
+        </>
+      </ListingGuard>
+
     </ListingContext.Provider>
   )
 }

--- a/sites/partners/pages/listings/add.tsx
+++ b/sites/partners/pages/listings/add.tsx
@@ -4,30 +4,34 @@ import { PageHeader, SiteAlert, t } from "@bloom-housing/ui-components"
 import Layout from "../../layouts"
 import PaperListingForm from "../../src/listings/PaperListingForm"
 import { MetaTags } from "../../src/MetaTags"
+import ListingGuard from '../../src/ListingGuard'
 
 const NewListing = () => {
   const metaDescription = ""
   const metaImage = "" // TODO: replace with hero image
 
   return (
-    <Layout>
-      <Head>
-        <title>{t("nav.siteTitlePartners")}</title>
-      </Head>
-      <MetaTags
-        title={t("nav.siteTitlePartners")}
-        image={metaImage}
-        description={metaDescription}
-      />
+    <ListingGuard>
+      <Layout>
+        <Head>
+          <title>{t("nav.siteTitlePartners")}</title>
+        </Head>
+        <MetaTags
+          title={t("nav.siteTitlePartners")}
+          image={metaImage}
+          description={metaDescription}
+        />
 
-      <PageHeader className="relative" title={t("listings.newListing")}>
-        <div className="flex top-4 right-4 absolute z-50 flex-col items-center">
-          <SiteAlert type="success" timeout={5000} dismissable />
-        </div>
-      </PageHeader>
+        <PageHeader className="relative" title={t("listings.newListing")}>
+          <div className="flex top-4 right-4 absolute z-50 flex-col items-center">
+            <SiteAlert type="success" timeout={5000} dismissable />
+          </div>
+        </PageHeader>
 
-      <PaperListingForm />
-    </Layout>
+        <PaperListingForm />
+      </Layout>
+    </ListingGuard>
+
   )
 }
 

--- a/sites/partners/src/ListingGuard.tsx
+++ b/sites/partners/src/ListingGuard.tsx
@@ -1,0 +1,25 @@
+import React, { useContext } from "react"
+import {
+  AuthContext,
+} from "@bloom-housing/ui-components"
+import { UserRole } from "@bloom-housing/backend-core/types"
+
+type AuthGuardProps = {
+  listingId?: string;
+  children: React.ReactElement;
+}
+
+const ListingGuard = ({ listingId, children }: AuthGuardProps) => {
+  const { profile } = useContext(AuthContext)
+
+  const leasingAgentInListingsIds = profile.leasingAgentInListings.map(item => item.id)
+  const hasPrivileges = profile.roles.includes(UserRole.admin) || leasingAgentInListingsIds.includes(listingId)
+
+  if (hasPrivileges) {
+    return children
+  }
+
+  return null
+}
+
+export { ListingGuard as default, ListingGuard }

--- a/sites/partners/src/ListingGuard.tsx
+++ b/sites/partners/src/ListingGuard.tsx
@@ -1,15 +1,18 @@
 import React, { useContext } from "react"
+import { useRouter } from "next/router"
 import {
   AuthContext,
 } from "@bloom-housing/ui-components"
 import { UserRole } from "@bloom-housing/backend-core/types"
 
 type AuthGuardProps = {
-  listingId?: string;
   children: React.ReactElement;
 }
 
-const ListingGuard = ({ listingId, children }: AuthGuardProps) => {
+const ListingGuard = ({ children }: AuthGuardProps) => {
+  const router = useRouter()
+  const listingId = router.query.id as string
+
   const { profile } = useContext(AuthContext)
 
   const leasingAgentInListingsIds = profile.leasingAgentInListings.map(item => item.id)


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1581 (issue)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

In this PR:
- Added a new `ListingGuard` component to show listing pages (add, details, edit) for admins and allowed leasing agents
- Removed `SHOW_LM_LINKS ` environment variable
- Updated 'Add listing' button to be visible for admin users only

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Admin:
1. Log in as an admin user
2. Check if on the main page the "Add listing" button is visible
3. Check if you can add/edit listing

User:
1. Log in as a user
2. Check if on the main page the "Add listing" button is hidden
3. Check if you can add/edit listing which is no assigned to the logged user (you shouldn't)

User (with assigned listing):
1. Log in as a user
2. Check if on the main page the "Add listing" button is hidden
3. Choose a listing where the currently logged user is a leasing agent
3. Check if you can add/edit listing

- [x] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
