### PR TITLE
fix: prefUnits on autofill summary

### DIFF
--- a/sites/public/src/forms/applications/FormSummaryDetails.tsx
+++ b/sites/public/src/forms/applications/FormSummaryDetails.tsx
@@ -107,7 +107,7 @@ const FormSummaryDetails = ({
 
   const preferredUnits = application.preferredUnit?.map((unit) => {
     const unitDetails = allListingUnitTypes?.find((unitType) => unitType.id === unit.id)
-    return unitDetails?.name
+    return unitDetails?.name || unit.name
   })
 
   return (


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2261

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This fixes an issue where if you fill out an application with one set of preferred units under an account, then apply to another listing with different preferred units, the translation string would be wrong.

## How Can This Be Tested/Reviewed?

Complete an application with SRO as an available unit type and choose SRO as your unit type preference
Create an account with that application
Apply to another application logged in
You should see this on your last application summary string

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
