### PR TITLE
feat: jurisdictional email signatures

### DIFF
--- a/backend/core/src/migration/1635546032998-add-jurisdictional-email-signatures.ts
+++ b/backend/core/src/migration/1635546032998-add-jurisdictional-email-signatures.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { Language } from "../shared/types/language-enum"
+
+export class addJurisdictionalEmailSignatures1635546032998 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const sanJoseTranslation = {
+      footer: {
+        footer: "City of San José, Housing Department",
+      },
+    }
+    const [{ id: sanJoseJurisdiction }] = await queryRunner.query(
+      `SELECT id FROM jurisdictions WHERE name = 'San Jose' LIMIT 1`
+    )
+
+    const alamedaTranslation = {
+      footer: {
+        footer: "Alameda County - Housing and Community Development (HCD) Department",
+      },
+    }
+    const [{ id: alamedaJurisdiction }] = await queryRunner.query(
+      `SELECT id FROM jurisdictions WHERE name = 'Alameda' LIMIT 1`
+    )
+
+    const sanMateoTranslation = {
+      footer: {
+        footer: "San Mateo County - Department of Housing",
+      },
+    }
+    const [{ id: sanMateoJurisdiction }] = await queryRunner.query(
+      `SELECT id FROM jurisdictions WHERE name = 'San Mateo' LIMIT 1`
+    )
+
+    const existingAlamedaTranslations = await queryRunner.query(
+      `SELECT translations FROM translations WHERE jurisdiction_id = ($1)`,
+      [alamedaJurisdiction]
+    )
+
+    const existingGeneralTranslations = await queryRunner.query(
+      `SELECT translations FROM translations WHERE jurisdiction_id is NULL`
+    )
+    const genericTranslation = {
+      ...existingAlamedaTranslations["0"]["translations"],
+      ...existingGeneralTranslations["0"]["translations"],
+      footer: {
+        footer: "",
+        thankYou: "Thanks!",
+      },
+    }
+
+    await queryRunner.query(
+      `UPDATE "translations" SET translations = ($1) where jurisdiction_id = ($2) and language = ($3)`,
+      [alamedaTranslation, alamedaJurisdiction, Language.en]
+    )
+    await queryRunner.query(
+      `INSERT into "translations" (jurisdiction_id, language, translations) VALUES ($1, $2, $3)`,
+      [sanJoseJurisdiction, Language.en, sanJoseTranslation]
+    )
+    await queryRunner.query(
+      `INSERT into "translations" (jurisdiction_id, language, translations) VALUES ($1, $2, $3)`,
+      [sanMateoJurisdiction, Language.en, sanMateoTranslation]
+    )
+    await queryRunner.query(
+      `UPDATE "translations" SET translations = ($1) where jurisdiction_id is NULL and language = ($2)`,
+      [genericTranslation, Language.en]
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/backend/core/src/seed.ts
+++ b/backend/core/src/seed.ts
@@ -52,7 +52,6 @@ const listingSeeds: any[] = [
   ListingDefaultOpenSoonSeed,
   ListingDefaultOnePreferenceSeed,
   ListingDefaultNoPreferenceSeed,
-  ListingDefaultNoPreferenceSeed,
   ListingDefaultBmrChartSeed,
   ListingTritonSeed,
   ListingDefaultReservedSeed,

--- a/backend/core/src/seeds/listings/listing-default-sanjose-seed.ts
+++ b/backend/core/src/seeds/listings/listing-default-sanjose-seed.ts
@@ -98,7 +98,7 @@ export class ListingDefaultSanJoseSeed {
           ],
         },
       ],
-      name: "Test: Default, Two Preferences",
+      name: "Test: Default, Two Preferences (San Jose)",
       property: property,
       assets: getDefaultAssets(),
       preferences: [getLiveWorkPreference(), { ...getDisplaceePreference(), ordinal: 2 }],

--- a/backend/core/src/shared/email/email.service.spec.ts
+++ b/backend/core/src/shared/email/email.service.spec.ts
@@ -71,6 +71,20 @@ describe("EmailService", () => {
     )
     await translationsRepository.createQueryBuilder().delete().execute()
     const translationsService = await module.resolve<TranslationsService>(TranslationsService)
+
+    await translationsService.create({
+      jurisdiction: {
+        id: null,
+      },
+      language: Language.en,
+      translations: {
+        footer: {
+          footer: "Generic footer",
+          thankYou: "Thank you!",
+        },
+      },
+    })
+
     await translationsService.create({
       jurisdiction: {
         id: jurisdiction.id,
@@ -146,13 +160,16 @@ describe("EmailService", () => {
   })
 
   describe("welcome", () => {
-    it("should generate html body", async () => {
+    it("should generate html body, jurisdictional footer", async () => {
       await service.welcome(user, "http://localhost:3000", "http://localhost:3000/?token=")
       expect(sendMock).toHaveBeenCalled()
       expect(sendMock.mock.calls[0][0].to).toEqual(user.email)
       expect(sendMock.mock.calls[0][0].subject).toEqual("Welcome to Bloom")
       // Check if translation is working correctly
-      expect(sendMock.mock.calls[0][0].html.substring(0, 26)).toEqual("<h1>Hello Test \n User</h1>")
+      expect(sendMock.mock.calls[0][0].html).toContain(
+        "Alameda County - Housing and Community Development (HCD) Department"
+      )
+      expect(sendMock.mock.calls[0][0].html).toContain("<h1>Hello Test \n User</h1>")
     })
   })
 

--- a/backend/core/src/shared/email/email.service.ts
+++ b/backend/core/src/shared/email/email.service.ts
@@ -202,7 +202,7 @@ export class EmailService {
 
   async invite(user: User, appUrl: string, confirmationUrl: string) {
     void (await this.loadTranslations(
-      user.jurisdictions.length === 1 ? user.jurisdictions[0] : null,
+      user.jurisdictions?.length === 1 ? user.jurisdictions[0] : null,
       user.language || Language.en
     ))
     await this.send(

--- a/backend/core/src/shared/email/email.service.ts
+++ b/backend/core/src/shared/email/email.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, Scope } from "@nestjs/common"
 import { SendGridService } from "@anchan828/nest-sendgrid"
 import { ResponseError } from "@sendgrid/helpers/classes"
+import merge from "lodash/merge"
 import Handlebars from "handlebars"
 import path from "path"
 import { User } from "../../auth/entities/user.entity"
@@ -132,11 +133,22 @@ export class EmailService {
   }
 
   private async loadTranslations(jurisdiction: Jurisdiction | null, language: Language) {
-    const translation = await this.translationService.getTranslationByLanguageAndJurisdictionOrDefaultEn(
+    const jurisdictionalTranslations = await this.translationService.getTranslationByLanguageAndJurisdictionOrDefaultEn(
       language,
       jurisdiction ? jurisdiction.id : null
     )
-    this.polyglot.replace(translation.translations)
+    const genericTranslations = await this.translationService.getTranslationByLanguageAndJurisdictionOrDefaultEn(
+      language,
+      null
+    )
+
+    // Deep merge
+    const translations = merge(
+      genericTranslations.translations,
+      jurisdictionalTranslations.translations
+    )
+
+    this.polyglot.replace(translations)
   }
 
   private template(view: string) {
@@ -189,7 +201,10 @@ export class EmailService {
   }
 
   async invite(user: User, appUrl: string, confirmationUrl: string) {
-    void (await this.loadTranslations(null, user.language || Language.en))
+    void (await this.loadTranslations(
+      user.jurisdictions.length === 1 ? user.jurisdictions[0] : null,
+      user.language || Language.en
+    ))
     await this.send(
       user.email,
       this.polyglot.t("invite.hello"),

--- a/backend/core/src/views/partials/footer.hbs
+++ b/backend/core/src/views/partials/footer.hbs
@@ -1,4 +1,4 @@
 <p>
-  {{t "footer.thankYou"}},<br/>
+  {{t "footer.thankYou"}}<br/>
   {{t "footer.footer"}}
 </p>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2082 #2086

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

If no jurisdiction is passed to an email, don't include a jurisdictional footer (previously was always saying Alameda's).
If a specific jurisdiction is passed, use a jurisdictional-specific footer (new ones for San Jose and San Mateo).

I restructured a little how we are storing the translations to reduce duplication. We had a lot duplicated between the general translations and Alameda's. Now we have a general object and overwrite it where we need to with jurisdictional specific ones.

Doesn't support adding multiple jurisdictional footers atm, which I don't think was requested anyway, so it's one jurisdiction's footer or none.

## How Can This Be Tested/Reviewed?

On partners:
* Create listings specific to Alameda, San Jose, and San Mateo (it's fine if they're drafts)
* On the users piece, add a user to just one listing, and ensure the email signature is the right jurisdiction's footer
* If you add a user to more than one jurisdiction through listings we don't include a jurisdictional footer

On public:
* Set your local jurisdiction env variable to any jurisdiction
* Ensure the follow email flows include the right footer: Create an account, submit an application, and the forgot password flow

Examples from just partners of each state:
Alameda:
<img src="https://user-images.githubusercontent.com/65367387/139515186-e1b58f60-d18b-4471-9458-18d226a14491.jpeg" width="300" />
San Jose:
<img src="https://user-images.githubusercontent.com/65367387/139515188-b1db9bad-ad93-42a1-a15f-3314b0ccb323.jpeg" width="300" />
San Mateo:
<img src="https://user-images.githubusercontent.com/65367387/139515192-1416e022-c92f-499d-9942-587fc5eb737b.jpeg" width="300" />
None:
<img src="https://user-images.githubusercontent.com/65367387/139515193-21acd39e-337f-4544-b05b-460500a3c8b7.jpeg" width="300" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
