### PR TITLE
fix: modals no longer prevent scroll after being closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable changes to this project will be documented in this file. The format 
   - Listings management AMI charts populate after Save and New on units ([#1952](https://github.com/bloom-housing/bloom/pull/1952)) (Emily Jablonski)
   - Brings in updates from Alameda which fixes some issues with preference handling and lisitngs getStaticProps in production ([#1958](https://github.com/bloom-housing/bloom/pull/1958))
   - Preview can load without building address ([#1960](https://github.com/bloom-housing/bloom/pull/1960)) (Emily Jablonski)
+  - Page now scrolls after closing modal ([#1962](https://github.com/bloom-housing/bloom/pull/1962)) (Emily Jablonski)
 
 - Changed:
 

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -746,8 +746,8 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
             type="button"
             styleType={AppearanceStyleType.secondary}
             onClick={() => {
-              triggerSubmitWithStatus(false, ListingStatus.closed)
               setCloseModal(false)
+              triggerSubmitWithStatus(false, ListingStatus.closed)
             }}
           >
             {t("listings.actions.close")}
@@ -776,10 +776,8 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
           <Button
             type="button"
             styleType={AppearanceStyleType.success}
-            onClick={async () => {
-              // If we don't await here, the scroll block stays in place on modal close
-              /* eslint-disable-next-line @typescript-eslint/await-thenable */
-              await setPublishModal(false)
+            onClick={() => {
+              setPublishModal(false)
               triggerSubmitWithStatus(false, ListingStatus.active)
             }}
           >

--- a/sites/partners/src/listings/PaperListingForm/sections/AdditionalEligibility.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/AdditionalEligibility.tsx
@@ -47,7 +47,7 @@ const AdditionalEligibility = () => {
             id={"rentalAssistance"}
             fullWidth={true}
             register={register}
-            errorMessage={fieldMessage(errors?.rentalAssistance?.message)}
+            errorMessage={fieldMessage(errors?.rentalAssistance)}
             inputProps={{
               onChange: () => clearErrors("rentalAssistance"),
             }}

--- a/sites/partners/src/listings/PaperListingForm/sections/AdditionalEligibility.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/AdditionalEligibility.tsx
@@ -47,7 +47,7 @@ const AdditionalEligibility = () => {
             id={"rentalAssistance"}
             fullWidth={true}
             register={register}
-            errorMessage={fieldMessage(errors?.rentalAssistance)}
+            errorMessage={fieldMessage(errors?.rentalAssistance?.message)}
             inputProps={{
               onChange: () => clearErrors("rentalAssistance"),
             }}

--- a/ui-components/src/overlays/Overlay.tsx
+++ b/ui-components/src/overlays/Overlay.tsx
@@ -71,7 +71,7 @@ export const Overlay = (props: OverlayProps) => {
     props.open ? disableBodyScroll(elForPortal) : enableBodyScroll(elForPortal)
 
     return () => {
-      if (!props.open) enableBodyScroll(elForPortal)
+      enableBodyScroll(elForPortal)
     }
   }, [elForPortal, overlayRoot, props.open])
 


### PR DESCRIPTION
# Pull Request Template

## Issue

Addresses #1961

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Modals in LM (publish, close) were preventing page scroll after being closed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

In LM try close a published listing, and ensure you can scroll on the page afterward.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
