### PR TITLE
chore: update auto-release scripts, token on checkout

### DIFF
--- a/.github/workflows/pre-release_components.yml
+++ b/.github/workflows/pre-release_components.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Set up Node.js
         uses: actions/setup-node@v1
@@ -24,7 +25,7 @@ jobs:
       - name: Version ui-components
         run: yarn version:prerelease:ui-components
         env:
-          GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Publish ui-components
         run: yarn publish:ui-components


### PR DESCRIPTION
The action is failing for auth reasons, but that's actually a good thing for now because it seems it wants to version every package even if one changed, so I'm purposefully not fixing the auth issue to let it version and then fail to commit those versions to iterate on the getting the version bumps solid.