### PR TITLE
fix: units with invalid ami chart

### DIFF
--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -97,12 +97,11 @@ const hmiData = (units: Units, maxHouseholdSize: number, amiCharts: AmiChart[]) 
           if (unit.amiChartOverride) {
             amiChart = mergeAmiChartWithOverrides(amiChart, unit.amiChartOverride)
           }
-          return {
+          return JSON.stringify({
             percentage: parseInt(unit.amiPercentage, 10),
             chart: amiChart,
-          }
+          })
         })
-        .map((item) => JSON.stringify(item))
     ),
   ].map((uniqueSetString) => JSON.parse(uniqueSetString))
 
@@ -190,6 +189,7 @@ const hmiData = (units: Units, maxHouseholdSize: number, amiCharts: AmiChart[]) 
 
     let rowHasData = false // Row is valid if at least one column is filled, otherwise don't push the row
     allPercentages.forEach((currentAmiPercent) => {
+      console.log({ uniquePercentageChartSet })
       // Get all the charts that we're using with this percentage and size
       const uniquePercentCharts = uniquePercentageChartSet.filter((uniqueChartAndPercentage) => {
         return uniqueChartAndPercentage.percentage === currentAmiPercent

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -91,6 +91,7 @@ const hmiData = (units: Units, maxHouseholdSize: number, amiCharts: AmiChart[]) 
   const uniquePercentageChartSet: ChartAndPercentage[] = [
     ...new Set(
       units
+        .filter((unit) => amiChartMap[unit.amiChartId])
         .map((unit) => {
           let amiChart = amiChartMap[unit.amiChartId]
           if (unit.amiChartOverride) {


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This issue came up because there are jurisdictions like San Mateo and San José on production, that don't have ami charts, but units were added to listings with those jurisdictions before we tied ami charts to jurisdictions. This is marked as only a partial fix, because while it does fix the issue, we also need to add the ami charts, which are in progress at least for SJ.

## How Can This Be Tested/Reviewed?

You can test this by:
1. create a new draft listing with
2. create a unit and select an ami chart (there should be one per jurisdiction from the seed)
3. save the listing
4. in your local db, reassign the ami chart you selected to a different  jurisdiction
5. edit the listing and one of the overrides on the listing (you shouldn't be able to select an ami chart now)
6. save the listing and you shouldn't see an error, but if you comment out the one line that fixes this, you should see the error. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
