### PR TITLE
feat: Show confirmation modal when publishing listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Added:
 
+  - Show confirmation modal when publishing listings ([#1772](https://github.com/bloom-housing/bloom/pull/1772)) (Jared White)
   - Split Listing form up into two main tabs ([#1644](https://github.com/bloom-housing/bloom/pull/1644)) (Jared White)
   - Allow lottery results to be uploaded for a closed listing ([#1568](https://github.com/bloom-housing/bloom/pull/1568)) (Jared White)
   - Update buttons / pages visibility depending on a user role ([#1609](https://github.com/bloom-housing/bloom/pull/1609)) (Dominik Barcikowski)

--- a/sites/partners/src/listings/Aside.tsx
+++ b/sites/partners/src/listings/Aside.tsx
@@ -21,6 +21,7 @@ type AsideProps = {
   setStatus?: (status: ListingStatus) => void
   showCloseListingModal?: () => void
   showLotteryResultsDrawer?: () => void
+  showPublishModal?: () => void
 }
 
 type AsideType = "add" | "edit" | "details"
@@ -30,6 +31,7 @@ const Aside = ({
   setStatus,
   showCloseListingModal,
   showLotteryResultsDrawer,
+  showPublishModal,
 }: AsideProps) => {
   const listing = useContext(ListingContext)
 
@@ -77,7 +79,7 @@ const Aside = ({
           <Button
             styleType={AppearanceStyleType.success}
             fullWidth
-            onClick={() => setStatus(ListingStatus.active)}
+            onClick={() => showPublishModal && showPublishModal()}
           >
             {t("listings.actions.publish")}
           </Button>
@@ -109,9 +111,10 @@ const Aside = ({
         elements.push(
           <GridCell key="btn-publish">
             <Button
+              type="button"
               styleType={AppearanceStyleType.success}
               fullWidth
-              onClick={() => setStatus(ListingStatus.active)}
+              onClick={() => showPublishModal && showPublishModal()}
             >
               {t("listings.actions.publish")}
             </Button>
@@ -213,7 +216,15 @@ const Aside = ({
     }
 
     return elements
-  }, [listing, listingId, setStatus, showCloseListingModal, showLotteryResultsDrawer, type])
+  }, [
+    listing,
+    listingId,
+    setStatus,
+    showCloseListingModal,
+    showLotteryResultsDrawer,
+    showPublishModal,
+    type,
+  ])
 
   return (
     <>

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -426,6 +426,11 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
   const [closeModal, setCloseModal] = useState(false)
 
   /**
+   * Publish modal
+   */
+  const [publishModal, setPublishModal] = useState(false)
+
+  /**
    * Lottery results drawer
    */
   const [lotteryResultsDrawer, setLotteryResultsDrawer] = useState(false)
@@ -662,6 +667,7 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                         setStatus={setStatus}
                         showCloseListingModal={() => setCloseModal(true)}
                         showLotteryResultsDrawer={() => setLotteryResultsDrawer(true)}
+                        showPublishModal={() => setPublishModal(true)}
                       />
                     </aside>
                   </div>
@@ -700,6 +706,36 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
         ]}
       >
         {t("listings.closeThisListing")}
+      </Modal>
+
+      <Modal
+        open={!!publishModal}
+        title={t("t.areYouSure")}
+        ariaDescription={t("listings.publishThisListing")}
+        onClose={() => setPublishModal(false)}
+        actions={[
+          <Button
+            styleType={AppearanceStyleType.success}
+            onClick={() => {
+              setStatus(ListingStatus.active)
+              triggerSubmit(getValues())
+              setPublishModal(false)
+            }}
+          >
+            {t("listings.actions.publish")}
+          </Button>,
+          <Button
+            styleType={AppearanceStyleType.secondary}
+            border={AppearanceBorderType.borderless}
+            onClick={() => {
+              setPublishModal(false)
+            }}
+          >
+            {t("t.cancel")}
+          </Button>,
+        ]}
+      >
+        {t("listings.publishThisListing")}
       </Modal>
     </>
   )

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -725,6 +725,7 @@
   "listings": {
     "error": "There was an issue submitting the form.",
     "closeThisListing": "Do you really want to close this listing?",
+    "publishThisListing": "Publishing will push the listing live on the public site.",
     "active": "Accepting Applications",
     "pending": "Coming Soon",
     "closed": "Closed",


### PR DESCRIPTION
## Issue

Addresses #1772

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

When clicking the Publish button on a listing, it will show a confirmation prompt before saving the new `active` listing status.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Ensure the modal is displayed when attempting to publish a listing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
