### PR TITLE
1630/preferences order bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Fixed:
   - Update Listings component to sort listings by status ([#1585](https://github.com/bloom-housing/bloom/pull/1585))
+  - Preferences ordinal bug in listings management ([#1641](https://github.com/bloom-housing/bloom/pull/1641)) (Emily Jablonski)
 
 ### UI Components
 

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -407,7 +407,7 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
           status,
         }
         const orderedPreferences = preferences.map((pref, index) => {
-          return { ...pref, ordinal: index }
+          return { ...pref, ordinal: index + 1 }
         })
         const formattedData = formatFormData(data, units, openHouseEvents, orderedPreferences)
         const result = editMode


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1630

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Check the issue for screenshots :)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Add a new listing in partners with 2 preferences, preview the listing, ensure the ordinal numbers are `1st` and `2nd`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
