### PR TITLE
chore: Update auto-release scripts, fetch depth

### DIFF
--- a/.github/workflows/pre-release_components.yml
+++ b/.github/workflows/pre-release_components.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Check out git repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       
       - name: Set up Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
The action is failing for auth reasons, but that's actually a good thing for now because it seems it wants to version every package even if one changed, so I'm purposefully not fixing the auth issue to let it version and then fail to commit those versions to iterate on the getting the version bumps solid.