### PR TITLE
fix: Reponsive TW grid classes, nested overlays

### DIFF
--- a/sites/partners/tailwind.config.js
+++ b/sites/partners/tailwind.config.js
@@ -18,5 +18,6 @@ module.exports = {
       "./layouts/**/*.tsx",
       "../../ui-components/src/**/*.tsx",
     ],
+    safelist: [/grid-cols-/],
   },
 }

--- a/sites/public/tailwind.config.js
+++ b/sites/public/tailwind.config.js
@@ -18,5 +18,6 @@ module.exports = {
       "./layouts/**/*.tsx",
       "../../ui-components/src/**/*.tsx",
     ],
+    safelist: [/grid-cols-/],
   },
 }

--- a/ui-components/src/overlays/Overlay.tsx
+++ b/ui-components/src/overlays/Overlay.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, createRef } from "react"
+import React, { useState, useEffect } from "react"
 import "./Overlay.scss"
 import useKeyPress from "../helpers/useKeyPress"
-import { useOutsideClick } from "../helpers/useOutsideClick"
 import { createPortal } from "react-dom"
 import FocusLock from "react-focus-lock"
 import { disableBodyScroll, enableBodyScroll } from "body-scroll-lock"
@@ -18,18 +17,11 @@ export type OverlayProps = {
 }
 
 const OverlayInner = (props: OverlayProps) => {
-  // close overlay on click outside overlay content
-  const overlayInnerRef = createRef<HTMLDivElement>()
-  useOutsideClick({
-    ref: overlayInnerRef,
-    callback: () => {
-      if (props.onClose) props.onClose()
-    },
-  })
-
-  useKeyPress("Escape", () => {
+  const closeHandler = () => {
     if (props.onClose) props.onClose()
-  })
+  }
+
+  useKeyPress("Escape", () => closeHandler())
 
   const classNames = ["fixed-overlay"]
   if (typeof props.backdrop === "undefined" || props.backdrop) classNames.push("is-backdrop")
@@ -41,8 +33,11 @@ const OverlayInner = (props: OverlayProps) => {
       role="dialog"
       aria-labelledby={props.ariaLabel}
       aria-describedby={props.ariaDescription}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) closeHandler()
+      }}
     >
-      <div className="fixed-overlay__inner" ref={overlayInnerRef}>
+      <div className="fixed-overlay__inner">
         <FocusLock>{props.children}</FocusLock>
       </div>
     </div>


### PR DESCRIPTION
## Issue

Addresses #857

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Fix for two issues found in QA. Regarding the nested drawers issue (the second drawer opened and closed immediately), the fix was remarkably simple (but took a while to arrive at)…no outside click algorithm is necessary because click handling directly on the overlay backdrop itself is all that's needed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Review the various forms in the Partners site as well as the "Select Preferences" button/drawer.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
