### PR TITLE
Contribute/Hide applicationStatus footer

### DIFF
--- a/ui-components/src/page_components/listing/ListingsList.tsx
+++ b/ui-components/src/page_components/listing/ListingsList.tsx
@@ -13,6 +13,7 @@ import "./ListingsList.scss"
 
 export interface ListingsProps {
   listings: Listing[]
+  hideApplicationStatus?: boolean
 }
 
 const ListingsList = (props: ListingsProps) => {
@@ -78,7 +79,7 @@ const ListingsList = (props: ListingsProps) => {
             subtitle={subtitle}
             imageUrl={imageUrl}
             href={`/listing/${listing.id}/${listing.urlSlug}`}
-            appStatus={appStatus}
+            appStatus={props.hideApplicationStatus ? undefined : appStatus}
             appStatusContent={content}
             tagLabel={
               listing.reservedCommunityType


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses # (issue)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Removes "Application Due" footer from Listings view. This update creates a hideApplicationStatus prop for ListingsList to hide the footer when needed. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Check the listings page to see if the footer is present or note.
In your local/test Listings.tsx, remove the hideApplicationStatus flag from line 163 to re-enable the "Application Due" footer.

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
