### PR TITLE
1402/multiple statuses under image card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file. The format 
 - Added:
 
   - Add ResponsiveTable for pricing
+  - Ability to have multiple statuses under the ImageCard ([#1700](https://github.com/bloom-housing/bloom/pull/1700)) (Emily Jablonski)
 
 - Fixed:
   - StandardTable styling bug ([#1632](https://github.com/bloom-housing/bloom/pull/1632)) (Emily Jablonski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file. The format 
 
   - Add ResponsiveTable for pricing
   - Ability to have multiple statuses under the ImageCard ([#1700](https://github.com/bloom-housing/bloom/pull/1700)) (Emily Jablonski)
+    - **Breaking Change**: Removed three props (appStatus, appStatusContent, and appStatusSubContent) in favor of an array that contains that data - will need to transitiona any status information to the new array format
 
 - Fixed:
   - StandardTable styling bug ([#1632](https://github.com/bloom-housing/bloom/pull/1632)) (Emily Jablonski)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file. The format 
 
   - Add ResponsiveTable for pricing
   - Ability to have multiple statuses under the ImageCard ([#1700](https://github.com/bloom-housing/bloom/pull/1700)) (Emily Jablonski)
-    - **Breaking Change**: Removed three props (appStatus, appStatusContent, and appStatusSubContent) in favor of an array that contains that data - will need to transitiona any status information to the new array format
+    - **Breaking Change**: Removed three props (appStatus, appStatusContent, and appStatusSubContent) in favor of an array that contains that data - will need to transition any status information to the new array format
 
 - Fixed:
   - StandardTable styling bug ([#1632](https://github.com/bloom-housing/bloom/pull/1632)) (Emily Jablonski)

--- a/sites/public/pages/applications/start/choose-language.tsx
+++ b/sites/public/pages/applications/start/choose-language.tsx
@@ -102,7 +102,7 @@ const ApplicationChooseLanguage = () => {
             <ImageCard
               title={listing.name}
               imageUrl={imageUrl}
-              appStatusContent={appStatusContent}
+              statuses={[{ content: appStatusContent }]}
             />
           </div>
         )}

--- a/ui-components/__tests__/blocks/ImageCard.test.tsx
+++ b/ui-components/__tests__/blocks/ImageCard.test.tsx
@@ -39,10 +39,26 @@ describe("<ImageCard>", () => {
         imageUrl={"/images/listing.jpg"}
         title={"My Building"}
         subtitle={"The Address"}
-        appStatus={ApplicationStatusType.Closed}
-        appStatusContent={t("listings.applicationsClosed")}
+        statuses={[
+          { status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") },
+        ]}
       />
     )
     expect(getByText("Applications Closed", { exact: false })).not.toBeNull()
+  })
+  it("renders with multiple applications status bars", () => {
+    const { getByText } = render(
+      <ImageCard
+        imageUrl={"/images/listing.jpg"}
+        title={"My Building"}
+        subtitle={"The Address"}
+        statuses={[
+          { status: ApplicationStatusType.Closed, content: "Applications Closed" },
+          { status: ApplicationStatusType.PreLottery, content: "Lottery Results Posted Tomorrow" },
+        ]}
+      />
+    )
+    expect(getByText("Applications Closed", { exact: false })).not.toBeNull()
+    expect(getByText("Lottery Results Posted Tomorrow", { exact: false })).not.toBeNull()
   })
 })

--- a/ui-components/src/blocks/ImageCard.stories.tsx
+++ b/ui-components/src/blocks/ImageCard.stories.tsx
@@ -1,12 +1,7 @@
 import * as React from "react"
 import { ImageCard } from "./ImageCard"
-import { Listing } from "@bloom-housing/backend-core/types"
-import { ArcherListing } from "@bloom-housing/backend-core/types/src/archer-listing"
 import { t } from "../helpers/translator"
 import { ApplicationStatusType } from "../global/ApplicationStatusType"
-import { Application } from "icons/Icons"
-
-const listing = Object.assign({}, ArcherListing) as Listing
 
 export default {
   title: "Blocks/Image Card",
@@ -27,13 +22,12 @@ export const withLink = () => (
   <ImageCard href="/listings" imageUrl="/images/listing.jpg" title="Hello World" />
 )
 
-export const withListing = () => (
+export const withOneStatus = () => (
   <ImageCard
     href="/listings"
     imageUrl="/images/listing.jpg"
     title="Hello World"
-    appStatus={ApplicationStatusType.Closed}
-    appStatusContent={t("listings.applicationsClosed")}
+    statuses={[{ status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") }]}
   />
 )
 
@@ -45,15 +39,14 @@ export const withDescriptionAsAlt = () => (
   />
 )
 
-export const withListingAndTag = () => (
+export const withOneStatusAndTag = () => (
   <ImageCard
     href="/listings"
     imageUrl="/images/listing.jpg"
     title="Hello World"
     subtitle="55 Triton Park Lane, Foster City CA, 94404"
     tagLabel="Label"
-    appStatus={ApplicationStatusType.Closed}
-    appStatusContent={t("listings.applicationsClosed")}
+    statuses={[{ status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") }]}
   />
 )
 
@@ -64,9 +57,18 @@ export const withMultipleAppStatus = () => (
     title="Hello World"
     subtitle="55 Triton Park Lane, Foster City CA, 94404"
     tagLabel="Label"
-    appStatus={ApplicationStatusType.Closed}
-    appStatusContent={t("listings.applicationsClosed")}
-    lotteryStatus={ApplicationStatusType.PostLottery}
-    lotteryStatusContent={t("listings.applicationsClosed")}
+    statuses={[
+      {
+        status: ApplicationStatusType.Open,
+        content: "First Come First Served",
+        subContent: "Application Due Date: July 10th",
+      },
+      { status: ApplicationStatusType.Closed, content: t("listings.applicationsClosed") },
+      {
+        status: ApplicationStatusType.PostLottery,
+        content: "Lottery Results Posted: September 3rd",
+        hideIcon: true,
+      },
+    ]}
   />
 )

--- a/ui-components/src/blocks/ImageCard.stories.tsx
+++ b/ui-components/src/blocks/ImageCard.stories.tsx
@@ -4,6 +4,7 @@ import { Listing } from "@bloom-housing/backend-core/types"
 import { ArcherListing } from "@bloom-housing/backend-core/types/src/archer-listing"
 import { t } from "../helpers/translator"
 import { ApplicationStatusType } from "../global/ApplicationStatusType"
+import { Application } from "icons/Icons"
 
 const listing = Object.assign({}, ArcherListing) as Listing
 
@@ -53,5 +54,19 @@ export const withListingAndTag = () => (
     tagLabel="Label"
     appStatus={ApplicationStatusType.Closed}
     appStatusContent={t("listings.applicationsClosed")}
+  />
+)
+
+export const withMultipleAppStatus = () => (
+  <ImageCard
+    href="/listings"
+    imageUrl="/images/listing.jpg"
+    title="Hello World"
+    subtitle="55 Triton Park Lane, Foster City CA, 94404"
+    tagLabel="Label"
+    appStatus={ApplicationStatusType.Closed}
+    appStatusContent={t("listings.applicationsClosed")}
+    lotteryStatus={ApplicationStatusType.PostLottery}
+    lotteryStatusContent={t("listings.applicationsClosed")}
   />
 )

--- a/ui-components/src/blocks/ImageCard.tsx
+++ b/ui-components/src/blocks/ImageCard.tsx
@@ -7,6 +7,13 @@ import { ApplicationStatusType } from "../global/ApplicationStatusType"
 import { AppearanceStyleType } from "../global/AppearanceTypes"
 import { t } from "../helpers/translator"
 
+export interface StatusBar {
+  status: ApplicationStatusType
+  content: string
+  subContent?: string
+  hideIcon?: boolean
+}
+
 export interface ImageCardProps {
   imageUrl: string
   subtitle?: string
@@ -14,54 +21,33 @@ export interface ImageCardProps {
   href?: string
   description?: string
   tagLabel?: string
-  appStatus?: ApplicationStatusType
-  appStatusContent?: string
-  appStatusSubContent?: string
-  lotteryStatus?: ApplicationStatusType
-  lotteryStatusContent?: string
+  statuses?: StatusBar[]
 }
 
 const ImageCard = (props: ImageCardProps) => {
-  let statusLabel
-  let lotteryStatusLabel
-  let tag
-
-  if (props.appStatus !== undefined && props.appStatusContent !== undefined) {
-    statusLabel = (
-      <aside className="image-card__status">
-        <ApplicationStatus
-          status={props.appStatus}
-          content={props.appStatusContent}
-          subContent={props.appStatusSubContent}
-          vivid
-        />
-      </aside>
-    )
-  }
-
-  if (props.lotteryStatus !== undefined && props.lotteryStatusContent !== undefined) {
-    lotteryStatusLabel = (
-      <aside className="image-card__status" aria-label={props.lotteryStatusContent}>
-        <ApplicationStatus
-          status={props.lotteryStatus}
-          content={props.lotteryStatusContent}
-          withIcon={false}
-        />
-      </aside>
-    )
-  }
-
-  if (props.tagLabel) {
-    tag = (
-      <div className="image-card-tag__wrapper">
-        <Tag styleType={AppearanceStyleType.warning}>{props.tagLabel}</Tag>
-      </div>
-    )
+  const getStatuses = () => {
+    return props.statuses?.map((status, index) => {
+      return (
+        <aside className="image-card__status" aria-label={status.content} key={index}>
+          <ApplicationStatus
+            status={status.status}
+            content={status.content}
+            subContent={status.subContent}
+            withIcon={!status.hideIcon}
+            vivid
+          />
+        </aside>
+      )
+    })
   }
 
   const image = (
     <div className="image-card__wrapper">
-      {tag}
+      {props.tagLabel && (
+        <div className="image-card-tag__wrapper">
+          <Tag styleType={AppearanceStyleType.warning}>{props.tagLabel}</Tag>
+        </div>
+      )}
       <figure className="image-card">
         {props.imageUrl && (
           <img src={props.imageUrl} alt={props.description || t("listings.buildingImageAltText")} />
@@ -71,8 +57,7 @@ const ImageCard = (props: ImageCardProps) => {
           {props.subtitle && <p className="image-card__subtitle">{props.subtitle}</p>}
         </figcaption>
       </figure>
-      {statusLabel}
-      {lotteryStatusLabel}
+      {getStatuses()}
     </div>
   )
 

--- a/ui-components/src/blocks/ImageCard.tsx
+++ b/ui-components/src/blocks/ImageCard.tsx
@@ -8,7 +8,7 @@ import { AppearanceStyleType } from "../global/AppearanceTypes"
 import { t } from "../helpers/translator"
 
 export interface StatusBar {
-  status: ApplicationStatusType
+  status?: ApplicationStatusType
   content: string
   subContent?: string
   hideIcon?: boolean

--- a/ui-components/src/blocks/ImageCard.tsx
+++ b/ui-components/src/blocks/ImageCard.tsx
@@ -7,7 +7,7 @@ import { ApplicationStatusType } from "../global/ApplicationStatusType"
 import { AppearanceStyleType } from "../global/AppearanceTypes"
 import { t } from "../helpers/translator"
 
-export interface StatusBar {
+export interface StatusBarType {
   status?: ApplicationStatusType
   content: string
   subContent?: string
@@ -21,7 +21,7 @@ export interface ImageCardProps {
   href?: string
   description?: string
   tagLabel?: string
-  statuses?: StatusBar[]
+  statuses?: StatusBarType[]
 }
 
 const ImageCard = (props: ImageCardProps) => {

--- a/ui-components/src/blocks/ImageCard.tsx
+++ b/ui-components/src/blocks/ImageCard.tsx
@@ -17,10 +17,13 @@ export interface ImageCardProps {
   appStatus?: ApplicationStatusType
   appStatusContent?: string
   appStatusSubContent?: string
+  lotteryStatus?: ApplicationStatusType
+  lotteryStatusContent?: string
 }
 
 const ImageCard = (props: ImageCardProps) => {
   let statusLabel
+  let lotteryStatusLabel
   let tag
 
   if (props.appStatus !== undefined && props.appStatusContent !== undefined) {
@@ -31,6 +34,18 @@ const ImageCard = (props: ImageCardProps) => {
           content={props.appStatusContent}
           subContent={props.appStatusSubContent}
           vivid
+        />
+      </aside>
+    )
+  }
+
+  if (props.lotteryStatus !== undefined && props.lotteryStatusContent !== undefined) {
+    lotteryStatusLabel = (
+      <aside className="image-card__status">
+        <ApplicationStatus
+          status={props.lotteryStatus}
+          content={props.lotteryStatusContent}
+          withIcon={false}
         />
       </aside>
     )
@@ -57,6 +72,7 @@ const ImageCard = (props: ImageCardProps) => {
         </figcaption>
       </figure>
       {statusLabel}
+      {lotteryStatusLabel}
     </div>
   )
 

--- a/ui-components/src/blocks/ImageCard.tsx
+++ b/ui-components/src/blocks/ImageCard.tsx
@@ -41,7 +41,7 @@ const ImageCard = (props: ImageCardProps) => {
 
   if (props.lotteryStatus !== undefined && props.lotteryStatusContent !== undefined) {
     lotteryStatusLabel = (
-      <aside className="image-card__status">
+      <aside className="image-card__status" aria-label={props.lotteryStatusContent}>
         <ApplicationStatus
           status={props.lotteryStatus}
           content={props.lotteryStatusContent}

--- a/ui-components/src/notifications/ApplicationStatus.stories.tsx
+++ b/ui-components/src/notifications/ApplicationStatus.stories.tsx
@@ -103,7 +103,7 @@ export const openedWithFCFSVivid = () => (
 
 export const postLottery = () => (
   <ApplicationStatus
-    content={"Post-lottery content: " + moment().format('MMMM Do, Y')}
+    content={"Post-lottery content: " + moment().format("MMMM Do, Y")}
     status={ApplicationStatusType.PostLottery}
     withIcon={false}
   />

--- a/ui-components/src/notifications/ApplicationStatus.stories.tsx
+++ b/ui-components/src/notifications/ApplicationStatus.stories.tsx
@@ -100,3 +100,11 @@ export const openedWithFCFSVivid = () => (
     vivid
   />
 )
+
+export const postLottery = () => (
+  <ApplicationStatus
+    content={"Post-lottery content: " + moment().format('MMMM Do, Y')}
+    status={ApplicationStatusType.PostLottery}
+    withIcon={false}
+  />
+)

--- a/ui-components/src/notifications/ApplicationStatus.tsx
+++ b/ui-components/src/notifications/ApplicationStatus.tsx
@@ -8,17 +8,29 @@ export interface ApplicationStatusProps {
   subContent?: string
   status?: ApplicationStatusType
   vivid?: boolean
+  withIcon?: boolean
 }
 
 const ApplicationStatus = (props: ApplicationStatusProps) => {
   let bgColor = ""
   // determine styling
   const vivid = props.vivid || false
-  const textColor = vivid ? "text-white" : "text-gray-800"
+  let textColor = vivid ? "text-white" : "text-gray-800"
   const textSize = vivid ? "text-xs" : "text-sm"
 
   const status = props.status || ApplicationStatusType.Open
   const content = props.content
+  const withIcon = props.withIcon ?? true
+
+  let icon
+
+  if (withIcon) {
+    icon = (
+      <span>
+        <Icon size="medium" symbol="clock" fill={vivid ? IconFillColors.white : undefined} /> &nbsp;
+      </span>
+    )
+  }
 
   switch (status) {
     case ApplicationStatusType.Open:
@@ -27,13 +39,17 @@ const ApplicationStatus = (props: ApplicationStatusProps) => {
     case ApplicationStatusType.Closed:
       bgColor = vivid ? "bg-alert" : "bg-alert-light"
       break
+    case ApplicationStatusType.PostLottery:
+      bgColor = "bg-gray-850"
+      textColor = "text-white"
+      break
     default:
       bgColor = "bg-primary"
   }
 
   return (
     <div className={`application-status ${textSize} ${textColor} ${bgColor}`}>
-      <Icon size="medium" symbol="clock" fill={vivid ? IconFillColors.white : undefined} /> &nbsp;
+      {icon}
       {content}
       {props.subContent && (
         <>

--- a/ui-components/src/page_components/listing/ListingsList.tsx
+++ b/ui-components/src/page_components/listing/ListingsList.tsx
@@ -82,9 +82,7 @@ const ListingsList = (props: ListingsProps) => {
             subtitle={subtitle}
             imageUrl={imageUrl}
             href={`/listing/${listing.id}/${listing.urlSlug}`}
-            appStatus={appStatus}
-            appStatusContent={content}
-            appStatusSubContent={subContent}
+            statuses={[{ status: appStatus, content: content, subContent: subContent }]}
             tagLabel={
               listing.reservedCommunityType
                 ? t(`listings.reservedCommunityTypes.${listing.reservedCommunityType.name}`)


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1402 
Re-made from https://github.com/bloom-housing/bloom/pull/1608

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Attempts to address the issue outlined in https://github.com/bloom-housing/bloom/issues/1402.  Particularly this comment regarding pre and post lottery states: https://github.com/bloom-housing/bloom/issues/1402#issuecomment-869831293

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

There's a new story that shows off the multiple statuses.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
