### PR TITLE
872/allow for unit sets to have multiple ami charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to this project will be documented in this file. The format 
   - Updates redis reset call to flush all keys
   - Updated listing's importer to handle latest reserved community type changes ([#1667](https://github.com/bloom-housing/bloom/pull/1667)) (Emily Jablonski)
   - Change whatToExpect to be a string instead of a json blob, make it editable in listings management ([#1681](https://github.com/bloom-housing/bloom/pull/1681)) (Emily Jablonski)
+  - Allow for unit sets to have multiple ami charts ([#1678](https://github.com/bloom-housing/bloom/pull/1678)) (Emily Jablonski)
 
 - Fixed:
   - Added checks for property in listing.dto transforms

--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -24,6 +24,7 @@ import { AuthContext } from "./auth/types/auth-context"
 import { ListingDefaultReservedSeed } from "./seeds/listings/listing-default-reserved-seed"
 import { ListingDefaultFCFSSeed } from "./seeds/listings/listing-default-fcfs-seed"
 import { UserRoles } from "./auth/entities/user-roles.entity"
+import { ListingDefaultMultipleAMI } from "./seeds/listings/listing-default-multiple-ami"
 
 const argv = yargs.scriptName("seed").options({
   test: { type: "boolean", default: false },
@@ -43,6 +44,7 @@ const listingSeeds: any[] = [
   ListingTritonSeed,
   ListingDefaultReservedSeed,
   ListingDefaultFCFSSeed,
+  ListingDefaultMultipleAMI,
 ]
 
 export function getSeedListingsCount() {

--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -25,6 +25,7 @@ import { ListingDefaultReservedSeed } from "./seeds/listings/listing-default-res
 import { ListingDefaultFCFSSeed } from "./seeds/listings/listing-default-fcfs-seed"
 import { UserRoles } from "./auth/entities/user-roles.entity"
 import { ListingDefaultMultipleAMI } from "./seeds/listings/listing-default-multiple-ami"
+import { ListingDefaultMultipleAMIAndPercentages } from "./seeds/listings/listing-default-multiple-ami-and-percentages"
 
 const argv = yargs.scriptName("seed").options({
   test: { type: "boolean", default: false },
@@ -45,6 +46,7 @@ const listingSeeds: any[] = [
   ListingDefaultReservedSeed,
   ListingDefaultFCFSSeed,
   ListingDefaultMultipleAMI,
+  ListingDefaultMultipleAMIAndPercentages,
 ]
 
 export function getSeedListingsCount() {

--- a/backend/core/src/seeder/seeder.module.ts
+++ b/backend/core/src/seeder/seeder.module.ts
@@ -34,6 +34,7 @@ import { ApplicationMethodsModule } from "../application-methods/applications-me
 import { PaperApplicationsModule } from "../paper-applications/paper-applications.module"
 import { AssetsModule } from "../assets/assets.module"
 import { ListingDefaultReservedSeed } from "../seeds/listings/listing-default-reserved-seed"
+import { ListingDefaultMultipleAMI } from "../seeds/listings/listing-default-multiple-ami"
 
 @Module({})
 export class SeederModule {
@@ -85,6 +86,7 @@ export class SeederModule {
         ListingTritonSeed,
         ListingDefaultReservedSeed,
         ListingDefaultFCFSSeed,
+        ListingDefaultMultipleAMI,
       ],
     }
   }

--- a/backend/core/src/seeder/seeder.module.ts
+++ b/backend/core/src/seeder/seeder.module.ts
@@ -35,6 +35,7 @@ import { PaperApplicationsModule } from "../paper-applications/paper-application
 import { AssetsModule } from "../assets/assets.module"
 import { ListingDefaultReservedSeed } from "../seeds/listings/listing-default-reserved-seed"
 import { ListingDefaultMultipleAMI } from "../seeds/listings/listing-default-multiple-ami"
+import { ListingDefaultMultipleAMIAndPercentages } from "../seeds/listings/listing-default-multiple-ami-and-percentages"
 
 @Module({})
 export class SeederModule {
@@ -87,6 +88,7 @@ export class SeederModule {
         ListingDefaultReservedSeed,
         ListingDefaultFCFSSeed,
         ListingDefaultMultipleAMI,
+        ListingDefaultMultipleAMIAndPercentages,
       ],
     }
   }

--- a/backend/core/src/seeds/listings/listing-default-bmr-chart-seed.ts
+++ b/backend/core/src/seeds/listings/listing-default-bmr-chart-seed.ts
@@ -1,18 +1,47 @@
 import { ListingDefaultSeed } from "./listing-default-seed"
-import { getDefaultUnits } from "./shared"
+import { getDefaultUnits, getDefaultProperty, getDefaultAmiChart } from "./shared"
+import { UnitCreateDto } from "../../units/dto/unit.dto"
+import { BaseEntity } from "typeorm"
 
 export class ListingDefaultBmrChartSeed extends ListingDefaultSeed {
   async seed() {
     const listing = await super.seed()
     const defaultUnits = getDefaultUnits()
+
+    const unitTypeOneBdrm = await this.unitTypeRepository.findOneOrFail({ name: "oneBdrm" })
+    const unitTypeTwoBdrm = await this.unitTypeRepository.findOneOrFail({ name: "twoBdrm" })
+
+    const amiChart = await this.amiChartRepository.save(getDefaultAmiChart())
+
+    const property = await this.propertyRepository.save({
+      ...getDefaultProperty(),
+    })
+
+    const bmrUnits = [
+      { ...defaultUnits[0], bmrProgramChart: true, monthlyIncomeMin: "700", monthlyRent: "350" },
+      { ...defaultUnits[1], bmrProgramChart: true, monthlyIncomeMin: "800", monthlyRent: "400" },
+    ]
+
+    const unitsToBeCreated: Array<Omit<UnitCreateDto, keyof BaseEntity>> = bmrUnits.map((unit) => {
+      return {
+        ...unit,
+        property: {
+          id: property.id,
+        },
+        amiChart,
+      }
+    })
+
+    unitsToBeCreated[0].unitType = unitTypeOneBdrm
+    unitsToBeCreated[1].unitType = unitTypeTwoBdrm
+
+    await this.unitsRepository.save(unitsToBeCreated)
+
     return await this.listingRepository.save({
       ...listing,
       name: "Test: Default, BMR Chart",
       preferences: [],
-      units: [
-        { ...defaultUnits[0], bmrProgramChart: true, monthlyIncomeMin: "700", monthlyRent: "350" },
-        { ...defaultUnits[1], bmrProgramChart: true, monthlyIncomeMin: "800", monthlyRent: "400" },
-      ],
+      property,
     })
   }
 }

--- a/backend/core/src/seeds/listings/listing-default-multiple-ami-and-percentages.ts
+++ b/backend/core/src/seeds/listings/listing-default-multiple-ami-and-percentages.ts
@@ -1,0 +1,121 @@
+import { ListingDefaultSeed } from "./listing-default-seed"
+import { getDefaultAmiChart, getDefaultProperty } from "./shared"
+import { tritonAmiChart } from "./listing-triton-seed"
+import { UnitCreateDto } from "../../units/dto/unit.dto"
+import { BaseEntity } from "typeorm"
+import { UnitSeedType } from "./listings"
+import { UnitStatus } from "../../units/types/unit-status-enum"
+
+export class ListingDefaultMultipleAMIAndPercentages extends ListingDefaultSeed {
+  async seed() {
+    const listing = await super.seed()
+
+    const unitTypeOneBdrm = await this.unitTypeRepository.findOneOrFail({ name: "oneBdrm" })
+
+    const amiChartOne = await this.amiChartRepository.save(tritonAmiChart)
+    const amiChartTwo = await this.amiChartRepository.save(getDefaultAmiChart())
+
+    const property = await this.propertyRepository.save({
+      ...getDefaultProperty(),
+    })
+
+    const multipleAMIUnits: Array<UnitSeedType> = [
+      {
+        amiChart: amiChartOne,
+        amiPercentage: "30",
+        annualIncomeMax: "45600",
+        annualIncomeMin: "36168",
+        bmrProgramChart: false,
+        floor: 1,
+        maxOccupancy: 3,
+        minOccupancy: 1,
+        monthlyIncomeMin: "3014",
+        monthlyRent: "1219",
+        monthlyRentAsPercentOfIncome: null,
+        numBathrooms: 1,
+        numBedrooms: 1,
+        number: null,
+        sqFeet: "635",
+        status: UnitStatus.available,
+      },
+      {
+        amiChart: amiChartTwo,
+        amiPercentage: "30",
+        annualIncomeMax: "45600",
+        annualIncomeMin: "36168",
+        bmrProgramChart: false,
+        floor: 1,
+        maxOccupancy: 3,
+        minOccupancy: 1,
+        monthlyIncomeMin: "3014",
+        monthlyRent: "1219",
+        monthlyRentAsPercentOfIncome: null,
+        numBathrooms: 1,
+        numBedrooms: 1,
+        number: null,
+        sqFeet: "635",
+        status: UnitStatus.available,
+      },
+      {
+        amiChart: amiChartOne,
+        amiPercentage: "50",
+        annualIncomeMax: "66600",
+        annualIncomeMin: "41616",
+        bmrProgramChart: false,
+        floor: 2,
+        maxOccupancy: 5,
+        minOccupancy: 2,
+        monthlyIncomeMin: "3468",
+        monthlyRent: "1387",
+        monthlyRentAsPercentOfIncome: null,
+        numBathrooms: 1,
+        numBedrooms: 2,
+        number: null,
+        sqFeet: "748",
+        status: UnitStatus.available,
+      },
+      {
+        amiChart: amiChartTwo,
+        amiPercentage: "50",
+        annualIncomeMax: "66600",
+        annualIncomeMin: "41616",
+        bmrProgramChart: false,
+        floor: 2,
+        maxOccupancy: 5,
+        minOccupancy: 2,
+        monthlyIncomeMin: "3468",
+        monthlyRent: "1387",
+        monthlyRentAsPercentOfIncome: null,
+        numBathrooms: 1,
+        numBedrooms: 2,
+        number: null,
+        sqFeet: "748",
+        status: UnitStatus.available,
+      },
+    ]
+
+    const unitsToBeCreated: Array<Omit<UnitCreateDto, keyof BaseEntity>> = multipleAMIUnits.map(
+      (unit) => {
+        return {
+          ...unit,
+          property: {
+            id: property.id,
+          },
+        }
+      }
+    )
+
+    unitsToBeCreated[0].unitType = unitTypeOneBdrm
+    unitsToBeCreated[1].unitType = unitTypeOneBdrm
+    unitsToBeCreated[2].unitType = unitTypeOneBdrm
+    unitsToBeCreated[3].unitType = unitTypeOneBdrm
+
+    await this.unitsRepository.save(unitsToBeCreated)
+
+    return await this.listingRepository.save({
+      ...listing,
+      property: property,
+      name: "Test: Default, Multiple AMI and Percentages",
+    })
+  }
+}

--- a/backend/core/src/seeds/listings/listing-default-multiple-ami.ts
+++ b/backend/core/src/seeds/listings/listing-default-multiple-ami.ts
@@ -1,0 +1,43 @@
+import { ListingDefaultSeed } from "./listing-default-seed"
+import { getDefaultAmiChart, getDefaultUnits, getDefaultProperty } from "./shared"
+import { tritonAmiChart } from "./listing-triton-seed"
+import { UnitCreateDto } from "../../units/dto/unit.dto"
+import { BaseEntity } from "typeorm"
+
+export class ListingDefaultMultipleAMI extends ListingDefaultSeed {
+  async seed() {
+    const listing = await super.seed()
+
+    const unitTypeOneBdrm = await this.unitTypeRepository.findOneOrFail({ name: "oneBdrm" })
+
+    const amiChartOne = await this.amiChartRepository.save(tritonAmiChart)
+    const amiChartTwo = await this.amiChartRepository.save(getDefaultAmiChart())
+
+    const property = await this.propertyRepository.save({
+      ...getDefaultProperty(),
+    })
+
+    const unitsToBeCreated: Array<Omit<UnitCreateDto, keyof BaseEntity>> = getDefaultUnits().map(
+      (unit, index) => {
+        return {
+          ...unit,
+          property: {
+            id: property.id,
+          },
+          amiChart: index % 2 === 0 ? amiChartOne : amiChartTwo,
+        }
+      }
+    )
+
+    unitsToBeCreated[0].unitType = unitTypeOneBdrm
+    unitsToBeCreated[1].unitType = unitTypeOneBdrm
+
+    await this.unitsRepository.save(unitsToBeCreated)
+
+    return await this.listingRepository.save({
+      ...listing,
+      property: property,
+      name: "Test: Default, Multiple AMI",
+    })
+  }
+}

--- a/backend/core/src/seeds/listings/listing-triton-seed.ts
+++ b/backend/core/src/seeds/listings/listing-triton-seed.ts
@@ -11,7 +11,7 @@ import { BaseEntity, DeepPartial } from "typeorm"
 import { Listing } from "../../listings/entities/listing.entity"
 import { UnitStatus } from "../../units/types/unit-status-enum"
 
-const tritonAmiChart: AmiChartCreateDto = {
+export const tritonAmiChart: AmiChartCreateDto = {
   name: "San Jose TCAC 2019",
   items: [
     {

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -72,9 +72,9 @@ const hmiData = (units: Units, maxHouseholdSize: number) => {
   const hmiRows = [] as AnyDict[]
 
   // 1. If there are multiple AMI levels, show each AMI level (max income per
-  //    year only) for each size (number of cols = # ami levels plus the size col)
+  //    year only) for each size (number of cols = the size col + # ami levels)
   // 2. If there is only one AMI level, show max income per month and per
-  //    year for each size (number of cols = 2 for each income style plus the size col)
+  //    year for each size (number of cols = the size col + 2 for each income style)
   if (allPercentages.length > 1) {
     allPercentages.forEach((percent) => {
       // Pass translation with its respective argument with format `key,argumentName:argumentValue`
@@ -109,13 +109,14 @@ const hmiData = (units: Units, maxHouseholdSize: number) => {
         )}`
   }
 
+  // Build row data by household size
   new Array(maxHouseholdSize).fill(maxHouseholdSize).forEach((_, index) => {
     const currentHouseholdSize = index + 1
     const rowData = {
       sizeColumn: showUnitType ? bmrHeaders[index] : currentHouseholdSize,
     }
 
-    let rowHasData = false // Row is valid if at least one column is filled, otherwise don't show the row
+    let rowHasData = false // Row is valid if at least one column is filled, otherwise don't push the row
     allPercentages.forEach((currentAmiPercent) => {
       // Get all the charts that we're using with this percentage and size
       const uniquePercentCharts = uniquePercentageChartSet.filter((uniqueChartAndPercentage) => {

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -38,6 +38,9 @@ const minMaxCurrency = (baseValue: MinMaxCurrency, newValue: number): MinMaxCurr
 // Unit sets can have multiple AMI charts used, in which case the table displays ranges
 const hmiData = (units: Units, maxHouseholdSize: number) => {
   // Currently, BMR chart is just toggling whether or not the first column shows Household Size or Unit Type
+  if (!units || units.length === 0) {
+    return null
+  }
   const showUnitType = units[0].bmrProgramChart
 
   type ChartAndPercentage = {

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -48,7 +48,7 @@ const hmiData = (units: Units, maxHouseholdSize: number) => {
   // All unique AMI percentages across all units
   const allPercentages: number[] = [
     ...new Set(
-      units.map((unit) => parseInt(unit.amiPercentage, 10)).filter((item) => item != null)
+      units.filter((item) => item != null).map((unit) => parseInt(unit.amiPercentage, 10))
     ),
   ].sort(function (a, b) {
     return a - b

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -47,12 +47,12 @@ const hmiData = (units: Units, maxHouseholdSize: number) => {
 
   // All unique AMI percentages across all units
   const allPercentages: number[] = [
-    ...new Set(units.map((unit) => unit.amiPercentage).filter((item) => item != null)),
-  ]
-    .map((percent) => parseInt(percent, 10))
-    .sort(function (a, b) {
-      return a - b
-    })
+    ...new Set(
+      units.map((unit) => parseInt(unit.amiPercentage, 10)).filter((item) => item != null)
+    ),
+  ].sort(function (a, b) {
+    return a - b
+  })
 
   // All unique combinations of an AMI percentage and an AMI chart across all units
   const uniquePercentageChartSet: ChartAndPercentage[] = [

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -76,7 +76,9 @@ export const ListingView = (props: ListingProps) => {
           const percentInt = parseInt(percent, 10)
           return percentInt
         })
-        .sort()
+        .sort(function (a, b) {
+          return a - b
+        })
     : []
 
   const hmiHeaders = listing?.unitsSummarized?.hmi?.columns as TableHeaders
@@ -84,7 +86,6 @@ export const ListingView = (props: ListingProps) => {
   const hmiData = listing?.unitsSummarized?.hmi?.rows.map((row) => {
     return { ...row, sizeColumn: <strong>{row["sizeColumn"]}</strong> }
   })
-  console.log(hmiData)
   let groupedUnits: GroupedTableGroup[] = null
 
   if (amiValues.length == 1) {

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -82,8 +82,9 @@ export const ListingView = (props: ListingProps) => {
   const hmiHeaders = listing?.unitsSummarized?.hmi?.columns as TableHeaders
 
   const hmiData = listing?.unitsSummarized?.hmi?.rows.map((row) => {
-    return { ...row, householdSize: <strong>{row["householdSize"]}</strong> }
+    return { ...row, sizeColumn: <strong>{row["sizeColumn"]}</strong> }
   })
+  console.log(hmiData)
   let groupedUnits: GroupedTableGroup[] = null
 
   if (amiValues.length == 1) {


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #872

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Allows for sets of units to have multiple AMI charts, and in doing so updates the HMI chart visually to display ranges of maximum income values if there are multiple AMI charts in use. Also fixes some existing sorting bugs, fixes the BMR chart seed which I discovered wasn't working, and adds two new seeds to test this behavior that will render each flavor of the HMI table with multiple AMI charts. Screenshots of them both below. I essentially re-wrote the function and added a few comments to try to make it more readable but I don't know that I succeeded there 😨 

![Screen Shot 2021-08-16 at 7 08 17 PM](https://user-images.githubusercontent.com/65367387/129648083-72f32751-57f7-4be3-9fc1-4ffa7f1b6f15.png)
![Screen Shot 2021-08-16 at 6 30 42 PM](https://user-images.githubusercontent.com/65367387/129648084-4ef86db0-3cb5-4722-bc50-3dbc223d41e9.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Check out the new seeds, and the existing seeds against the tables on dev to ensure they didn't break.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
