### PR TITLE
feat: updates email confirmation for lottery

### DIFF
--- a/backend/core/src/migration/1620660845209-seed-translation-entries.ts
+++ b/backend/core/src/migration/1620660845209-seed-translation-entries.ts
@@ -16,7 +16,7 @@ export class seedTranslationEntries1620660845209 implements MigrationInterface {
           FCFS:
             "Applicants will be contacted by the property agent on a first come first serve basis until vacancies are filled.",
           lottery:
-            "The lottery will be held on %{lotteryDate}. Applicants will be contacted by the agent in lottery rank order until vacancies are filled.",
+            "Applicants will be contacted by the agent in lottery rank order until vacancies are filled.",
           noLottery:
             "Applicants will be contacted by the agent in waitlist order until vacancies are filled.",
         },

--- a/backend/core/src/shared/email/email.service.ts
+++ b/backend/core/src/shared/email/email.service.ts
@@ -14,6 +14,7 @@ import { TranslationsService } from "../../translations/translations.service"
 import { Language } from "../types/language-enum"
 import { JurisdictionResolverService } from "../../jurisdictions/services/jurisdiction-resolver.service"
 import { Jurisdiction } from "../../jurisdictions/entities/jurisdiction.entity"
+import { ListingReviewOrder } from "../../listings/types/listing-review-order-enum"
 
 @Injectable({ scope: Scope.REQUEST })
 export class EmailService {
@@ -94,7 +95,7 @@ export class EmailService {
     }
 
     if (listing.applicationDueDate) {
-      if (!listing.waitlistMaxSize) {
+      if (listing.reviewOrderType === ListingReviewOrder.lottery) {
         whatToExpectText = this.polyglot.t("confirmation.whatToExpect.lottery", {
           lotteryDate: listing.applicationDueDate,
         })

--- a/sites/partners/cypress/fixtures/listingImage.json
+++ b/sites/partners/cypress/fixtures/listingImage.json
@@ -1,3 +1,3 @@
 {
-    "filePath": "cypress/fixtures/exygy.jpeg"
+  "filePath": "cypress/fixtures/exygy.jpeg"
 }

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailAdditionalFees.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailAdditionalFees.tsx
@@ -31,7 +31,7 @@ const DetailAdditionalFees = () => {
         </GridCell>
       </GridSection>
       <GridSection columns={2}>
-      <GridCell>
+        <GridCell>
           <ViewItem label={t("listings.sections.depositHelperText")}>
             {getDetailFieldString(listing.depositHelperText)}
           </ViewItem>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2192

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This removes a sentence from the lottery section of the email confirmation. It also updates the logic in the email service to base lottery/noLottery off of the listing review order type.

This includes an update to the seeds for local and dev, but I will also run the following SQL to update it in other environments:
```
update translations set translations = jsonb_set("translations"::jsonb, '{confirmation, whatToExpect, lottery}', to_jsonb('Applicants will be contacted by the agent in lottery rank order until vacancies are filled.'::text)) where id = <translation id to update>
```

## How Can This Be Tested/Reviewed?

Reseed and apply to a listing that has a review order type of "lottery" (set the lottery radio on the L.M. form). The email confirmation should no longer have the sentence with the lottery date as noted in the related issue.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
