### PR TITLE
fix: improved UX for the Building Selection Criteria drawer

### DIFF
--- a/sites/partners/src/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -42,6 +42,7 @@ const LotteryResults = () => {
       id: "",
       url: "",
     })
+    setValue("criteriaAttachType", null)
     setDrawerState(false)
   }
 
@@ -220,13 +221,16 @@ const LotteryResults = () => {
           <Button
             key={0}
             onClick={() => {
-              const value = getValues("buildingSelectionCriteriaURL")
-              if (value) {
-                deletePDF()
-                saveURL(value)
-              } else {
-                deleteURL()
-                savePDF()
+              // Only try to save values if an attachment type has been selected
+              if (criteriaAttachType) {
+                const value = getValues("buildingSelectionCriteriaURL")
+                if (value) {
+                  deletePDF()
+                  saveURL(value)
+                } else {
+                  deleteURL()
+                  savePDF()
+                }
               }
               resetDrawerState()
             }}


### PR DESCRIPTION
## Issue

Addresses QA feedback from #1755 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This improves the experience of clicking Save without selecting an attachment option (it will now do the same thing as Cancel). In addition, the drawer will now reset to the state of showing the two attachment options more reliably.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

Try editing an existing Building Selection Criteria row in the Listings MVP.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
