### PR TITLE
1728/notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ All notable changes to this project will be documented in this file. The format 
   - Adds UnitAmiChartOverride entity and implements ami chart overriding at Unit level [#1575](https://github.com/bloom-housing/bloom/pull/1575)
   - Adds `authz.e2e-spec.ts` test cover for preventing user from voluntarily changing his associated `roles` object [#1575](https://github.com/bloom-housing/bloom/pull/1575)
   - Adds Jurisdictions to users, listings and translations. The migration script assigns the first alpha sorted jurisdiction to users, so this piece may need to be changed for Detroit, if they have more than Detroit in their DB. [#1776](https://github.com/bloom-housing/bloom/pull/1776)
+  - Added the optional jurisdiction setting notificationsSignUpURL, which now appears on the home page if set ([#1802](https://github.com/bloom-housing/bloom/pull/1802)) (Emily Jablonski)
 
 - Changed:
 

--- a/backend/core/src/jurisdictions/entities/jurisdiction.entity.ts
+++ b/backend/core/src/jurisdictions/entities/jurisdiction.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity } from "typeorm"
 import { AbstractEntity } from "../../shared/entities/abstract.entity"
 import { Expose } from "class-transformer"
-import { IsString, MaxLength } from "class-validator"
+import { IsString, MaxLength, IsOptional } from "class-validator"
 import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enum"
 
 @Entity({ name: "jurisdictions" })
@@ -11,4 +11,10 @@ export class Jurisdiction extends AbstractEntity {
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @MaxLength(256, { groups: [ValidationsGroupsEnum.default] })
   name: string
+
+  @Column({ nullable: true, type: "text" })
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  notificationsSignUpURL?: string | null
 }

--- a/backend/core/src/jurisdictions/jurisdictions.controller.ts
+++ b/backend/core/src/jurisdictions/jurisdictions.controller.ts
@@ -11,7 +11,7 @@ import {
   ValidationPipe,
 } from "@nestjs/common"
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger"
-import { DefaultAuthGuard } from "../auth/guards/default.guard"
+import { OptionalAuthGuard } from "../auth/guards/optional-auth.guard"
 import { AuthzGuard } from "../auth/guards/authz.guard"
 import { ResourceType } from "../auth/decorators/resource-type.decorator"
 import { mapTo } from "../shared/mapTo"
@@ -27,7 +27,7 @@ import {
 @ApiTags("jurisdictions")
 @ApiBearerAuth()
 @ResourceType("jurisdiction")
-@UseGuards(DefaultAuthGuard, AuthzGuard)
+@UseGuards(OptionalAuthGuard, AuthzGuard)
 @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
 export class JurisdictionsController {
   constructor(private readonly jurisdictionsService: JurisdictionsService) {}
@@ -50,12 +50,12 @@ export class JurisdictionsController {
     return mapTo(JurisdictionDto, await this.jurisdictionsService.update(jurisdiction))
   }
 
-  @Get(`:jurisdictionId`)
-  @ApiOperation({ summary: "Get jurisdiction by id", operationId: "retrieve" })
-  async retrieve(@Param("jurisdictionId") jurisdictionId: string): Promise<JurisdictionDto> {
+  @Get(`:jurisdictionName`)
+  @ApiOperation({ summary: "Get jurisdiction by name", operationId: "retrieve" })
+  async retrieve(@Param("jurisdictionName") jurisdictionName: string): Promise<JurisdictionDto> {
     return mapTo(
       JurisdictionDto,
-      await this.jurisdictionsService.findOne({ where: { id: jurisdictionId } })
+      await this.jurisdictionsService.findOne({ where: { name: jurisdictionName } })
     )
   }
 

--- a/backend/core/src/jurisdictions/jurisdictions.controller.ts
+++ b/backend/core/src/jurisdictions/jurisdictions.controller.ts
@@ -50,9 +50,20 @@ export class JurisdictionsController {
     return mapTo(JurisdictionDto, await this.jurisdictionsService.update(jurisdiction))
   }
 
-  @Get(`:jurisdictionName`)
-  @ApiOperation({ summary: "Get jurisdiction by name", operationId: "retrieve" })
-  async retrieve(@Param("jurisdictionName") jurisdictionName: string): Promise<JurisdictionDto> {
+  @Get(`:jurisdictionId`)
+  @ApiOperation({ summary: "Get jurisdiction by id", operationId: "retrieve" })
+  async retrieve(@Param("jurisdictionId") jurisdictionId: string): Promise<JurisdictionDto> {
+    return mapTo(
+      JurisdictionDto,
+      await this.jurisdictionsService.findOne({ where: { id: jurisdictionId } })
+    )
+  }
+
+  @Get(`byName/:jurisdictionName`)
+  @ApiOperation({ summary: "Get jurisdiction by name", operationId: "retrieveByName" })
+  async retrieveByName(
+    @Param("jurisdictionName") jurisdictionName: string
+  ): Promise<JurisdictionDto> {
     return mapTo(
       JurisdictionDto,
       await this.jurisdictionsService.findOne({ where: { name: jurisdictionName } })

--- a/backend/core/src/migration/1630105131436-add-jurisdiction-notification-setting.ts
+++ b/backend/core/src/migration/1630105131436-add-jurisdiction-notification-setting.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { CountyCode } from "../shared/types/county-code"
+
+export class addJurisdictionNotificationSetting1630105131436 implements MigrationInterface {
+  name = "addJurisdictionNotificationSetting1630105131436"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "jurisdictions" ADD "notifications_sign_up_url" text`)
+
+    await queryRunner.query(
+      `UPDATE "jurisdictions" SET notifications_sign_up_url = 'https://public.govdelivery.com/accounts/CAALAME/signup/29386' WHERE name = ($1)`,
+      [CountyCode.alameda]
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "jurisdictions" DROP COLUMN "notifications_sign_up_url"`)
+  }
+}

--- a/backend/core/test/jurisdictions/jurisdictions.e2e-spec.ts
+++ b/backend/core/test/jurisdictions/jurisdictions.e2e-spec.ts
@@ -58,7 +58,7 @@ describe("Jurisdictions", () => {
     expect(res.body.name).toBe("test")
 
     const getById = await supertest(app.getHttpServer())
-      .get(`/jurisdictions/${res.body.id}`)
+      .get(`/jurisdictions/${res.body.name}`)
       .set(...setAuthorization(adminAccesstoken))
       .expect(200)
     expect(getById.body.name).toBe("test")

--- a/backend/core/test/jurisdictions/jurisdictions.e2e-spec.ts
+++ b/backend/core/test/jurisdictions/jurisdictions.e2e-spec.ts
@@ -58,10 +58,37 @@ describe("Jurisdictions", () => {
     expect(res.body.name).toBe("test")
 
     const getById = await supertest(app.getHttpServer())
-      .get(`/jurisdictions/${res.body.name}`)
+      .get(`/jurisdictions/${res.body.id}`)
       .set(...setAuthorization(adminAccesstoken))
       .expect(200)
     expect(getById.body.name).toBe("test")
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(async () => {
+    await app.close()
+  })
+
+  it(`should create and return a new jurisdiction by name`, async () => {
+    const res = await supertest(app.getHttpServer())
+      .post(`/jurisdictions`)
+      .set(...setAuthorization(adminAccesstoken))
+      .send({ name: "test2" })
+      .expect(201)
+    expect(res.body).toHaveProperty("id")
+    expect(res.body).toHaveProperty("createdAt")
+    expect(res.body).toHaveProperty("updatedAt")
+    expect(res.body).toHaveProperty("name")
+    expect(res.body.name).toBe("test2")
+
+    const getById = await supertest(app.getHttpServer())
+      .get(`/jurisdictions/byName/${res.body.name}`)
+      .set(...setAuthorization(adminAccesstoken))
+      .expect(200)
+    expect(getById.body.name).toBe("test2")
   })
 
   afterEach(() => {

--- a/backend/core/test/jurisdictions/jurisdictions.e2e-spec.ts
+++ b/backend/core/test/jurisdictions/jurisdictions.e2e-spec.ts
@@ -59,7 +59,6 @@ describe("Jurisdictions", () => {
 
     const getById = await supertest(app.getHttpServer())
       .get(`/jurisdictions/${res.body.id}`)
-      .set(...setAuthorization(adminAccesstoken))
       .expect(200)
     expect(getById.body.name).toBe("test")
   })
@@ -84,11 +83,10 @@ describe("Jurisdictions", () => {
     expect(res.body).toHaveProperty("name")
     expect(res.body.name).toBe("test2")
 
-    const getById = await supertest(app.getHttpServer())
+    const getByName = await supertest(app.getHttpServer())
       .get(`/jurisdictions/byName/${res.body.name}`)
-      .set(...setAuthorization(adminAccesstoken))
       .expect(200)
-    expect(getById.body.name).toBe("test2")
+    expect(getByName.body.name).toBe("test2")
   })
 
   afterEach(() => {

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -3562,6 +3562,9 @@ export interface Jurisdiction {
 
   /**  */
   name: string
+
+  /**  */
+  notificationsSignUpURL?: string
 }
 
 export interface User {
@@ -3821,6 +3824,9 @@ export interface UserInvite {
 export interface JurisdictionCreate {
   /**  */
   name: string
+
+  /**  */
+  notificationsSignUpURL?: string
 }
 
 export interface JurisdictionUpdate {
@@ -3835,6 +3841,9 @@ export interface JurisdictionUpdate {
 
   /**  */
   name: string
+
+  /**  */
+  notificationsSignUpURL?: string
 }
 
 export interface ListingFilterParams {

--- a/sites/public/pages/index.tsx
+++ b/sites/public/pages/index.tsx
@@ -121,7 +121,7 @@ export async function getStaticProps() {
     })
     const jurisdictionName = process.env.jurisdictionName
     const jurisdiction = await axios.get(
-      `${process.env.backendApiBase}/jurisdictions/${jurisdictionName}`
+      `${process.env.backendApiBase}/jurisdictions/byName/${jurisdictionName}`
     )
     thisJurisdiction = jurisdiction?.data ? jurisdiction.data : null
     listings = listingsResponse?.data?.items ? listingsResponse.data.items : []

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -135,6 +135,7 @@ export const ListingView = (props: ListingProps) => {
     )
   }
 
+  console.log(listing)
   let openHouseEvents: ListingEvent[] | null = null
   let publicLottery: ListingEvent | null = null
   let lotteryResults: ListingEvent | null = null

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -135,7 +135,6 @@ export const ListingView = (props: ListingProps) => {
     )
   }
 
-  console.log(listing)
   let openHouseEvents: ListingEvent[] | null = null
   let publicLottery: ListingEvent | null = null
   let lotteryResults: ListingEvent | null = null

--- a/ui-components/src/global/homepage.scss
+++ b/ui-components/src/global/homepage.scss
@@ -1,8 +1,14 @@
 .homepage-extra {
   @apply text-center;
   @apply text-base;
+  @apply flex;
+  @apply flex-col;
+  @apply justify-center;
+  @apply items-center;
 
   @screen md {
     @apply text-lg;
+    @apply flex-row;
+    @apply justify-around;
   }
 }

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1300,6 +1300,8 @@
     "seeRentalListings": "See Rentals",
     "title": "Apply for affordable housing in",
     "seeMoreOpportunities": "See more rental and ownership housing opportunities",
+    "signUp": "Get emailed whenever a new listing is posted",
+    "signUpToday": "Sign up today",
     "viewAdditionalHousing": "View Additional Housing Opportunities and Resources"
   },
   "whatToExpect": {


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1728 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

If a jurisdiction has the notificationsSignUpURL field set, the home page will display a second action block with the sign up link. The migration sets the value for Alameda to be the current sign-up link.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Load up the homepage with the jurisdiction ENV variable set to Alameda and to anything but Alameda to see both states.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
