### PR TITLE
Clear SiteAlert message in RequireLogin component.

### DIFF
--- a/sites/partners/cypress/integration/navigation.ts
+++ b/sites/partners/cypress/integration/navigation.ts
@@ -25,6 +25,13 @@ describe("Navigating around the site", () => {
         cy.contains("This will be the home page")
       })
     })
+
+    it("Forgot password does not show alert", () => {
+      cy.visit("/")
+      cy.contains("Forgot password?").click()
+      cy.contains("Send email")
+      cy.get(".alert-box").should("not.exist")
+    })
   })
 
   describe("with a logged in user", () => {

--- a/ui-components/src/authentication/RequireLogin.tsx
+++ b/ui-components/src/authentication/RequireLogin.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useContext, useEffect } from "react"
-import { setSiteAlertMessage } from "../notifications/SiteAlert"
+import { clearSiteAlertMessage, setSiteAlertMessage } from "../notifications/SiteAlert"
 import { NavigationContext } from "../config/NavigationContext"
 import { AuthContext } from "./AuthContext"
 
@@ -48,6 +48,8 @@ const RequireLogin: FunctionComponent<RequireLoginProps> = ({
     if (loginRequiredForPath && initialStateLoaded && !profile) {
       setSiteAlertMessage(signInMessage, "notice")
       void router.push(signInPath)
+    } else {
+      clearSiteAlertMessage("notice")
     }
   }, [loginRequiredForPath, initialStateLoaded, profile, router, signInPath, signInMessage])
 

--- a/ui-components/src/notifications/SiteAlert.tsx
+++ b/ui-components/src/notifications/SiteAlert.tsx
@@ -13,6 +13,10 @@ export const setSiteAlertMessage = (message: string, type: AlertTypes) => {
   sessionStorage.setItem(`alert_message_${type}`, message)
 }
 
+export const clearSiteAlertMessage = (type: AlertTypes) => {
+  sessionStorage.removeItem(`alert_message_${type}`)
+}
+
 /**
  * Show an alert based on a url query param.
  */


### PR DESCRIPTION
Clear SiteAlert message in RequireLogin component.

## Issue

When navigating to /forgot-password from / in the partners portal, there is a SiteAlert that shows which says "Login is required to view this page". The user can still input their email, but the messaging could be confusing.

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This CL clears the SiteAlert dialog when the state of the page changes from requiring login to not requiring login. This can happen e.g. when the page finishes loading.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Prototype/POC (not to merge)
- [ ] This change is a refactor/addresses technical debt
- [ ] This change requires a documentation update
- [ ] This change requires a SQL Script

## How Can This Be Tested/Reviewed?

`cd sites/partner/cypress/integration && yarn cypress run`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have updated the changelog to include a description of my changes
- [ ] I have run `yarn generate:client` if I made backend changes
- [ ] I have exported any new pieces in ui-components
