### PR TITLE
fix: ami chart values were not appearing after save and new

### DIFF
--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -244,6 +244,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, existingId, nextId }: UnitFo
       })
       onClose(true, null)
       reset()
+      void resetDefaultValues()
       setValue("status", "available")
     } else {
       onSubmit({


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1544

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

In LM if you created a unit by hitting "save and new" and then to the second unit tried to add an ami chart and percentage the values would not populate.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/address technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Create a unit by hitting "save and new" and then to the second unit try to add an ami chart and percentage and ensure the fields populate.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
