### PR TITLE
fix: translation typo in alternate contact page

### DIFF
--- a/sites/public/pages/applications/contact/alternate-contact-contact.tsx
+++ b/sites/public/pages/applications/contact/alternate-contact-contact.tsx
@@ -102,7 +102,7 @@ export default () => {
               name="emailAddress"
               label={t("application.alternateContact.contact.emailAddressFormLabel")}
               readerOnly={true}
-              placeholder={t("t.emailAddressPlaceHolder")}
+              placeholder={t("t.emailAddressPlaceholder")}
               defaultValue={application.alternateContact.emailAddress || null}
               register={register}
             />

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -672,7 +672,7 @@
     "deposit": "Depósito",
     "edit": "Editar",
     "email": "Email",
-    "emailAddressPlaceHolder": "you@myemail.com",
+    "emailAddressPlaceholder": "you@myemail.com",
     "floor": "piso",
     "floors": "pisos",
     "getDirections": "Obtener instrucciones para llegar",

--- a/ui-components/src/locales/vi.json
+++ b/ui-components/src/locales/vi.json
@@ -672,7 +672,7 @@
     "deposit": "Đặt cọc",
     "edit": "Hiệu đính",
     "email": "Email",
-    "emailAddressPlaceHolder": "you@myemail.com",
+    "emailAddressPlaceholder": "you@myemail.com",
     "floor": "sàn",
     "floors": "các sàn",
     "getDirections": "Lấy hướng dẫn chỉ đường",

--- a/ui-components/src/locales/zh.json
+++ b/ui-components/src/locales/zh.json
@@ -672,7 +672,7 @@
     "deposit": "訂金",
     "edit": "編輯",
     "email": "電子郵件",
-    "emailAddressPlaceHolder": "you@myemail.com",
+    "emailAddressPlaceholder": "you@myemail.com",
     "floor": "樓層",
     "floors": "樓層",
     "getDirections": "取得路線",


### PR DESCRIPTION
## Issue

(doesn't address existing issue)

## Description

There was a typo on the Alternate Contact page in the public site, along with all-but-the-English translation files. `t.emailAddressPlaceHolder` instead of `t.emailAddressPlaceholder`. It was causing the email address field to show the t. key string instead of the actual text on English locale.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Please describe the tests that you ran to verify your changes. Provide instructions so we can review. Please also list any relevant details for your test configuration

- [x] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
