### PR TITLE
fix: fetchBaseListingData

### DIFF
--- a/sites/public/lib/hooks.ts
+++ b/sites/public/lib/hooks.ts
@@ -78,9 +78,9 @@ export const useGetApplicationStatusProps = (listing: Listing): ApplicationStatu
 }
 
 export async function fetchBaseListingData() {
-  const { id: jurisdictionId } = await fetchJurisdictionByName()
   let listings = []
   try {
+    const { id: jurisdictionId } = await fetchJurisdictionByName()
     const response = await axios.get(process.env.listingServiceUrl, {
       params: {
         view: "base",

--- a/sites/public/lib/hooks.ts
+++ b/sites/public/lib/hooks.ts
@@ -79,27 +79,34 @@ export const useGetApplicationStatusProps = (listing: Listing): ApplicationStatu
 
 export async function fetchBaseListingData() {
   const { id: jurisdictionId } = await fetchJurisdictionByName()
-  const response = await axios.get(process.env.listingServiceUrl, {
-    params: {
-      view: "base",
-      limit: "all",
-      filter: [
-        {
-          $comparison: "<>",
-          status: "pending",
-        },
-        {
-          $comparison: "=",
-          jurisdiction: jurisdictionId,
-        },
-      ],
-    },
-    paramsSerializer: (params) => {
-      return qs.stringify(params)
-    },
-  })
+  let listings = []
+  try {
+    const response = await axios.get(process.env.listingServiceUrl, {
+      params: {
+        view: "base",
+        limit: "all",
+        filter: [
+          {
+            $comparison: "<>",
+            status: "pending",
+          },
+          {
+            $comparison: "=",
+            jurisdiction: jurisdictionId,
+          },
+        ],
+      },
+      paramsSerializer: (params) => {
+        return qs.stringify(params)
+      },
+    })
 
-  return response.data?.items ?? []
+    listings = response.data?.items
+  } catch (e) {
+    console.log("fetchBaseListingData error: ", e)
+  }
+
+  return listings
 }
 
 let jurisdiction: Jurisdiction | null = null


### PR DESCRIPTION
This rewraps public's fetchBaseListingData with a try catch, so build in cypress passes (it's dependent on the backend and should be handled differently in the long run).