### PR TITLE
fix unit form issues

### DIFF
--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -114,8 +114,6 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
       }
       setValue("amiPercentage", parseInt(defaultUnit["amiPercentage"]))
       setValue("rentType", getRentType(defaultUnit))
-      setValue("amiPercentage", parseInt(defaultUnit["amiPercentage"]))
-      setValue("rentType", getRentType(defaultUnit))
     }
     setValue("status", "available")
     setLoading(false)

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -114,12 +114,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
       }
       setValue("amiPercentage", parseInt(defaultUnit["amiPercentage"]))
       setValue("rentType", getRentType(defaultUnit))
-    }
-    setValue("status", "available")
-    if (defaultUnit) {
       setValue("amiPercentage", parseInt(defaultUnit["amiPercentage"]))
       setValue("rentType", getRentType(defaultUnit))
     }
+    setValue("status", "available")
     setLoading(false)
   }
 

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -116,11 +116,16 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
       setValue("rentType", getRentType(defaultUnit))
     }
     setValue("status", "available")
+    if (defaultUnit) {
+      setValue("amiPercentage", parseInt(defaultUnit["amiPercentage"]))
+      setValue("rentType", getRentType(defaultUnit))
+    }
     setLoading(false)
   }
 
   useEffect(() => {
     void resetDefaultValues()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const fetchAmiChart = async (defaultChartID?: string) => {
@@ -166,6 +171,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
     if (amiPercentage && !loading && options) {
       resetAmiTableValues()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amiPercentage])
 
   async function onFormSubmit(action?: string) {
@@ -279,6 +285,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
       setValue("priorityType.id", defaultUnit.priorityType?.id)
       setValue("unitType.id", defaultUnit.unitType?.id)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options])
 
   useEffect(() => {
@@ -290,6 +297,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
         setValue("monthlyRentAsPercentOfIncome", defaultUnit.monthlyRentAsPercentOfIncome)
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rentType])
 
   return (


### PR DESCRIPTION
Some form issues slipped through the AMI override PR and on current dev you can't do add listing --> open the unit form
Somehow lint issues also got through even though the job passed on the PR. I looked at adding the appropriate dependencies to all four dependency arrays and that broke functionality each time, so I'm disabling the rule in these cases.