### PR TITLE
Add limit all to listings call on partners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Fixed:
   - Added checks for property in listing.dto transforms
+  - Display all listings on partners with `limit=all` ([#1635](https://github.com/bloom-housing/bloom/issues/1635)) (Marcin Jędras)
 
 ## v1.0.5 08/03/2021
 

--- a/sites/partners/lib/hooks.ts
+++ b/sites/partners/lib/hooks.ts
@@ -28,7 +28,7 @@ export function useSingleListingData(listingId: string) {
 
 export function useListingsData() {
   const { listingsService } = useContext(AuthContext)
-  const fetcher = () => listingsService.list()
+  const fetcher = () => listingsService.list({ limit: "all" })
 
   const { data, error } = useSWR(`${process.env.backendApiBase}/listings?limit=all`, fetcher)
 


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1635 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Only first 10 listings were showing up on partners. Pagination is not yet enabled on that page and `limit=all` was only enable for stale cache.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
