### PR TITLE
Add ariaLabel prop to Button component

### DIFF
--- a/ui-components/__tests__/actions/Button.test.tsx
+++ b/ui-components/__tests__/actions/Button.test.tsx
@@ -106,4 +106,11 @@ describe("<Button>", () => {
     expect(container.getElementsByClassName("is-fullwidth").length).toBe(1)
     expect(container.getElementsByClassName("extra-special-extra-class").length).toBe(1)
   })
+
+  it("adds aria-label", () => {
+    const { getByText } = render(<Button ariaLabel="button action">Button Content</Button>)
+
+    expect(getByText("Button Content")).not.toBeNull()
+    expect(getByText("Button Content").getAttribute("aria-label")).toBe("button action")
+  })
 })

--- a/ui-components/src/actions/Button.tsx
+++ b/ui-components/src/actions/Button.tsx
@@ -19,6 +19,7 @@ export interface ButtonProps extends AppearanceProps {
   className?: string
   disabled?: boolean
   loading?: boolean
+  ariaLabel?: string
 }
 
 export const buttonClassesForProps = (props: Omit<ButtonProps, "onClick">) => {
@@ -72,6 +73,7 @@ const Button = (props: ButtonProps) => {
       className={buttonClasses.join(" ")}
       onClick={props.onClick}
       disabled={props.disabled || props.loading}
+      aria-label={props.ariaLabel}
     >
       {buttonInner(props)}
     </button>


### PR DESCRIPTION
# Pull Request Template

## Description

Add ariaLabel as a prop to the Button component. This is used in https://github.com/CityOfDetroit/bloom/pull/753 to make our icon buttons accessible.

## How Can This Be Tested/Reviewed?

Ran `yarn test` on ui-components.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
