### PR TITLE
Add two lines to the LeasingAgent UI component to display information about the listing management company

### DIFF
--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -370,13 +370,7 @@ export const ListingView = (props: ListingProps) => {
             )}
             {lotterySection}
             <WhatToExpect listing={listing} />
-            <LeasingAgent
-              listing={listing}
-              managementCompany={{
-                name: listing.managementCompany,
-                website: listing.managementWebsite,
-              }}
-            />
+            <LeasingAgent listing={listing} />
           </aside>
         </ListingDetailItem>
 

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -370,7 +370,13 @@ export const ListingView = (props: ListingProps) => {
             )}
             {lotterySection}
             <WhatToExpect listing={listing} />
-            <LeasingAgent listing={listing} />
+            <LeasingAgent
+              listing={listing}
+              managementCompany={{
+                name: listing.managementCompany,
+                website: listing.managementWebsite,
+              }}
+            />
           </aside>
         </ListingDetailItem>
 

--- a/ui-components/__tests__/page_components/LeasingAgent.test.tsx
+++ b/ui-components/__tests__/page_components/LeasingAgent.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup } from "@testing-library/react"
+import { render, cleanup, queryByText } from "@testing-library/react"
 import { LeasingAgent } from "../../src/page_components/listing/listing_sidebar/LeasingAgent"
 import { ArcherListing } from "@bloom-housing/backend-core/types/src/archer-listing"
 import { Listing } from "@bloom-housing/backend-core/types"
@@ -30,5 +30,32 @@ describe("<LeasingAgent>", () => {
     expect(
       listing.leasingAgentOfficeHours && queryByText(listing.leasingAgentOfficeHours)
     ).toBeNull()
+  })
+  it("shows management company details if managementCompany is present", () => {
+    const listing = Object.assign({}, ArcherListing) as Listing
+    const managementCompany = "Some Management Company"
+    const managementWebsite = "a fake management website url"
+
+    // No managementCompany prop
+    {
+      const { queryByText } = render(<LeasingAgent listing={listing} />)
+      expect(queryByText(managementCompany)).toBeNull()
+      expect(queryByText("Website")).toBeNull()
+    }
+
+    // With managementCompany prop --> management company info is displayed
+    {
+      const { getByText } = render(
+        <LeasingAgent
+          listing={listing}
+          managementCompany={{
+            name: managementCompany,
+            website: managementWebsite,
+          }}
+        />
+      )
+      expect(getByText(managementCompany)).toBeTruthy()
+      expect(getByText("Website")).toBeTruthy()
+    }
   })
 })

--- a/ui-components/__tests__/page_components/LeasingAgent.test.tsx
+++ b/ui-components/__tests__/page_components/LeasingAgent.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, queryByText } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { LeasingAgent } from "../../src/page_components/listing/listing_sidebar/LeasingAgent"
 import { ArcherListing } from "@bloom-housing/backend-core/types/src/archer-listing"
 import { Listing } from "@bloom-housing/backend-core/types"
@@ -31,31 +31,30 @@ describe("<LeasingAgent>", () => {
       listing.leasingAgentOfficeHours && queryByText(listing.leasingAgentOfficeHours)
     ).toBeNull()
   })
-  it("shows management company details if managementCompany is present", () => {
+  it("does not show management company details if managementCompany prop is absent", () => {
+    const listing = Object.assign({}, ArcherListing) as Listing
+    const managementCompany = "Some Management Company"
+
+    const { queryByText } = render(<LeasingAgent listing={listing} />)
+    expect(queryByText(managementCompany)).toBeNull()
+    expect(queryByText("Website")).toBeNull()
+  })
+  it("shows management company details if managementCompany prop is present", () => {
     const listing = Object.assign({}, ArcherListing) as Listing
     const managementCompany = "Some Management Company"
     const managementWebsite = "a fake management website url"
 
-    // No managementCompany prop
-    {
-      const { queryByText } = render(<LeasingAgent listing={listing} />)
-      expect(queryByText(managementCompany)).toBeNull()
-      expect(queryByText("Website")).toBeNull()
-    }
+    const { getByText } = render(
+      <LeasingAgent
+        listing={listing}
+        managementCompany={{
+          name: managementCompany,
+          website: managementWebsite,
+        }}
+      />
+    )
+    expect(getByText(managementCompany)).toBeTruthy()
+    expect(getByText("Website")).toBeTruthy()
 
-    // With managementCompany prop --> management company info is displayed
-    {
-      const { getByText } = render(
-        <LeasingAgent
-          listing={listing}
-          managementCompany={{
-            name: managementCompany,
-            website: managementWebsite,
-          }}
-        />
-      )
-      expect(getByText(managementCompany)).toBeTruthy()
-      expect(getByText("Website")).toBeTruthy()
-    }
   })
 })

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1250,6 +1250,7 @@
     "view": "View",
     "viewMap": "View Map",
     "viewOnMap": "View on Map",
+    "website": "Website",
     "year": "Year",
     "yes": "Yes",
     "you": "You"

--- a/ui-components/src/locales/general_OLD.json
+++ b/ui-components/src/locales/general_OLD.json
@@ -843,6 +843,7 @@
     "unitFeatures": "Unit Features",
     "unitType": "Unit Type",
     "viewOnMap": "View on Map",
+    "website": "Website",
     "year": "Year",
     "yes": "Yes",
     "you": "You"

--- a/ui-components/src/locales/vi.json
+++ b/ui-components/src/locales/vi.json
@@ -726,6 +726,7 @@
     "unitType": "Loại Căn nhà",
     "viewMap": "Xem Bản đồ",
     "viewOnMap": "Xem trên Bản đồ",
+    "website": "Trang mạng",
     "year": "Năm",
     "yes": "Có",
     "you": "Quý vị"

--- a/ui-components/src/locales/zh.json
+++ b/ui-components/src/locales/zh.json
@@ -726,6 +726,7 @@
     "unitType": "單位類型",
     "viewMap": "檢視地圖",
     "viewOnMap": "在地圖上檢視",
+    "website": "网站",
     "year": "年",
     "yes": "是",
     "you": "您"

--- a/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
@@ -56,23 +56,21 @@ const LeasingAgent = (props: LeasingAgentProps) => {
         </p>
       )}
 
+      {props.managementCompany?.website && (
+        <div className="my-5">
+          {managementWebsite && (
+            <a href={managementWebsite} target="_blank" rel="noreferrer noopener">
+              <Icon symbol="globe" size="medium" fill={IconFillColors.primary} /> {t("t.website")}
+            </a>
+          )}
+        </div>
+      )}
+
       {listing.leasingAgentAddress && (
         <SidebarAddress
           address={listing.leasingAgentAddress}
           officeHours={listing.leasingAgentOfficeHours}
         />
-      )}
-
-      {props.managementCompany?.website && (
-        <>
-          <div className="mt-5">
-            {managementWebsite && (
-              <a href={managementWebsite} target="_blank" rel="noreferrer noopener">
-                <Icon symbol="globe" size="medium" fill={IconFillColors.primary} /> {t("t.website")}
-              </a>
-            )}
-          </div>
-        </>
       )}
     </section>
   )

--- a/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
@@ -56,14 +56,12 @@ const LeasingAgent = (props: LeasingAgentProps) => {
         </p>
       )}
 
-      {props.managementCompany?.website && (
-        <div className="my-5">
-          {managementWebsite && (
-            <a href={managementWebsite} target="_blank" rel="noreferrer noopener">
-              <Icon symbol="globe" size="medium" fill={IconFillColors.primary} /> {t("t.website")}
-            </a>
-          )}
-        </div>
+      {managementWebsite && (
+        <p className="my-5">
+          <a href={managementWebsite} target="_blank" rel="noreferrer noopener">
+            <Icon symbol="globe" size="medium" fill={IconFillColors.primary} /> {t("t.website")}
+          </a>
+        </p>
       )}
 
       {listing.leasingAgentAddress && (

--- a/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
@@ -32,6 +32,9 @@ const LeasingAgent = (props: LeasingAgentProps) => {
 
       {listing.leasingAgentName && <p className="text-xl">{listing.leasingAgentName}</p>}
       {listing.leasingAgentTitle && <p className="text-gray-700">{listing.leasingAgentTitle}</p>}
+      {props.managementCompany?.name && (
+        <p className="text-gray-700">{props.managementCompany.name}</p>
+      )}
 
       {listing.leasingAgentPhone && (
         <>
@@ -60,10 +63,9 @@ const LeasingAgent = (props: LeasingAgentProps) => {
         />
       )}
 
-      {props.managementCompany && (
+      {props.managementCompany?.website && (
         <>
           <div className="mt-5">
-            <p>{props.managementCompany.name}</p>
             {managementWebsite && (
               <a href={managementWebsite} target="_blank" rel="noreferrer noopener">
                 <Icon symbol="globe" size="medium" fill={IconFillColors.primary} /> {t("t.website")}

--- a/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/LeasingAgent.tsx
@@ -7,6 +7,7 @@ import { openDateState } from "../../../helpers/state"
 
 interface LeasingAgentProps {
   listing: Listing
+  managementCompany?: { name: string; website: string }
 }
 
 const LeasingAgent = (props: LeasingAgentProps) => {
@@ -19,6 +20,11 @@ const LeasingAgent = (props: LeasingAgentProps) => {
   const phoneNumber = listing.leasingAgentPhone
     ? `tel:${listing.leasingAgentPhone.replace(/[-()]/g, "")}`
     : ""
+
+  let managementWebsite = props.managementCompany?.website
+  if (managementWebsite && !managementWebsite.startsWith("http")) {
+    managementWebsite = `http://${managementWebsite}`
+  }
 
   return (
     <section className="aside-block">
@@ -52,6 +58,19 @@ const LeasingAgent = (props: LeasingAgentProps) => {
           address={listing.leasingAgentAddress}
           officeHours={listing.leasingAgentOfficeHours}
         />
+      )}
+
+      {props.managementCompany && (
+        <>
+          <div className="mt-5">
+            <p>{props.managementCompany.name}</p>
+            {managementWebsite && (
+              <a href={managementWebsite} target="_blank" rel="noreferrer noopener">
+                <Icon symbol="globe" size="medium" fill={IconFillColors.primary} /> {t("t.website")}
+              </a>
+            )}
+          </div>
+        </>
       )}
     </section>
   )


### PR DESCRIPTION
## Description

This change adds a field to the `LeasingAgentProps` to optionally include data (name and website URL) about the listing management company. If present, the management company name and a link to the website will be shown in the `ListingView`. Screenshot:

![image](https://user-images.githubusercontent.com/8754454/130492555-d8293eb3-f6d7-4fed-9c00-730cfdcebce0.png)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

To view this change locally, it'll be necessary to make a change to `sites/public/src/ListingView.tsx` (to pass in the `managementCompany` prop to the `LeasingAgent` component).

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have reviewed the changes in a desktop view
- [X] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
