### PR TITLE
1629/fcfs with date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
   - Update buttons / pages visibility depending on a user role ([#1609](https://github.com/bloom-housing/bloom/pull/1609)) (Dominik Barcikowski)
   - Terms page checkbox text changed to blue ([#1645](https://github.com/bloom-housing/bloom/pull/1645)) (Emily Jablonski)
   - Add FCFS and Lottery section to listing management ([#1485](https://github.com/bloom-housing/bloom/pull/1485)) (Emily Jablonski)
+  - Allow application status to show both FCFS and a due date ([#1680](https://github.com/bloom-housing/bloom/pull/1680)) (Emily Jablonski)
 
 - Fixed:
   - Update Listings component to sort listings by status ([#1585](https://github.com/bloom-housing/bloom/pull/1585))

--- a/sites/public/lib/hooks.ts
+++ b/sites/public/lib/hooks.ts
@@ -39,11 +39,12 @@ export const useFormConductor = (stepName: string) => {
 }
 
 export const useGetApplicationStatusProps = (listing: Listing): ApplicationStatusProps => {
-  const [props, setProps] = useState({ content: "" })
+  const [props, setProps] = useState({ content: "", subContent: "" })
 
   useEffect(() => {
     if (!listing) return
     let content = ""
+    let subContent = ""
     let formattedDate = ""
     if (openDateState(listing)) {
       const date = listing.applicationOpenDate
@@ -64,13 +65,15 @@ export const useGetApplicationStatusProps = (listing: Listing): ApplicationStatu
         } else {
           content = t("listings.applicationsClosed")
         }
-      } else if (listing.reviewOrderType === EnumListingReviewOrderType.firstComeFirstServe) {
-        content = t("listings.applicationFCFS")
       }
     }
     content = formattedDate !== "" ? `${content}: ${formattedDate}` : content
+    if (listing.reviewOrderType === EnumListingReviewOrderType.firstComeFirstServe) {
+      subContent = content
+      content = t("listings.applicationFCFS")
+    }
 
-    setProps({ content })
+    setProps({ content, subContent })
   }, [listing])
 
   return props

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -49,7 +49,10 @@ export const ListingView = (props: ListingProps) => {
   let buildingSelectionCriteria, preferencesSection
   const { listing } = props
 
-  const { content: appStatusContent } = useGetApplicationStatusProps(listing)
+  const {
+    content: appStatusContent,
+    subContent: appStatusSubContent,
+  } = useGetApplicationStatusProps(listing)
 
   if (!listing) {
     return <ErrorPage />
@@ -234,7 +237,7 @@ export const ListingView = (props: ListingProps) => {
         )}
       </div>
       <div className="w-full md:w-2/3 md:mt-3 md:hidden md:mx-3 border-gray-400 border-b">
-        <ApplicationStatus content={appStatusContent} />
+        <ApplicationStatus content={appStatusContent} subContent={appStatusSubContent} />
         <div className="mx-4">
           <DownloadLotteryResults
             event={lotteryResults}
@@ -342,7 +345,7 @@ export const ListingView = (props: ListingProps) => {
         >
           <aside className="w-full static md:absolute md:right-0 md:w-1/3 md:top-0 sm:w-2/3 md:ml-2 h-full md:border border-gray-400 bg-white">
             <div className="hidden md:block">
-              <ApplicationStatus content={appStatusContent} />
+              <ApplicationStatus content={appStatusContent} subContent={appStatusSubContent} />
               <DownloadLotteryResults
                 event={lotteryResults}
                 cloudName={process.env.cloudinaryCloudName}

--- a/ui-components/src/blocks/ImageCard.tsx
+++ b/ui-components/src/blocks/ImageCard.tsx
@@ -16,6 +16,7 @@ export interface ImageCardProps {
   tagLabel?: string
   appStatus?: ApplicationStatusType
   appStatusContent?: string
+  appStatusSubContent?: string
 }
 
 const ImageCard = (props: ImageCardProps) => {
@@ -25,7 +26,12 @@ const ImageCard = (props: ImageCardProps) => {
   if (props.appStatus !== undefined && props.appStatusContent !== undefined) {
     statusLabel = (
       <aside className="image-card__status">
-        <ApplicationStatus status={props.appStatus} content={props.appStatusContent} vivid />
+        <ApplicationStatus
+          status={props.appStatus}
+          content={props.appStatusContent}
+          subContent={props.appStatusSubContent}
+          vivid
+        />
       </aside>
     )
   }

--- a/ui-components/src/notifications/ApplicationStatus.scss
+++ b/ui-components/src/notifications/ApplicationStatus.scss
@@ -4,3 +4,7 @@
     @apply whitespace-no-wrap;
   }
 }
+
+.application-status__sub-content {
+  padding-left: 22px;
+}

--- a/ui-components/src/notifications/ApplicationStatus.tsx
+++ b/ui-components/src/notifications/ApplicationStatus.tsx
@@ -5,6 +5,7 @@ import "./ApplicationStatus.scss"
 
 export interface ApplicationStatusProps {
   content: string
+  subContent?: string
   status?: ApplicationStatusType
   vivid?: boolean
 }
@@ -34,6 +35,12 @@ const ApplicationStatus = (props: ApplicationStatusProps) => {
     <div className={`application-status ${textSize} ${textColor} ${bgColor}`}>
       <Icon size="medium" symbol="clock" fill={vivid ? IconFillColors.white : undefined} /> &nbsp;
       {content}
+      {props.subContent && (
+        <>
+          <br />
+          <span className={"application-status__sub-content"}>{props.subContent}</span>
+        </>
+      )}
     </div>
   )
 }

--- a/ui-components/src/page_components/listing/ListingsList.tsx
+++ b/ui-components/src/page_components/listing/ListingsList.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { ImageCard } from "../../blocks/ImageCard"
-import { Listing } from "@bloom-housing/backend-core/types"
+import { Listing, EnumListingReviewOrderType } from "@bloom-housing/backend-core/types"
 import { LinkButton } from "../../actions/LinkButton"
 import { getSummariesTable } from "../../helpers/tableSummaries"
 import { GroupedTable, GroupedTableGroup } from "../../tables/GroupedTable"
@@ -36,6 +36,7 @@ const ListingsList = (props: ListingsProps) => {
     const { street, city, state, zipCode } = listing.buildingAddress || {}
     const subtitle = `${street}, ${city} ${state}, ${zipCode}`
     let content = ""
+    let subContent = ""
     let formattedDate = ""
     let appStatus = ApplicationStatusType.Open
 
@@ -61,13 +62,16 @@ const ListingsList = (props: ListingsProps) => {
           appStatus = ApplicationStatusType.Closed
           content = t("listings.applicationsClosed")
         }
-      } else {
-        content = t("listings.applicationFCFS")
       }
     }
 
     if (formattedDate != "") {
       content = content + `: ${formattedDate}`
+    }
+
+    if (listing.reviewOrderType === EnumListingReviewOrderType.firstComeFirstServe) {
+      subContent = content
+      content = t("listings.applicationFCFS")
     }
 
     return (
@@ -80,6 +84,7 @@ const ListingsList = (props: ListingsProps) => {
             href={`/listing/${listing.id}/${listing.urlSlug}`}
             appStatus={appStatus}
             appStatusContent={content}
+            appStatusSubContent={subContent}
             tagLabel={
               listing.reservedCommunityType
                 ? t(`listings.reservedCommunityTypes.${listing.reservedCommunityType.name}`)


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1629

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

When a listing is First Come First Served and also has an application due date, the application status bar on both the listings page and individual listing page should show both of those indicators.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Our seed data already has the variety needed. The FCFS listing should just show `First Come First Serve` and the Coliseum and Triton listings are FCFS with a due date. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
