### PR TITLE
Make actions an optional prop and hide the footer when not present.

### DIFF
--- a/ui-components/__tests__/overlays/Modal.test.tsx
+++ b/ui-components/__tests__/overlays/Modal.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup } from "@testing-library/react"
+import { render, cleanup, getByTestId } from "@testing-library/react"
 import { Modal } from "../../src/overlays/Modal"
 
 afterEach(cleanup)
@@ -46,5 +46,16 @@ describe("<Modal>", () => {
     expect(getByText("Modal Children")).toBeTruthy()
     expect(getByText("Action 1")).toBeTruthy()
     expect(getByText("Action 2")).toBeTruthy()
+  })
+  it("does not render footer with no actions", () => {
+    const portalRoot = document.createElement("div")
+    portalRoot.setAttribute("id", "__next")
+    document.body.appendChild(portalRoot)
+    const { queryByTestId } = render(
+      <Modal open={true} title={"Modal Title"} onClose={() => {}} ariaDescription={"My Modal"}>
+        <strong>Modal Children</strong>
+      </Modal>
+    )
+    expect(queryByTestId("footer")).toBeFalsy()
   })
 })

--- a/ui-components/src/overlays/Modal.tsx
+++ b/ui-components/src/overlays/Modal.tsx
@@ -6,7 +6,7 @@ import { Overlay, OverlayProps } from "./Overlay"
 
 export interface ModalProps extends Omit<OverlayProps, "children"> {
   title: string
-  actions: React.ReactNode[]
+  actions?: React.ReactNode[]
   hideCloseIcon?: boolean
   children?: React.ReactNode
 }
@@ -18,7 +18,7 @@ const ModalHeader = (props: { title: string }) => (
 )
 
 const ModalFooter = (props: { actions: React.ReactNode[] }) => (
-  <footer className="modal__footer bg-primary-lighter">
+  <footer className="modal__footer bg-primary-lighter" data-testid="footer">
     <GridSection columns={4} reverse={true} tightSpacing={true}>
       {props.actions &&
         props.actions.map((action: React.ReactNode, index: number) => (
@@ -48,7 +48,7 @@ export const Modal = (props: ModalProps) => {
           )}
         </section>
 
-        <ModalFooter actions={props.actions} />
+        {props.actions && <ModalFooter actions={props.actions} />}
 
         {!props.hideCloseIcon && (
           <button className="modal__close" aria-label="Close" onClick={props.onClose} tabIndex={0}>


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses https://github.com/CityOfDetroit/bloom/issues/412

- [x] This change addresses only certain aspects of the issue

## Description

The empty footer was being displayed when no actions were present, so we make the actions prop optional and hide the footer when it is not present.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Unit tests passed and visual inspection showed the footer not present in the modal when actions were not passed.

- [x] Desktop View
- [x] Mobile View

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
