### PR TITLE
Add screenreader messages to ProgresssNav

### DIFF
--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -603,6 +603,10 @@
   "region": {
     "name": "Región local"
   },
+  "progressNav": {
+      "srHeading": "Progreso",
+      "current": "Paso actual: "
+  },
   "states": {
     "AL": "Alabama",
     "AK": "Alaska",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -1123,6 +1123,10 @@
   "region": {
     "name": "Local Region"
   },
+  "progressNav": {
+    "srHeading": "Progress",
+    "current": "Current step: "
+  },
   "states": {
     "AL": "Alabama",
     "AK": "Alaska",

--- a/ui-components/src/locales/vi.json
+++ b/ui-components/src/locales/vi.json
@@ -603,6 +603,10 @@
   "region": {
     "name": "Địa phương"
   },
+  "progressNav": {
+    "srHeading": "Tiến trình",
+    "current": "Bước hiện tại:"
+  },
   "states": {
     "AL": "Alabama",
     "AK": "Alaska",

--- a/ui-components/src/locales/zh.json
+++ b/ui-components/src/locales/zh.json
@@ -603,6 +603,10 @@
   "region": {
     "name": "當地地區"
   },
+  "progressNav": {
+    "srHeading": "进度",
+    "current": "当前步骤："
+  },
   "states": {
     "AL": "Alabama（阿拉巴馬州）",
     "AK": "Alaska（阿拉斯加州）",

--- a/ui-components/src/navigation/ProgressNav.tsx
+++ b/ui-components/src/navigation/ProgressNav.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { OnClientSide } from "../helpers/nextjs"
 import "./ProgressNav.scss"
+import { t } from "../helpers/translator"
 
 const ProgressNavItem = (props: {
   section: number
@@ -17,9 +18,17 @@ const ProgressNavItem = (props: {
     }
   }
 
+  const srText =
+    props.section === props.currentPageSection ? (
+      <span className="sr-only">{t("progressNav.current")}</span>
+    ) : (
+      ""
+    )
+
   return (
     <li className={`progress-nav__item ${bgColor}`}>
       <a aria-disabled={bgColor === "is-disabled"} href={"#"}>
+        {srText}
         {props.label}
       </a>
     </li>
@@ -32,18 +41,21 @@ const ProgressNav = (props: {
   labels: string[]
 }) => {
   return (
-    <ul className={!OnClientSide() ? "invisible" : "progress-nav"}>
-      {props.labels.map((label, i) => (
-        <ProgressNavItem
-          key={label}
-          // Sections are 1-indexed
-          section={i + 1}
-          currentPageSection={props.currentPageSection}
-          completedSections={props.completedSections}
-          label={label}
-        />
-      ))}
-    </ul>
+    <div>
+      <h2 className="sr-only">{t("progressNav.srHeading")}</h2>
+      <ul className={!OnClientSide() ? "invisible" : "progress-nav"}>
+        {props.labels.map((label, i) => (
+          <ProgressNavItem
+            key={label}
+            // Sections are 1-indexed
+            section={i + 1}
+            currentPageSection={props.currentPageSection}
+            completedSections={props.completedSections}
+            label={label}
+          />
+        ))}
+      </ul>
+    </div>
   )
 }
 


### PR DESCRIPTION
Add messages to ProgressNav so it's clear to screenreader users what the bar is, and what step
they're on.

# Pull Request Template

## Issue CityOfDetroit/bloom#267

Addresses CityOfDetroit/bloom#267

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Add messages to ProgressNav so it's clear to screenreader users what the bar is, and what step
they're on.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [x] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

- [x] Desktop View
- [ ] Mobile View
- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
