### PR TITLE
Add support for comma-separated lists to filters, ensure comparison is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. The format 
 
   - Filtering, pagination, and tests for listings endpoint (Parts of Detroit Team [#18](https://github.com/CityOfDetroit/bloom/pull/18), [#133](https://github.com/CityOfDetroit/bloom/pull/133), [#180](https://github.com/CityOfDetroit/bloom/pull/180), [#257](https://github.com/CityOfDetroit/bloom/pull/257), [#264](https://github.com/CityOfDetroit/bloom/pull/264), [#271](https://github.com/CityOfDetroit/bloom/pull/271)) [#1578](https://github.com/CityOfDetroit/bloom/pull/1578)
   - Units summary table ([#1607](https://github.com/bloom-housing/bloom/pull/1607))
+  - Add support for comma-separated lists to filters, ensure comparison is valid ([Detroit Team #356](https://github.com/CityOfDetroit/bloom/pull/356), [#1634](https://github.com/bloom-housing/bloom/pull/1634))
 
 - Changed:
 

--- a/backend/core/src/shared/dto/filter.dto.ts
+++ b/backend/core/src/shared/dto/filter.dto.ts
@@ -5,6 +5,7 @@ import { Expose } from "class-transformer"
 export enum Compare {
   "=" = "=",
   "<>" = "<>",
+  "IN" = "IN",
 }
 
 export class BaseFilter {


### PR DESCRIPTION
# Pull Request Template

## Issue
Add support for IN comparison for lists

Addresses CityOfDetroit/bloom#255 

- [x] This change addresses the issue in full

## Description
Add support for commas-separated lists to filters. Also ensures that provided comparison is valid.
- Adds an `IN` comparison type
- If the filter specifies an `IN` comparison, treat the filter value as a comma-separated list
- Handles if there are extra commas and spaces between the commas and the value
- Add tests to listings service spec. (We should also start writing tests for the addFilters code itself)
- Adds switch statement to `addFilters()` to ensure that the provided comparison is a valid one

In the future we may want to add validation to the `$comparison` FilterParam, but this works well for now.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [x] Returns 2: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster%20City,Coliseum,`
- [x] Returns 1: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster%20City`
- [x] Returns 2: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster%20City, Coliseum,  ,`
- [x] Returns 2: `http://localhost:3100/listings?filter[$comparison]=IN&filter[neighborhood]=Foster City, Coliseum. ,`
- [x] Returns a 400 error `http://localhost:3100/listings?filter[$comparison]=fake%20comparison&filter[neighborhood]=Foster%20City`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
