### PR TITLE
Feat: create getSummariesTableFromUnitsSummary

### DIFF
--- a/backend/core/src/units-summary/dto/units-summary.dto.ts
+++ b/backend/core/src/units-summary/dto/units-summary.dto.ts
@@ -1,26 +1,25 @@
-import { OmitType } from "@nestjs/swagger"
-import { Expose, Type } from "class-transformer"
-import { IsString, IsUUID, ValidateNested } from "class-validator"
-import { IdDto } from "../../shared/dto/id.dto"
+import { ApiHideProperty, OmitType } from "@nestjs/swagger"
+import { Exclude, Expose, Type } from "class-transformer"
+import { IsOptional, IsUUID, ValidateNested } from "class-validator"
+import { UnitTypeDto } from "../../unit-types/dto/unit-type.dto"
 import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enum"
 import { UnitsSummary } from "../entities/units-summary.entity"
 
 export class UnitsSummaryDto extends OmitType(UnitsSummary, ["listing", "unitType"] as const) {
-  @Expose()
-  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
-  @Type(() => IdDto)
-  listing: IdDto
+  @Exclude()
+  @ApiHideProperty()
+  listing
 
   @Expose()
   @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
-  @Type(() => IdDto)
-  unitType: IdDto
+  @Type(() => UnitTypeDto)
+  unitType: UnitTypeDto
 }
 
 export class UnitsSummaryCreateDto extends OmitType(UnitsSummaryDto, ["id"] as const) {}
 export class UnitsSummaryUpdateDto extends OmitType(UnitsSummaryCreateDto, [] as const) {
   @Expose()
-  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsUUID()
-  id: string
+  id?: string
 }

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -4258,59 +4258,56 @@ export interface Unit {
 }
 
 export interface UnitsSummary {
-  /**  */
-  listing: Id
+    /**  */
+    unitType: UnitType
 
-  /**  */
-  unitType: Id
-
-  /**  */
-  id: string
-
-  /**  */
-  monthlyRentMin?: number
-
-  /**  */
-  monthlyRentMax?: number
-
-  /**  */
-  monthlyRentAsPercentOfIncome?: string
-
-  /**  */
-  amiPercentage?: number
-
-  /**  */
-  minimumIncomeMin?: string
-
-  /**  */
-  minimumIncomeMax?: string
-
-  /**  */
-  maxOccupancy?: number
-
-  /**  */
-  minOccupancy?: number
-
-  /**  */
-  floorMin?: number
-
-  /**  */
-  floorMax?: number
-
-  /**  */
-  sqFeetMin?: string
-
-  /**  */
-  sqFeetMax?: string
-
-  /**  */
-  priorityType?: CombinedPriorityTypeTypes
-
-  /**  */
-  totalCount?: number
-
-  /**  */
-  totalAvailable?: number
+    /**  */
+    id: string
+  
+    /**  */
+    monthlyRentMin?: number
+  
+    /**  */
+    monthlyRentMax?: number
+  
+    /**  */
+    monthlyRentAsPercentOfIncome?: string
+  
+    /**  */
+    amiPercentage?: number
+  
+    /**  */
+    minimumIncomeMin?: string
+  
+    /**  */
+    minimumIncomeMax?: string
+  
+    /**  */
+    maxOccupancy?: number
+  
+    /**  */
+    minOccupancy?: number
+  
+    /**  */
+    floorMin?: number
+  
+    /**  */
+    floorMax?: number
+  
+    /**  */
+    sqFeetMin?: string
+  
+    /**  */
+    sqFeetMax?: string
+  
+    /**  */
+    priorityType?: CombinedPriorityTypeTypes
+  
+    /**  */
+    totalCount?: number
+  
+    /**  */
+    totalAvailable?: number
 }
 
 export interface Listing {

--- a/sites/public/pages/listings.tsx
+++ b/sites/public/pages/listings.tsx
@@ -9,7 +9,7 @@ import {
   ApplicationStatusType,
   ListingCard,
   imageUrlFromListing,
-  getSummariesTable,
+  getSummariesTableFromUnitSummary,
 } from "@bloom-housing/ui-components"
 import {
   Listing,
@@ -81,7 +81,9 @@ const getListingCardSubtitle = (address: Address) => {
 }
 
 const getListingTableData = (unitsSummarized: UnitsSummarized) => {
-  return unitsSummarized !== undefined ? getSummariesTable(unitsSummarized.byUnitTypeAndRent) : []
+  return unitsSummarized !== undefined
+    ? getSummariesTableFromUnitSummary(unitsSummarized.byUnitTypeAndRent)
+    : []
 }
 
 const getListings = (listings) => {

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -39,7 +39,7 @@ import {
   Waitlist,
   WhatToExpect,
   getOccupancyDescription,
-  getSummariesTable,
+  getSummariesTableFromUnitSummary,
   imageUrlFromListing,
   occupancyTable,
   t,
@@ -110,7 +110,7 @@ export const ListingView = (props: ListingProps) => {
   let groupedUnits: GroupedTableGroup[] = null
 
   if (amiValues.length == 1) {
-    groupedUnits = getSummariesTable(listing.unitsSummarized.byUnitTypeAndRent)
+    groupedUnits = getSummariesTableFromUnitSummary(listing.unitsSummarized.byUnitTypeAndRent)
   } // else condition is handled inline below
 
   const occupancyDescription = getOccupancyDescription(listing)
@@ -349,7 +349,7 @@ export const ListingView = (props: ListingProps) => {
               return parseInt(item.percent, 10) == percent
             })
 
-            groupedUnits = byAMI ? getSummariesTable(byAMI.byUnitType) : []
+            groupedUnits = byAMI ? getSummariesTableFromUnitSummary(byAMI.byUnitType) : []
 
             return (
               <React.Fragment key={percent}>

--- a/ui-components/src/helpers/tableSummaries.tsx
+++ b/ui-components/src/helpers/tableSummaries.tsx
@@ -1,75 +1,139 @@
 import * as React from "react"
 import { t } from "./translator"
-import { UnitSummary } from "@bloom-housing/backend-core/types"
+import { UnitSummary, UnitsSummary } from "@bloom-housing/backend-core/types"
 import { GroupedTableGroup } from "../tables/GroupedTable"
 
-export const unitSummariesTable = (summaries: UnitSummary[]) => {
-  const unitSummaries = summaries.map((unitSummary) => {
-    const unitPluralization = unitSummary.totalAvailable == 1 ? t("t.unit") : t("t.units")
-    const minIncome =
-      unitSummary.minIncomeRange.min == unitSummary.minIncomeRange.max ? (
-        <strong>{unitSummary.minIncomeRange.min}</strong>
-      ) : (
-        <>
-          <strong>{unitSummary.minIncomeRange.min}</strong> {t("t.to")}{" "}
-          <strong>{unitSummary.minIncomeRange.max}</strong>
-        </>
-      )
+export const getSummaryRow = (
+  totalAvailable: number,
+  minIncomeRangeMin?: string,
+  minIncomeRangeMax?: string,
+  rentRangeMin?: string,
+  rentRangeMax?: string,
+  rentAsPercentIncomeRangeMin?: string,
+  rentAsPercentIncomeRangeMax?: string,
+  unitTypeName?: string
+) => {
+  let minIncome = <></>
+  if (minIncomeRangeMin == undefined && minIncomeRangeMax == undefined) {
+    minIncome = <strong>{t("t.call")}</strong>
+  } else if (minIncomeRangeMin == minIncomeRangeMax || minIncomeRangeMax == undefined) {
+    minIncome = (
+      <>
+        <strong>{minIncomeRangeMin}</strong>
+        {t("t.perMonth")}
+      </>
+    )
+  } else if (minIncomeRangeMin == undefined) {
+    minIncome = (
+      <>
+        <strong>{minIncomeRangeMax}</strong>
+        {t("t.perMonth")}
+      </>
+    )
+  } else {
+    minIncome = (
+      <>
+        <strong>{minIncomeRangeMin}</strong> {t("t.to")} <strong>{minIncomeRangeMax}</strong>
+        {t("t.perMonth")}
+      </>
+    )
+  }
 
-    const getRent = (rentMin: string, rentMax: string, percent = false) => {
-      const unit = percent ? `% ${t("t.income")}` : ` ${t("t.perMonth")}`
-      return rentMin == rentMax ? (
+  const getRent = (rentMin?: string, rentMax?: string, percent = false) => {
+    const unit = percent ? `% ${t("t.income")}` : ` ${t("t.perMonth")}`
+    if (rentMin == undefined && rentMax == undefined) {
+      return <strong>{t("t.call")}</strong>
+    } else if (rentMin == rentMax || rentMax == undefined) {
+      return (
         <>
-          <strong>{rentMin}</strong>
+          <strong>{`$${rentMin}`}</strong>
           {unit}
         </>
-      ) : (
+      )
+    } else if (rentMin == undefined) {
+      return (
         <>
-          <strong>{rentMin}</strong> {t("t.to")} <strong>{rentMax}</strong>
+          <strong>{`$${rentMax}`}</strong>
+          {unit}
+        </>
+      )
+    } else {
+      return (
+        <>
+          <strong>{`$${rentMin}`}</strong> {t("t.to")} <strong>{`$${rentMax}`}</strong>
           {unit}
         </>
       )
     }
+  }
+  // Use rent as percent income if available, otherwise use exact rent
+  const rent = rentAsPercentIncomeRangeMin
+    ? getRent(rentAsPercentIncomeRangeMin, rentAsPercentIncomeRangeMax, true)
+    : getRent(rentRangeMin, rentRangeMax)
 
-    // Use rent as percent income if available, otherwise use exact rent
-    const rent = unitSummary.rentAsPercentIncomeRange.min
-      ? getRent(
-          unitSummary.rentAsPercentIncomeRange.min.toString(),
-          unitSummary.rentAsPercentIncomeRange.max.toString(),
-          true
-        )
-      : getRent(unitSummary.rentRange.min, unitSummary.rentRange.max)
-
-    return {
-      unitType: <strong>{t(`listings.unitTypes.${unitSummary.unitType?.name}`)}</strong>,
-      minimumIncome: (
-        <>
-          {minIncome} {t("t.perMonth")}
-        </>
-      ),
-      rent: <>{rent}</>,
-      availability: (
-        <>
-          {unitSummary.totalAvailable > 0 ? (
-            <>
-              <strong>{unitSummary.totalAvailable}</strong> {unitPluralization}
-            </>
-          ) : (
-            <span className="uppercase">{t("listings.waitlist.label")}</span>
-          )}
-        </>
-      ),
-    }
-  })
-
-  return unitSummaries
+  return {
+    unitType: <strong>{t(`listings.unitTypes.${unitTypeName}`)}</strong>,
+    minimumIncome: <>{minIncome}</>,
+    rent: <>{rent}</>,
+    availability: (
+      <>
+        {totalAvailable > 0 ? (
+          <>
+            <strong>{totalAvailable}</strong> {totalAvailable == 1 ? t("t.unit") : t("t.units")}
+          </>
+        ) : (
+          <span className="uppercase">{t("listings.waitlist.label")}</span>
+        )}
+      </>
+    ),
+  }
 }
 
-export const getSummariesTable = (summaries: UnitSummary[]) => {
+export const getSummariesTableFromUnitSummary = (summaries: UnitSummary[]) => {
   let groupedUnits = [] as Array<GroupedTableGroup>
 
   if (summaries?.length > 0) {
-    const unitSummaries = unitSummariesTable(summaries)
+    const unitSummaries = summaries.map((unitSummary) => {
+      return getSummaryRow(
+        unitSummary.totalAvailable ? unitSummary.totalAvailable : 0,
+        unitSummary.minIncomeRange.min,
+        unitSummary.minIncomeRange.max,
+        unitSummary.rentRange.min,
+        unitSummary.rentRange.max,
+        unitSummary.rentAsPercentIncomeRange.min
+          ? unitSummary.rentAsPercentIncomeRange.min.toString()
+          : "",
+        unitSummary.rentAsPercentIncomeRange.max
+          ? unitSummary.rentAsPercentIncomeRange.max.toString()
+          : "",
+        unitSummary.unitType.name
+      )
+    })
+    groupedUnits = [
+      {
+        data: unitSummaries,
+      },
+    ]
+  }
+  return groupedUnits
+}
+
+export const getSummariesTableFromUnitsSummary = (summaries: UnitsSummary[]) => {
+  let groupedUnits = [] as Array<GroupedTableGroup>
+
+  if (summaries?.length > 0) {
+    const unitSummaries = summaries.map((unitSummary) => {
+      return getSummaryRow(
+        unitSummary.totalAvailable ? unitSummary.totalAvailable : 0,
+        unitSummary.minimumIncomeMin,
+        unitSummary.minimumIncomeMax,
+        unitSummary.monthlyRentMin?.toString(),
+        unitSummary.monthlyRentMax?.toString(),
+        unitSummary.monthlyRentAsPercentOfIncome,
+        unitSummary.monthlyRentAsPercentOfIncome,
+        unitSummary.unitType.name
+      )
+    })
     groupedUnits = [
       {
         data: unitSummaries,


### PR DESCRIPTION
Create new summary table from UnitsSummary.  Also enables UnitSummary tables to still be called.

# Pull Request Template

- [x] This change addresses the issue in full

## Description

This change enables summary tables to be created for the listings and individual listing pages from unitsSummary, and still enable summaries from unitSummary to be created.  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Open the listing page and see the summary tables are still populated.  Same with individual listing pages.

- [x] Desktop View
- [x] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
