### PR TITLE
1544/ami overrides + unit form refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file. The format 
   - Allow application status to show both FCFS and a due date ([#1680](https://github.com/bloom-housing/bloom/pull/1680)) (Emily Jablonski)
   - Add new /users page with table ([#1679](https://github.com/bloom-housing/bloom/pull/1679)) (Dominik Barcikowski)
   - Add new /unauthorized page ([#1763](https://github.com/bloom-housing/bloom/pull/1763)) (Dominik Barcikowski)
+  - Adds ability to create AMI chart overrides in listings management and refactors the unit form ([#1706](https://github.com/bloom-housing/bloom/pull/1706)) (Emily Jablonski)
 
 - Fixed:
 

--- a/sites/partners/lib/hooks.ts
+++ b/sites/partners/lib/hooks.ts
@@ -207,6 +207,19 @@ export function useAmiChartList() {
   }
 }
 
+export function useSingleAmiChart(amiChartId: string) {
+  const { amiChartsService } = useContext(AuthContext)
+  const fetcher = () => amiChartsService.retrieve({ amiChartId })
+
+  const { data, error } = useSWR(`${process.env.backendApiBase}/amiCharts/${amiChartId}`, fetcher)
+
+  return {
+    data,
+    loading: !error && !data,
+    error,
+  }
+}
+
 export function useUnitPriorityList() {
   const { unitPriorityService } = useContext(AuthContext)
   const fetcher = () => unitPriorityService.list()

--- a/sites/partners/src/listings/PaperListingDetails/DetailsUnitDrawer.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/DetailsUnitDrawer.tsx
@@ -75,11 +75,20 @@ const DetailUnitDrawer = ({ unit, setUnitDrawer }: UnitDrawerProps) => {
               label={t("listings.unit.amiChart")}
               children={unit?.amiChart?.id ? AmiChartWrapper(unit.amiChart.id) : t("t.n/a")}
             />
-
             <ViewItem
               label={t("listings.unit.amiPercentage")}
               children={unit?.amiPercentage || t("t.n/a")}
             />
+          </GridSection>
+          <GridSection columns={1}>
+            {unit?.amiChartOverride?.items.map((override) => {
+              return (
+                <ViewItem
+                  label={t("listings.amiOverrideTitle", { householdSize: override.householdSize })}
+                  children={`$${override.income}`}
+                />
+              )
+            })}
           </GridSection>
           <GridSection columns={4} className="pt-6">
             {rentType === "fixed" && (

--- a/sites/partners/src/listings/PaperListingDetails/DetailsUnitDrawer.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/DetailsUnitDrawer.tsx
@@ -81,9 +81,10 @@ const DetailUnitDrawer = ({ unit, setUnitDrawer }: UnitDrawerProps) => {
             />
           </GridSection>
           <GridSection columns={1}>
-            {unit?.amiChartOverride?.items.map((override) => {
+            {unit?.amiChartOverride?.items.map((override, index) => {
               return (
                 <ViewItem
+                  key={index}
                   label={t("listings.amiOverrideTitle", { householdSize: override.householdSize })}
                   children={`$${override.income}`}
                 />

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -102,7 +102,8 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
 
   const resetDefaultValues = async () => {
     if (defaultUnit) {
-      await fetchAmiChart(defaultUnit.amiChart.id, defaultUnit.amiPercentage)
+      const chartData = await fetchAmiChart(defaultUnit.amiChart.id, defaultUnit.amiPercentage)
+      resetAmiTableValues(chartData, defaultUnit.amiPercentage)
       Object.keys(defaultUnit).forEach((key) => {
         setValue(key, defaultUnit[key])
       })
@@ -141,21 +142,28 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
           }
         })
       )
+      return amiChartData
     } catch (e) {
       console.error(e)
     }
   }
 
+  const resetAmiTableValues = (defaultAmiChart?: AmiChartItem[], defaultAmiPercentage?: string) => {
+    const chart = defaultAmiChart ?? currentAmiChart
+    const percentage = defaultAmiPercentage ?? amiPercentage
+    const newPercentages = chart
+      .filter((item: AmiChartItem) => item.percentOfAmi === parseInt(percentage))
+      .sort(function (a: AmiChartItem, b: AmiChartItem) {
+        return a.householdSize - b.householdSize
+      })
+    newPercentages.forEach((amiValue, index) => {
+      setValue(`maxIncomeHouseholdSize${index + 1}`, amiValue.income.toString())
+    })
+  }
+
   useEffect(() => {
     if (amiPercentage && !loading && options) {
-      const newPercentages = currentAmiChart
-        .filter((item: AmiChartItem) => item.percentOfAmi === parseInt(amiPercentage))
-        .sort(function (a: AmiChartItem, b: AmiChartItem) {
-          return a.householdSize - b.householdSize
-        })
-      newPercentages.forEach((amiValue, index) => {
-        setValue(`maxIncomeHouseholdSize${index + 1}`, amiValue.income.toString())
-      })
+      resetAmiTableValues()
     }
   }, [amiPercentage])
 

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -96,8 +96,9 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     })
   }
 
-  const resetDefaultValues = () => {
+  const resetDefaultValues = async () => {
     if (defaultUnit) {
+      await fetchAmiChart(defaultUnit.amiChart.id, defaultUnit.amiPercentage)
       Object.keys(defaultUnit).forEach((key) => {
         setValue(key, defaultUnit[key])
       })
@@ -110,13 +111,13 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     resetDefaultValues()
   }, [])
 
-  const fetchAmiChart = async () => {
+  const fetchAmiChart = async (defaultChartID?: string, defaultAmiPercentage?: string) => {
     try {
       const thisAmiChart = await amiChartsService.retrieve({
-        amiChartId: amiChartID,
+        amiChartId: defaultChartID ?? amiChartID,
       })
       const amiChartData = thisAmiChart.items
-        .filter((item) => item.percentOfAmi === parseInt(amiPercentage))
+        .filter((item) => item.percentOfAmi === parseInt(defaultAmiPercentage ?? amiPercentage))
         .sort(function (a, b) {
           return a.householdSize - b.householdSize
         })

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -25,7 +25,6 @@ import {
 } from "@bloom-housing/backend-core/types"
 import { useAmiChartList, useUnitPriorityList, useUnitTypeList } from "../../../lib/hooks"
 import { arrayToFormOptions, getRentType } from "../../../lib/helpers"
-import ResetPassword from "../../../pages/reset-password"
 
 type UnitFormProps = {
   onSubmit: (unit: any) => void
@@ -37,7 +36,6 @@ type UnitFormProps = {
 const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
   const { amiChartsService } = useContext(AuthContext)
 
-  // const [tempId, setTempId] = useState<number | null>(null)
   const [options, setOptions] = useState({
     amiCharts: [],
     unitPriorities: [],
@@ -110,7 +108,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
   const resetDefaultValues = () => {
     if (defaultUnit) {
       Object.keys(defaultUnit).forEach((key) => {
-        console.log("setting value", key, defaultUnit[key])
         setValue(key, defaultUnit[key])
       })
     }
@@ -132,7 +129,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
         .sort(function (a, b) {
           return a.householdSize - b.householdSize
         })
-      console.log("fetched ami chart", amiChartData)
       amiChartData.forEach((amiValue, index) => {
         setValue(`maxIncomeHouseholdSize${index + 1}`, amiValue.income.toString())
       })
@@ -142,24 +138,16 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
   }
 
   useEffect(() => {
-    console.log("use effect 4")
-    console.log(amiChartID && amiPercentage && loading)
     if (amiChartID && amiPercentage && !loading) {
       void fetchAmiChart()
     }
   }, [amiChartID, amiPercentage])
-
-  const amiChartTableHeaders = {
-    householdSize: "listings.householdSize",
-    maxIncome: "listings.maxAnnualIncome",
-  }
 
   async function onFormSubmit(action?: string) {
     setLoading(true)
     const data = getValues()
     const validation = await trigger()
     if (!validation) {
-      console.log({ data })
       ;[...Array(maxAmiHouseholdSize)].forEach((index) => {
         const fieldName = `maxIncomeHouseholdSize${index + 1}`
         setValue(fieldName, data[fieldName])
@@ -203,16 +191,8 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
       ...data,
     }
 
-    // open fresh, save with tempId
-    // open from edited, save with tempId
-    // open fresh, copy and new, save with tempId, open again with new id and default
-    // open from edited, copy and new, DONT save current one just open with new ID and default
-
     const existingId = units.filter((unit) => unit.tempId === defaultUnit?.tempId)[0]?.tempId
     const nextId = units.length + 1
-
-    console.log({ existingId })
-    console.log({ nextId })
 
     if (action === "copyNew") {
       onSubmit({
@@ -228,6 +208,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
       })
       onClose(true, null)
       reset()
+      setValue("status", "available")
     } else {
       onSubmit({
         ...formData,
@@ -251,8 +232,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
   ]
 
   useEffect(() => {
-    console.log("use effect 5")
-    // hm this seems to be running a lot
     setOptions({
       amiCharts: arrayToFormOptions<AmiChart>(amiCharts, "name", "id"),
       unitPriorities: arrayToFormOptions<UnitAccessibilityPriorityType>(
@@ -423,7 +402,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
               </thead>
               <tbody>{getAmiChartTableData()}</tbody>
             </table>
-            {/* <MinimalTable headers={amiChartTableHeaders} data={getAmiChartTableData()} /> */}
           </GridCell>
         </GridSection>
         <GridSection columns={4} className="pt-6">

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -102,7 +102,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
 
   const resetDefaultValues = async () => {
     if (defaultUnit) {
-      const chartData = await fetchAmiChart(defaultUnit.amiChart.id, defaultUnit.amiPercentage)
+      const chartData = await fetchAmiChart(defaultUnit.amiChart.id)
       resetAmiTableValues(chartData, defaultUnit.amiPercentage)
       Object.keys(defaultUnit).forEach((key) => {
         setValue(key, defaultUnit[key])
@@ -123,7 +123,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
     void resetDefaultValues()
   }, [])
 
-  const fetchAmiChart = async (defaultChartID?: string, defaultAmiPercentage?: string) => {
+  const fetchAmiChart = async (defaultChartID?: string) => {
     try {
       const thisAmiChart = await amiChartsService.retrieve({
         amiChartId: defaultChartID ?? amiChartID,
@@ -204,9 +204,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
 
     // Only keep overrides so we're not duplicating existing ami data
     ;[...Array(maxAmiHouseholdSize)].forEach((_, index) => {
-      const existingChartValue = currentAmiChart
-        .filter((item: AmiChartItem) => item.householdSize === index + 1)
-        .filter((item: AmiChartItem) => item.percentOfAmi === parseInt(amiPercentage))[0]
+      const existingChartValue = currentAmiChart.filter(
+        (item: AmiChartItem) =>
+          item.householdSize === index + 1 && item.percentOfAmi === parseInt(amiPercentage)
+      )[0]
       if (
         data[`maxIncomeHouseholdSize${index + 1}`] &&
         parseInt(data[`maxIncomeHouseholdSize${index + 1}`]) === existingChartValue.income

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -41,6 +41,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     unitTypes: [],
   })
   const [loading, setLoading] = useState(true)
+  const [currentAmiChart, setCurrentAmiChart] = useState(null)
 
   const unitStatusOptions = Object.values(UnitStatus).map((status) => ({
     label: t(`listings.unit.statusOptions.${status}`),
@@ -122,6 +123,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
         .sort(function (a, b) {
           return a.householdSize - b.householdSize
         })
+      setCurrentAmiChart(amiChartData)
       amiChartData.forEach((amiValue, index) => {
         setValue(`maxIncomeHouseholdSize${index + 1}`, amiValue.income.toString())
       })
@@ -163,6 +165,16 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     } else {
       delete data.unitType
     }
+
+    // Only keep overrides so we're not duplicating existing ami data
+    ;[...Array(maxAmiHouseholdSize)].forEach((_, index) => {
+      if (
+        data[`maxIncomeHouseholdSize${index + 1}`] &&
+        parseInt(data[`maxIncomeHouseholdSize${index + 1}`]) === currentAmiChart[index].income
+      ) {
+        delete data[`maxIncomeHouseholdSize${index + 1}`]
+      }
+    })
 
     const formData: TempUnit = {
       createdAt: undefined,

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -118,7 +118,7 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
       acc.push({ householdSize: index + 1, maxIncome: incomeCell })
       return acc
     }, [])
-  }, [fetchedAmiChart])
+  }, [fetchedAmiChart, register])
 
   useEffect(() => {
     const fetchAmiChart = async () => {

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -74,8 +74,7 @@ const UnitForm = ({ onSubmit, onClose, tempId, defaultUnit }: UnitFormProps) => 
   const maxAmiHouseholdSize = 8
 
   const getAmiChartTableData = () => {
-    console.log("getamiChartTableData")
-    return [...Array(maxAmiHouseholdSize)].reduce((acc, _, index) => {
+    return [...Array(maxAmiHouseholdSize)].map((_, index) => {
       const fieldName = `maxIncomeHouseholdSize${index + 1}`
       const incomeCell = (
         <Field
@@ -97,9 +96,13 @@ const UnitForm = ({ onSubmit, onClose, tempId, defaultUnit }: UnitFormProps) => 
           }}
         />
       )
-      acc.push({ householdSize: index + 1, maxIncome: incomeCell })
-      return acc
-    }, [])
+      return (
+        <tr>
+          <td>{index + 1}</td>
+          <td>{incomeCell}</td>
+        </tr>
+      )
+    })
   }
 
   useEffect(() => {
@@ -109,6 +112,7 @@ const UnitForm = ({ onSubmit, onClose, tempId, defaultUnit }: UnitFormProps) => 
         setValue(key, defaultUnit[key])
       })
     }
+    setValue("status", "available")
   }, [])
 
   useEffect(() => {
@@ -368,7 +372,14 @@ const UnitForm = ({ onSubmit, onClose, tempId, defaultUnit }: UnitFormProps) => 
         </GridSection>
         <GridSection columns={2} className="pt-6">
           <GridCell>
-            <MinimalTable headers={amiChartTableHeaders} data={getAmiChartTableData()} />
+            <table>
+              <tr>
+                <th>{t("listings.householdSize")}</th>
+                <th>{t("listings.maxAnnualIncome")}</th>
+              </tr>
+              {getAmiChartTableData()}
+            </table>
+            {/* <MinimalTable headers={amiChartTableHeaders} data={getAmiChartTableData()} /> */}
           </GridCell>
         </GridSection>
         <GridSection columns={4} className="pt-6">

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -27,7 +27,7 @@ import { useAmiChartList, useUnitPriorityList, useUnitTypeList } from "../../../
 import { arrayToFormOptions, getRentType } from "../../../lib/helpers"
 
 type UnitFormProps = {
-  onSubmit: (unit: any) => void
+  onSubmit: (unit: TempUnit) => void
   onClose: (reopen: boolean, defaultUnit?: TempUnit) => void
   defaultUnit: TempUnit | undefined
   units: TempUnit[]
@@ -41,7 +41,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     unitPriorities: [],
     unitTypes: [],
   })
-  const [amiOverrides, setAmiOverrides] = useState({})
   const [loading, setLoading] = useState(true)
 
   const unitStatusOptions = Object.values(UnitStatus).map((status) => ({
@@ -57,15 +56,16 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
   const { data: unitTypes = [] } = useUnitTypeList()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, watch, errors, trigger, getValues, setValue, control, reset } = useForm()
+  const { register, errors, trigger, getValues, setValue, control, reset } = useForm()
 
-  const rentType = watch("rentType")
-
+  const rentType: string = useWatch({
+    control,
+    name: "rentType",
+  })
   const amiPercentage: string = useWatch({
     control,
     name: "amiPercentage",
   })
-
   const amiChartID: string = useWatch({
     control,
     name: "amiChart.id",
@@ -86,14 +86,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
           type="number"
           prepend="$"
           readerOnly
-          inputProps={{
-            onChange: (e) => {
-              const { id, value } = e.target
-              const overrides = amiOverrides
-              overrides[id] = value
-              setAmiOverrides(overrides)
-            },
-          }}
         />
       )
       return (
@@ -147,13 +139,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     setLoading(true)
     const data = getValues()
     const validation = await trigger()
-    if (!validation) {
-      ;[...Array(maxAmiHouseholdSize)].forEach((index) => {
-        const fieldName = `maxIncomeHouseholdSize${index + 1}`
-        setValue(fieldName, data[fieldName])
-      })
-      return
-    }
+    if (!validation) return
 
     if (data.amiChart?.id) {
       const chart = amiCharts.find((chart) => chart.id === data.amiChart.id)

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext, useCallback } from "react"
+import React, { useEffect, useState, useContext } from "react"
 import {
   t,
   GridSection,
@@ -12,7 +12,6 @@ import {
   Button,
   Form,
   numberOptions,
-  MinimalTable,
   AuthContext,
 } from "@bloom-housing/ui-components"
 import { useForm, useWatch } from "react-hook-form"
@@ -90,7 +89,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
       )
       return (
         <tr key={index}>
-          <td>{index + 1}</td>
+          <td className={"pl-4"}>{index + 1}</td>
           <td>{incomeCell}</td>
         </tr>
       )
@@ -130,7 +129,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
   }
 
   useEffect(() => {
-    if (amiChartID && amiPercentage && !loading) {
+    if (amiChartID && amiPercentage && !loading && options) {
       void fetchAmiChart()
     }
   }, [amiChartID, amiPercentage])
@@ -228,6 +227,14 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
       unitTypes: arrayToFormOptions<UnitType>(unitTypes, "name", "id"),
     })
   }, [amiCharts, unitPriorities, unitTypes])
+
+  // useEffect(() => {
+  //   if (defaultUnit) {
+  //     setValue("amiChart.id", defaultUnit.amiChart?.id)
+  //     setValue("priorityType.id", defaultUnit.priorityType?.id)
+  //     setValue("unitType.id", defaultUnit.unitType?.id)
+  //   }
+  // }, [options])
 
   return (
     <Form onSubmit={() => false}>

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -104,6 +104,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
       })
     }
     setValue("status", "available")
+    setValue("rentType", getRentType(defaultUnit))
     setLoading(false)
   }
 

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -34,6 +34,7 @@ type UnitFormProps = {
 }
 
 const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) => {
+  console.log("Re-render")
   const { amiChartsService } = useContext(AuthContext)
 
   const [current, setCurrent] = useState<TempUnit>(null)
@@ -58,7 +59,7 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
   const { data: unitTypes = [] } = useUnitTypeList()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, watch, errors, trigger, getValues, reset, setValue } = useForm({
+  const { register, watch, errors, trigger, getValues, reset } = useForm({
     defaultValues: {
       number: current?.number,
       unitType: current?.unitType,
@@ -85,6 +86,7 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
   useEffect(() => {
     const unit = units.filter((unit) => unit.tempId === tempId)[0]
     setCurrent(unit)
+    console.log("reset 3")
     reset({
       ...unit,
       rentType: getRentType(unit),
@@ -98,13 +100,16 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
 
   const maxAmiHouseholdSize = 8
 
+  // could keep updated values in state, check for state value before setting default
+
   const getAmiChartTableData = useMemo(() => {
     console.log("getAmiChartTableData")
     return [...Array(maxAmiHouseholdSize)].reduce((acc, current, index) => {
+      const fieldName = `maxIncomeHouseholdSize${index + 1}`
       const incomeCell = (
         <Field
-          id={`maxIncomeHouseholdSize${index + 1}`}
-          name={`maxIncomeHouseholdSize${index + 1}`}
+          id={fieldName}
+          name={fieldName}
           label={t("t.minimumIncome")}
           defaultValue={
             fetchedAmiChart && fetchedAmiChart.length ? fetchedAmiChart[index].income : 0
@@ -143,16 +148,18 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
     }
   }, [amiChartID, amiPercentage])
 
-  console.log("rendering form")
-
   const amiChartTableHeaders = {
     householdSize: "listings.householdSize",
     maxIncome: "listings.maxAnnualIncome",
   }
 
   async function onFormSubmit(action?: string) {
+    console.log("onFormSubmit")
     const data = getValues()
+    console.log(data)
+    console.log("getting values")
     const validation = await trigger()
+    console.log("validation trigger")
     if (!validation) return
 
     if (data.amiChart?.id) {
@@ -160,16 +167,6 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
       data.amiChart = chart
     } else {
       delete data.amiChart
-    }
-
-    console.log(data)
-
-    for (const key in data) {
-      if (key.slice(0, -1) === "maxIncomeHouseholdSize") {
-        if (data[key] !== fetchedAmiChart[parseInt(key[key.length - 1]) - 1]) {
-          console.log("we have an override!")
-        }
-      }
     }
 
     if (data.rentType === "fixed") {
@@ -208,9 +205,11 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
     setTempId(null)
     if (action === "copyNew") {
       setCurrent({ ...formData, id: current?.id, tempId: units.length + 1 })
+      console.log("reset 1")
       reset({ ...formData })
     } else if (action === "saveNew") {
       setCurrent(null)
+      console.log("reset 2")
       reset()
     } else {
       onClose()
@@ -242,6 +241,7 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
     })
   }, [amiCharts, unitPriorities, unitTypes])
 
+  console.log("in component", getValues())
   return (
     <Form onSubmit={() => false}>
       <div className="border rounded-md p-8 bg-white">

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -230,6 +230,17 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     }
   }, [options])
 
+  useEffect(() => {
+    if (defaultUnit) {
+      if (rentType === "fixed") {
+        setValue("monthlyIncomeMin", defaultUnit.monthlyIncomeMin)
+        setValue("monthlyRent", defaultUnit.monthlyRent)
+      } else {
+        setValue("monthlyRentAsPercentOfIncome", defaultUnit.monthlyRentAsPercentOfIncome)
+      }
+    }
+  }, [rentType])
+
   return (
     <Form onSubmit={() => false}>
       <div className="border rounded-md p-8 bg-white">
@@ -362,8 +373,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
                 controlClassName="control"
                 options={options.amiCharts}
                 inputProps={{
-                  onChange: (e) => {
-                    console.log("chart on change")
+                  onChange: () => {
                     if (amiChartID && amiPercentage && !loading && options) {
                       void fetchAmiChart()
                     }
@@ -383,8 +393,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
                 type="number"
                 readerOnly
                 inputProps={{
-                  onChange: (e) => {
-                    console.log("percentage on change")
+                  onChange: () => {
                     if (amiChartID && amiPercentage && !loading && options) {
                       void fetchAmiChart()
                     }

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from "react"
+import React, { useEffect, useState, useContext, useMemo } from "react"
 import {
   t,
   GridSection,
@@ -98,7 +98,7 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
 
   const maxAmiHouseholdSize = 8
 
-  const getAmiChartTableData = () => {
+  const getAmiChartTableData = useMemo(() => {
     console.log("getAmiChartTableData")
     return [...Array(maxAmiHouseholdSize)].reduce((acc, current, index) => {
       const incomeCell = (
@@ -106,7 +106,9 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
           id={`maxIncomeHouseholdSize${index + 1}`}
           name={`maxIncomeHouseholdSize${index + 1}`}
           label={t("t.minimumIncome")}
-          defaultValue={fetchedAmiChart ? fetchedAmiChart[index].income : 0}
+          defaultValue={
+            fetchedAmiChart && fetchedAmiChart.length ? fetchedAmiChart[index].income : 0
+          }
           register={register}
           type="number"
           prepend="$"
@@ -116,7 +118,7 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
       acc.push({ householdSize: index + 1, maxIncome: incomeCell })
       return acc
     }, [])
-  }
+  }, [fetchedAmiChart])
 
   useEffect(() => {
     const fetchAmiChart = async () => {
@@ -391,7 +393,7 @@ const UnitForm = ({ onSubmit, onClose, units, currentTempId }: UnitFormProps) =>
         {amiChartID && amiPercentage && fetchedAmiChart && fetchedAmiChart.length > 0 && (
           <GridSection columns={2} className="pt-6">
             <GridCell>
-              <MinimalTable headers={amiChartTableHeaders} data={getAmiChartTableData()} />
+              <MinimalTable headers={amiChartTableHeaders} data={getAmiChartTableData} />
             </GridCell>
           </GridSection>
         )}

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -113,13 +113,14 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
         })
       }
     }
+    setValue("amiPercentage", parseInt(defaultUnit["amiPercentage"]))
     setValue("status", "available")
     setValue("rentType", getRentType(defaultUnit))
     setLoading(false)
   }
 
   useEffect(() => {
-    resetDefaultValues()
+    void resetDefaultValues()
   }, [])
 
   const fetchAmiChart = async (defaultChartID?: string, defaultAmiPercentage?: string) => {
@@ -156,7 +157,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
       .sort(function (a: AmiChartItem, b: AmiChartItem) {
         return a.householdSize - b.householdSize
       })
-    newPercentages.forEach((amiValue, index) => {
+    newPercentages.forEach((amiValue: AmiChartItem, index: number) => {
       setValue(`maxIncomeHouseholdSize${index + 1}`, amiValue.income.toString())
     })
   }
@@ -228,7 +229,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
         tempId: nextId,
       })
       onClose(true, { ...formData, tempId: nextId + 1 })
-      resetDefaultValues()
+      void resetDefaultValues()
     } else if (action === "saveNew") {
       onSubmit({
         ...formData,

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -99,7 +99,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
 
   const resetDefaultValues = async () => {
     if (defaultUnit) {
-      console.log({ defaultUnit })
       await fetchAmiChart(defaultUnit.amiChart.id, defaultUnit.amiPercentage)
       Object.keys(defaultUnit).forEach((key) => {
         setValue(key, defaultUnit[key])

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -128,12 +128,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     }
   }
 
-  useEffect(() => {
-    if (amiChartID && amiPercentage && !loading && options) {
-      void fetchAmiChart()
-    }
-  }, [amiChartID, amiPercentage])
-
   async function onFormSubmit(action?: string) {
     setLoading(true)
     const data = getValues()
@@ -228,13 +222,13 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
     })
   }, [amiCharts, unitPriorities, unitTypes])
 
-  // useEffect(() => {
-  //   if (defaultUnit) {
-  //     setValue("amiChart.id", defaultUnit.amiChart?.id)
-  //     setValue("priorityType.id", defaultUnit.priorityType?.id)
-  //     setValue("unitType.id", defaultUnit.unitType?.id)
-  //   }
-  // }, [options])
+  useEffect(() => {
+    if (defaultUnit) {
+      setValue("amiChart.id", defaultUnit.amiChart?.id)
+      setValue("priorityType.id", defaultUnit.priorityType?.id)
+      setValue("unitType.id", defaultUnit.unitType?.id)
+    }
+  }, [options])
 
   return (
     <Form onSubmit={() => false}>
@@ -367,6 +361,14 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
                 register={register}
                 controlClassName="control"
                 options={options.amiCharts}
+                inputProps={{
+                  onChange: (e) => {
+                    console.log("chart on change")
+                    if (amiChartID && amiPercentage && !loading && options) {
+                      void fetchAmiChart()
+                    }
+                  },
+                }}
               />
             </ViewItem>
           </GridCell>
@@ -380,6 +382,14 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
                 register={register}
                 type="number"
                 readerOnly
+                inputProps={{
+                  onChange: (e) => {
+                    console.log("percentage on change")
+                    if (amiChartID && amiPercentage && !loading && options) {
+                      void fetchAmiChart()
+                    }
+                  },
+                }}
               />
             </ViewItem>
           </GridCell>

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -99,10 +99,16 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, units }: UnitFormProps) => {
 
   const resetDefaultValues = async () => {
     if (defaultUnit) {
+      console.log({ defaultUnit })
       await fetchAmiChart(defaultUnit.amiChart.id, defaultUnit.amiPercentage)
       Object.keys(defaultUnit).forEach((key) => {
         setValue(key, defaultUnit[key])
       })
+      if (defaultUnit.amiChartOverride) {
+        defaultUnit.amiChartOverride.items.forEach((override) => {
+          setValue(`maxIncomeHouseholdSize${override.householdSize}`, override.income)
+        })
+      }
     }
     setValue("status", "available")
     setValue("rentType", getRentType(defaultUnit))

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -251,8 +251,6 @@ const formatFormData = (
     data.applicationDueTimeField
   )
 
-  console.log("onSubmit units", units)
-
   units.forEach((unit) => {
     switch (unit.unitType?.name) {
       case "fourBdrm":
@@ -300,8 +298,6 @@ const formatFormData = (
 
     delete unit.tempId
   })
-
-  console.log("onSubmit after massaging", units)
 
   const events: ListingEventCreate[] = data.events.filter(
     (event) => !(event?.type === ListingEventType.publicLottery)

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -33,7 +33,6 @@ import {
   PaperApplication,
   PaperApplicationCreate,
   ListingReviewOrder,
-  UnitAmiChartOverrideCreate,
 } from "@bloom-housing/backend-core/types"
 import { YesNoAnswer } from "../../applications/PaperApplicationForm/FormTypes"
 import moment from "moment"

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -217,14 +217,6 @@ const defaults: FormListing = {
 
 export type TempUnit = Unit & {
   tempId?: number
-  maxIncomeHouseholdSize1?: string
-  maxIncomeHouseholdSize2?: string
-  maxIncomeHouseholdSize3?: string
-  maxIncomeHouseholdSize4?: string
-  maxIncomeHouseholdSize5?: string
-  maxIncomeHouseholdSize6?: string
-  maxIncomeHouseholdSize7?: string
-  maxIncomeHouseholdSize8?: string
 }
 
 export type TempEvent = ListingEvent & {

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -33,6 +33,7 @@ import {
   PaperApplication,
   PaperApplicationCreate,
   ListingReviewOrder,
+  UnitAmiChartOverrideCreate,
 } from "@bloom-housing/backend-core/types"
 import { YesNoAnswer } from "../../applications/PaperApplicationForm/FormTypes"
 import moment from "moment"
@@ -217,6 +218,14 @@ const defaults: FormListing = {
 
 export type TempUnit = Unit & {
   tempId?: number
+  maxIncomeHouseholdSize1?: string
+  maxIncomeHouseholdSize2?: string
+  maxIncomeHouseholdSize3?: string
+  maxIncomeHouseholdSize4?: string
+  maxIncomeHouseholdSize5?: string
+  maxIncomeHouseholdSize6?: string
+  maxIncomeHouseholdSize7?: string
+  maxIncomeHouseholdSize8?: string
 }
 
 export type TempEvent = ListingEvent & {
@@ -242,6 +251,8 @@ const formatFormData = (
     data.applicationDueTimeField
   )
 
+  console.log("onSubmit units", units)
+
   units.forEach((unit) => {
     switch (unit.unitType?.name) {
       case "fourBdrm":
@@ -260,6 +271,24 @@ const formatFormData = (
         unit.numBedrooms = null
     }
 
+    Object.keys(unit).forEach((key) => {
+      if (key.indexOf("maxIncomeHouseholdSize") >= 0) {
+        if (!unit.amiChartOverride) {
+          unit.amiChartOverride = {
+            id: undefined,
+            createdAt: undefined,
+            updatedAt: undefined,
+            items: [],
+          }
+        }
+        unit.amiChartOverride.items.push({
+          percentOfAmi: parseInt(unit.amiPercentage),
+          householdSize: parseInt(key[key.length - 1]),
+          income: parseInt(unit[key]),
+        })
+      }
+    })
+
     unit.floor = stringToNumber(unit.floor)
     unit.maxOccupancy = stringToNumber(unit.maxOccupancy)
     unit.minOccupancy = stringToNumber(unit.minOccupancy)
@@ -271,6 +300,8 @@ const formatFormData = (
 
     delete unit.tempId
   })
+
+  console.log("onSubmit after massaging", units)
 
   const events: ListingEventCreate[] = data.events.filter(
     (event) => !(event?.type === ListingEventType.publicLottery)

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -217,6 +217,14 @@ const defaults: FormListing = {
 
 export type TempUnit = Unit & {
   tempId?: number
+  maxIncomeHouseholdSize1?: string
+  maxIncomeHouseholdSize2?: string
+  maxIncomeHouseholdSize3?: string
+  maxIncomeHouseholdSize4?: string
+  maxIncomeHouseholdSize5?: string
+  maxIncomeHouseholdSize6?: string
+  maxIncomeHouseholdSize7?: string
+  maxIncomeHouseholdSize8?: string
 }
 
 export type TempEvent = ListingEvent & {

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -24,7 +24,7 @@ type UnitProps = {
 }
 
 const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
-  const [unitDrawer, setUnitDrawer] = useState<number | null>(null)
+  const [unitDrawerId, setUnitDrawerId] = useState<number | null>(null)
   const [unitDeleteModal, setUnitDeleteModal] = useState<number | null>(null)
 
   const formMethods = useFormContext()
@@ -48,9 +48,9 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
 
   const editUnit = useCallback(
     (tempId: number) => {
-      setUnitDrawer(tempId)
+      setUnitDrawerId(tempId)
     },
-    [setUnitDrawer]
+    [setUnitDrawerId]
   )
 
   const deleteUnit = useCallback(
@@ -69,7 +69,6 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
   )
 
   function saveUnit(newUnit: TempUnit) {
-    console.log(newUnit)
     const exists = units.some((unit) => unit.tempId === newUnit.tempId)
     if (exists) {
       const updateUnits = units.map((unit) => (unit.tempId === newUnit.tempId ? newUnit : unit))
@@ -164,16 +163,16 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
       </GridSection>
 
       <Drawer
-        open={unitDrawer !== null && unitDrawer !== undefined}
+        open={unitDrawerId !== null && unitDrawerId !== undefined}
         title={t("listings.unit.add")}
         ariaDescription={t("listings.unit.add")}
-        onClose={() => setUnitDrawer(null)}
+        onClose={() => setUnitDrawerId(null)}
       >
         <UnitForm
           onSubmit={(unit) => saveUnit(unit)}
-          onClose={() => setUnitDrawer(null)}
-          units={units}
-          currentTempId={unitDrawer}
+          onClose={() => setUnitDrawerId(null)}
+          defaultUnit={units.filter((unit) => unit.tempId === unitDrawerId)[0]}
+          tempId={unitDrawerId}
         />
       </Drawer>
 

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -69,6 +69,7 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
   )
 
   function saveUnit(newUnit: TempUnit) {
+    console.log(newUnit)
     const exists = units.some((unit) => unit.tempId === newUnit.tempId)
     if (exists) {
       const updateUnits = units.map((unit) => (unit.tempId === newUnit.tempId ? newUnit : unit))

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -162,15 +162,13 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
       </GridSection>
 
       <Drawer
-        open={unitDrawerId !== null && unitDrawerId !== undefined}
+        open={!!unitDrawerId}
         title={t("listings.unit.add")}
         ariaDescription={t("listings.unit.add")}
         onClose={() => setUnitDrawerId(null)}
       >
         <UnitForm
-          onSubmit={(unit) => {
-            saveUnit(unit)
-          }}
+          onSubmit={(unit) => saveUnit(unit)}
           onClose={(reopen: boolean, defaultUnit: TempUnit) => {
             if (reopen) {
               if (defaultUnit) {

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -184,7 +184,8 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
             }
           }}
           defaultUnit={defaultUnit}
-          units={units}
+          existingId={units.filter((unit) => unit.tempId === defaultUnit?.tempId)[0]?.tempId}
+          nextId={units.length + 1}
         />
       </Drawer>
 

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -163,7 +163,7 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
       </GridSection>
 
       <Drawer
-        open={!!unitDrawer}
+        open={unitDrawer !== null && unitDrawer !== undefined}
         title={t("listings.unit.add")}
         ariaDescription={t("listings.unit.add")}
         onClose={() => setUnitDrawer(null)}

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -48,7 +48,6 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
   }, [disableUnitsAccordion, setValue])
 
   const editUnit = (tempId: number) => {
-    console.log({ units })
     setDefaultUnit(units.filter((unit) => unit.tempId === tempId)[0])
     setUnitDrawerId(tempId)
   }
@@ -68,12 +67,8 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
     [setUnitDeleteModal, setUnits, units]
   )
 
-  console.log({ units })
   function saveUnit(newUnit: TempUnit) {
-    console.log("in the save unit")
-    console.log({ newUnit })
     const exists = units.some((unit) => unit.tempId === newUnit.tempId)
-    console.log("exists", exists)
     if (exists) {
       const updateUnits = units.map((unit) => (unit.tempId === newUnit.tempId ? newUnit : unit))
       setUnits(updateUnits)
@@ -174,12 +169,9 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
       >
         <UnitForm
           onSubmit={(unit) => {
-            console.log("on submit")
             saveUnit(unit)
           }}
           onClose={(reopen: boolean, defaultUnit: TempUnit) => {
-            console.log("in the on close")
-            console.log(reopen, defaultUnit)
             if (reopen) {
               if (defaultUnit) {
                 setDefaultUnit(defaultUnit)

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -26,6 +26,7 @@ type UnitProps = {
 const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
   const [unitDrawerId, setUnitDrawerId] = useState<number | null>(null)
   const [unitDeleteModal, setUnitDeleteModal] = useState<number | null>(null)
+  const [defaultUnit, setDefaultUnit] = useState<TempUnit | null>(null)
 
   const formMethods = useFormContext()
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -46,12 +47,11 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
     setValue("disableUnitsAccordion", disableUnitsAccordion ? "true" : "false")
   }, [disableUnitsAccordion, setValue])
 
-  const editUnit = useCallback(
-    (tempId: number) => {
-      setUnitDrawerId(tempId)
-    },
-    [setUnitDrawerId]
-  )
+  const editUnit = (tempId: number) => {
+    console.log({ units })
+    setDefaultUnit(units.filter((unit) => unit.tempId === tempId)[0])
+    setUnitDrawerId(tempId)
+  }
 
   const deleteUnit = useCallback(
     (tempId: number) => {
@@ -68,8 +68,12 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
     [setUnitDeleteModal, setUnits, units]
   )
 
+  console.log({ units })
   function saveUnit(newUnit: TempUnit) {
+    console.log("in the save unit")
+    console.log({ newUnit })
     const exists = units.some((unit) => unit.tempId === newUnit.tempId)
+    console.log("exists", exists)
     if (exists) {
       const updateUnits = units.map((unit) => (unit.tempId === newUnit.tempId ? newUnit : unit))
       setUnits(updateUnits)
@@ -169,10 +173,28 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
         onClose={() => setUnitDrawerId(null)}
       >
         <UnitForm
-          onSubmit={(unit) => saveUnit(unit)}
-          onClose={() => setUnitDrawerId(null)}
-          defaultUnit={units.filter((unit) => unit.tempId === unitDrawerId)[0]}
-          tempId={unitDrawerId}
+          onSubmit={(unit) => {
+            console.log("on submit")
+            saveUnit(unit)
+          }}
+          onClose={(reopen: boolean, defaultUnit: TempUnit) => {
+            console.log("in the on close")
+            console.log(reopen, defaultUnit)
+            if (reopen) {
+              if (defaultUnit) {
+                setDefaultUnit(defaultUnit)
+                editUnit(units.length + 1)
+              } else {
+                setDefaultUnit(null)
+                setUnitDrawerId(units.length + 1)
+              }
+            } else {
+              setDefaultUnit(null)
+              setUnitDrawerId(null)
+            }
+          }}
+          defaultUnit={defaultUnit}
+          units={units}
         />
       </Drawer>
 

--- a/ui-components/src/forms/Field.tsx
+++ b/ui-components/src/forms/Field.tsx
@@ -87,7 +87,7 @@ const Field = (props: FieldProps) => {
       <div className={controlClasses.join(" ")}>
         {props.prepend && <span className="prepend">{props.prepend}</span>}
         <input
-          aria-describedby={props.describedBy ? props.describedBy : `${idOrName}-error`}
+          aria-describedby={props.describedBy ? props.describedBy : `${idOrName}`}
           aria-invalid={!!props.error || false}
           className="input"
           type={type}

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -848,6 +848,7 @@
     "mapPinPosition": "Map Pin Position",
     "mapPreview": "Map Preview",
     "mapPreviewNoAddress": "Enter an address to preview the map",
+    "maxAnnualIncome": "Maximum Annual Income",
     "maxIncomeMonth": "Maximum Income / Month",
     "maxIncomeYear": "Maximum Income / Year",
     "monthlyIncome": "%{income} per month",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -749,6 +749,7 @@
     "additionalInformation": "Additional Information",
     "allUnits": "All Units",
     "allUnitsReservedFor": "All units reserved for %{type}",
+    "amiOverrideTitle": "Override for household size of %{householdSize}",
     "annualIncome": "%{income} per year",
     "annualIncomeRange": "%{from} to %{to} per year",
     "applicationTitle": "Application Data",

--- a/ui-components/src/tables/StandardTable.tsx
+++ b/ui-components/src/tables/StandardTable.tsx
@@ -75,10 +75,6 @@ export const StandardTable = (props: StandardTableProps) => {
 
   const [tableData, setTableData] = useState<StandardTableData>()
 
-  useEffect(() => {
-    setTableData(props.data)
-  }, [props.data])
-
   const headerLabels = Object.values(headers)?.map((header, index) => {
     const uniqKey = process.env.NODE_ENV === "test" ? `header-${index}` : nanoid()
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -18372,16 +18372,6 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -18460,13 +18450,6 @@ react-input-autosize@^3.0.0:
   integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
   dependencies:
     prop-types "^15.5.8"
-
-react-hotkeys@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-2.0.0.tgz#a7719c7340cbba888b0e9184f806a9ec0ac2c53f"
-  integrity sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==
-  dependencies:
-    prop-types "^15.6.1"
 
 react-inspector@^5.1.0:
   version "5.1.1"
@@ -18650,15 +18633,6 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.1:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-
-react@16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
     prop-types "^15.6.2"
 
 react@^17.0.2:

--- a/yarn.lock
+++ b/yarn.lock
@@ -18372,6 +18372,16 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
+react-dom@16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
+  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -18640,6 +18650,15 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.1:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
+react@16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
     prop-types "^15.6.2"
 
 react@^17.0.2:

--- a/yarn.lock
+++ b/yarn.lock
@@ -18451,6 +18451,13 @@ react-input-autosize@^3.0.0:
   dependencies:
     prop-types "^15.5.8"
 
+react-hotkeys@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-hotkeys/-/react-hotkeys-2.0.0.tgz#a7719c7340cbba888b0e9184f806a9ec0ac2c53f"
+  integrity sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==
+  dependencies:
+    prop-types "^15.6.1"
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1706

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Adds the ability to create ami chart overrides in listings management, and also due to lots of state issues refactors the UnitForm component.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [x] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Create a new listing. Set an ami chart. Set an ami percentage from the dropdown (will pulls unique ami percentages from the selected dropdown). The table should populate with the ami chart values. Change one of the values (creating an override). Save the unit. Re-open the unit before saving the listing and ensure the override is still there. Change the percentage and the chart and ensure the override isn't sticky.

Save a listing with a unit with an overrides and view the details page for that unit and ensure the only value saved as an override is the one(s) that was overridden and that the default values aren't duplicated.

Ensure Copy and New works and brings overrides with it. Ensure Save and New and Save and Exit work as well.

Open an existing seeded listing to edit it and ensure the ami values populate.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
