### PR TITLE
2081/recalculate units available on listing update

### DIFF
--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -155,11 +155,16 @@ export class ListingsService {
     if (!listing) {
       throw new NotFoundException()
     }
+    let availableUnits = 0
     listingDto.units.forEach((unit) => {
       if (!unit.id) {
         delete unit.id
       }
+      if (unit.status === "available") {
+        availableUnits++
+      }
     })
+    listingDto.unitsAvailable = availableUnits
     Object.assign(listing, {
       ...plainToClass(Listing, listingDto, { excludeExtraneousValues: true }),
       property: plainToClass(


### PR DESCRIPTION
## Issue Overview

This PR addresses https://github.com/bloom-housing/bloom/issues/2081


- [x] This change addresses the issue in full

## Description
Before when a listing was updated the units available column on the listing grid on the partners side was not recalculating properly. Now on save, that column should recalculate properly

## How Can This Be Tested/Reviewed?
Create a listing (or use an existing listing). Take note of the units available column, and the units actually available on that listing. 

Go in and edit that listing, either: adding units, subtracting units, or leaving the units the same. Now note the units available, it should have recalculated based on what was done to the units

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
