### PR TITLE
1663/when seeding data, create application methods unique to each listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file. The format 
 - Fixed:
   - Added checks for property in listing.dto transforms
   - Display all listings on partners with `limit=all` ([#1635](https://github.com/bloom-housing/bloom/issues/1635)) (Marcin Jędras)
+  - Seed data should create unique application methods ([#1662](https://github.com/bloom-housing/bloom/issues/1662)) (Emily Jablonski)
 
 ## v1.0.5 08/03/2021
 

--- a/backend/core/scripts/listings-importer.ts
+++ b/backend/core/scripts/listings-importer.ts
@@ -36,6 +36,8 @@ const authService = new client.AuthService()
 const amiChartService = new client.AmiChartsService()
 const unitTypesService = new client.UnitTypesService()
 const unitAccessibilityPriorityTypesService = new client.UnitAccessibilityPriorityTypesService()
+const applicationMethodsService = new client.ApplicationMethodsService()
+const reservedCommunityTypesService = new client.ReservedCommunityTypesService()
 
 async function uploadEntity(entityKey, entityService, listing) {
   const newRecordsIds = await Promise.all(
@@ -144,11 +146,14 @@ async function main() {
   })
   const unitTypes = await unitTypesService.list()
   const priorityTypes = await unitAccessibilityPriorityTypesService.list()
+  const reservedCommunityTypes = await reservedCommunityTypesService.list()
 
   let listing = JSON.parse(fs.readFileSync(listingFilePath, "utf-8"))
   const relationsKeys = []
   listing = reformatListing(listing, relationsKeys)
   listing = await uploadEntity("preferences", preferencesService, listing)
+  listing = await uploadEntity("applicationMethods", applicationMethodsService, listing)
+  listing.reservedCommunityType = findByName(reservedCommunityTypes, listing.reservedCommunityType)
 
   const amiChartName = listing.amiChart.name
   let chart = await getAmiChart(amiChartName)

--- a/backend/core/src/application-methods/dto/application-method.dto.ts
+++ b/backend/core/src/application-methods/dto/application-method.dto.ts
@@ -7,7 +7,6 @@ import { PaperApplicationDto } from "../../paper-applications/dto/paper-applicat
 import { IdDto } from "../../shared/dto/id.dto"
 
 export class ApplicationMethodDto extends OmitType(ApplicationMethod, [
-  "listing",
   "paperApplications",
 ] as const) {
   @Expose()

--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -20,9 +20,6 @@ import { ListingTritonSeed } from "./seeds/listings/listing-triton-seed"
 import { ListingDefaultBmrChartSeed } from "./seeds/listings/listing-default-bmr-chart-seed"
 import { ApplicationMethodsService } from "./application-methods/application-methods.service"
 import { ApplicationMethodType } from "./application-methods/types/application-method-type-enum"
-import { PaperApplicationsService } from "./paper-applications/paper-applications.service"
-import { Language } from "./shared/types/language-enum"
-import { AssetsService } from "./assets/services/assets.service"
 import { AuthContext } from "./auth/types/auth-context"
 import { ListingDefaultReservedSeed } from "./seeds/listings/listing-default-reserved-seed"
 import { ListingDefaultFCFSSeed } from "./seeds/listings/listing-default-fcfs-seed"
@@ -64,52 +61,29 @@ export async function createLeasingAgents(app: INestApplicationContext) {
   return leasingAgents
 }
 
-async function createApplicationMethods(app: INestApplicationContext) {
-  const assetsService = await app.resolve<AssetsService>(AssetsService)
-  const englishFileAsset = await assetsService.create({
-    fileId: "englishFileId",
-    label: "English paper application",
-  })
-  const paperApplicationsService = await app.resolve<PaperApplicationsService>(
-    PaperApplicationsService
-  )
-  const englishPaperApplication = await paperApplicationsService.create({
-    language: Language.en,
-    file: englishFileAsset,
-  })
-  const applicationMethodsService = await app.resolve<ApplicationMethodsService>(
-    ApplicationMethodsService
-  )
-
-  await applicationMethodsService.create({
-    type: ApplicationMethodType.FileDownload,
-    acceptsPostmarkedApplications: false,
-    externalReference: "https://bit.ly/2wH6dLF",
-    label: "English",
-    paperApplications: [englishPaperApplication],
-  })
-
-  await applicationMethodsService.create({
-    type: ApplicationMethodType.Internal,
-    acceptsPostmarkedApplications: false,
-    externalReference: "",
-    label: "Label",
-    paperApplications: [],
-  })
-}
-
 const seedListings = async (app: INestApplicationContext) => {
   const seeds = []
   const leasingAgents = await createLeasingAgents(app)
-  await createApplicationMethods(app)
 
   const allSeeds = listingSeeds.map((listingSeed) => app.get<ListingDefaultSeed>(listingSeed))
   const listingRepository = app.get<Repository<Listing>>(getRepositoryToken(Listing))
+  const applicationMethodsService = await app.resolve<ApplicationMethodsService>(
+    ApplicationMethodsService
+  )
 
   for (const [index, listingSeed] of allSeeds.entries()) {
     const everyOtherAgent = index % 2 ? leasingAgents[0] : leasingAgents[1]
     const listing = await listingSeed.seed()
     listing.leasingAgents = [everyOtherAgent]
+    const applicationMethods = await applicationMethodsService.create({
+      type: ApplicationMethodType.Internal,
+      acceptsPostmarkedApplications: false,
+      externalReference: "",
+      label: "Label",
+      paperApplications: [],
+      listing: listing,
+    })
+    listing.applicationMethods = [applicationMethods]
     await listingRepository.save(listing)
 
     seeds.push(listing)

--- a/backend/core/src/seeds/listings/listing-coliseum-seed.ts
+++ b/backend/core/src/seeds/listings/listing-coliseum-seed.ts
@@ -15,7 +15,6 @@ import { Listing } from "../../listings/entities/listing.entity"
 import { BaseEntity, DeepPartial } from "typeorm"
 import { UnitCreateDto } from "../../units/dto/unit.dto"
 import { ListingDefaultSeed } from "./listing-default-seed"
-import { ApplicationMethodType } from "../../application-methods/types/application-method-type-enum"
 import { UnitStatus } from "../../units/types/unit-status-enum"
 
 const coliseumProperty: PropertySeedType = {
@@ -1011,9 +1010,6 @@ export class ListingColiseumSeed extends ListingDefaultSeed {
     }
 
     await this.unitsRepository.save(unitsToBeCreated)
-    const applicationMethods = await this.applicationMethodRepository.find({
-      type: ApplicationMethodType.Internal,
-    })
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,
@@ -1027,7 +1023,6 @@ export class ListingColiseumSeed extends ListingDefaultSeed {
         { ...getPbvPreference(), ordinal: 2, page: 2 },
         { ...getHopwaPreference(), ordinal: 3, page: 3 },
       ],
-      applicationMethods: applicationMethods,
       events: [],
     }
 

--- a/backend/core/src/seeds/listings/listing-default-seed.ts
+++ b/backend/core/src/seeds/listings/listing-default-seed.ts
@@ -21,7 +21,6 @@ import {
   getLiveWorkPreference,
 } from "./shared"
 import { ApplicationMethod } from "../../application-methods/entities/application-method.entity"
-import { ApplicationMethodType } from "../../application-methods/types/application-method-type-enum"
 
 export class ListingDefaultSeed {
   constructor(
@@ -69,11 +68,7 @@ export class ListingDefaultSeed {
     unitsToBeCreated[1].priorityType = priorityTypeMobilityAndHearing
     unitsToBeCreated[0].unitType = unitTypeOneBdrm
     unitsToBeCreated[1].unitType = unitTypeTwoBdrm
-
     await this.unitsRepository.save(unitsToBeCreated)
-    const applicationMethods = await this.applicationMethodRepository.find({
-      type: ApplicationMethodType.Internal,
-    })
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,
@@ -84,7 +79,6 @@ export class ListingDefaultSeed {
       property: property,
       assets: getDefaultAssets(),
       preferences: [getLiveWorkPreference(), { ...getDisplaceePreference(), ordinal: 2 }],
-      applicationMethods: applicationMethods,
       events: getDefaultListingEvents(),
     }
 

--- a/backend/core/src/seeds/listings/listing-triton-seed.ts
+++ b/backend/core/src/seeds/listings/listing-triton-seed.ts
@@ -4,7 +4,6 @@ import { getDefaultAmiChart, getDate, getDefaultAssets, getLiveWorkPreference } 
 import { ListingStatus } from "../../listings/types/listing-status-enum"
 import { CountyCode } from "../../shared/types/county-code"
 import { CSVFormattingType } from "../../csv/types/csv-formatting-type-enum"
-import { ApplicationMethodType } from "../../application-methods/types/application-method-type-enum"
 import { AmiChart } from "../../ami-charts/entities/ami-chart.entity"
 import { ListingDefaultSeed } from "./listing-default-seed"
 import { UnitCreateDto } from "../../units/dto/unit.dto"
@@ -782,9 +781,6 @@ export class ListingTritonSeed extends ListingDefaultSeed {
     unitsToBeCreated[4].unitType = unitTypeOneBdrm
 
     await this.unitsRepository.save(unitsToBeCreated)
-    const applicationMethods = await this.applicationMethodRepository.find({
-      type: ApplicationMethodType.FileDownload,
-    })
 
     const listingCreateDto: Omit<
       DeepPartial<Listing>,
@@ -794,7 +790,6 @@ export class ListingTritonSeed extends ListingDefaultSeed {
       property: property,
       assets: getDefaultAssets(),
       preferences: [getLiveWorkPreference()],
-      applicationMethods: applicationMethods,
       events: [],
     }
 

--- a/backend/core/test/listings/listings.e2e-spec.ts
+++ b/backend/core/test/listings/listings.e2e-spec.ts
@@ -16,6 +16,7 @@ import { PaperApplicationsModule } from "../../src/paper-applications/paper-appl
 import { ListingEventCreateDto } from "../../src/listings/dto/listing-event.dto"
 import { ListingEventType } from "../../src/listings/types/listing-event-type-enum"
 import { getSeedListingsCount } from "../../src/seed"
+import { Listing } from "../../src/listings/entities/listing.entity"
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const dbOptions = require("../../ormconfig.test")
@@ -152,7 +153,7 @@ describe("Listings", () => {
   it("should add/overwrite application methods in existing listing", async () => {
     const res = await supertest(app.getHttpServer()).get("/listings").expect(200)
 
-    const listing: ListingUpdateDto = { ...res.body.items[0] }
+    const listing: Listing = { ...res.body.items[0] }
 
     const adminAccessToken = await getUserAccessToken(app, "admin@example.com", "abcdef")
 
@@ -176,6 +177,7 @@ describe("Listings", () => {
     const am: ApplicationMethodCreateDto = {
       type: ApplicationMethodType.FileDownload,
       paperApplications: [{ id: paperApplication.body.id }],
+      listing: listing,
     }
 
     const applicationMethod = await supertest(app.getHttpServer())


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1663

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

With the changes to application methods, our seed data listings now need to uniquely create application methods tied to each specific listing. The bug we were visually seeing was that only one of our seed data listings had `Apply Online` showing when they should all show `Apply Online` because only one listing had the `Internal` application method tied to it.

I also updated the listings importer to properly add application methods (and fixed an existing bug around reserved community type).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Re-seed the database and check the listings for `Apply Online`, as well as importing a new listing with the `Internal` application method and a `reservedCommunityType`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
