### PR TITLE
fix: fix hero button width with secondary button

### DIFF
--- a/ui-components/src/headers/Hero.scss
+++ b/ui-components/src/headers/Hero.scss
@@ -20,6 +20,13 @@
   width: 100%;
 }
 
+.hero__buttons {
+  @apply grid;
+  @apply md:grid-cols-4;
+  @apply gap-5;
+  @apply max-w-screen-md;
+  @apply m-auto;
+}
 .hero__title {
   @apply text-4xl;
   @apply mb-5;

--- a/ui-components/src/headers/Hero.tsx
+++ b/ui-components/src/headers/Hero.tsx
@@ -46,9 +46,9 @@ const Hero = (props: HeroProps) => {
       {props.buttonTitle && props.buttonLink && (
         <>
           {props.secondaryButtonTitle && props.secondaryButtonLink ? (
-            <div className="grid md:grid-cols-6 gap-5 max-w-screen-lg m-auto">
+            <div className="hero__buttons">
               <HeroButton
-                className={"md:col-start-3 with_secondary"}
+                className={"md:col-start-2 with_secondary"}
                 href={props.buttonLink}
                 title={props.buttonTitle}
               />


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses a release bug with [DAH-968](https://sfgovdt.jira.com/browse/DAH-968)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Around 777px, we were seeing that button text for secondary hero buttons was cut off for spanish
![image](https://user-images.githubusercontent.com/11825994/145659157-f86da2b6-b00f-4758-a40b-79b5a86bb3b7.png)

This PR switches from 6 to 4 columns and tweaks the max width of the div to make the buttons look OK in spanish at any size. 

## How Can This Be Tested/Reviewed?

1. Open up `/?path=/story/headers-hero--with-secondary-button` on the review app, and check the styles at varying screen widths.
2. Manually update the buttons to longer strings (e.g. "Aquilar" and "Comprar") and see that they aren't cut off
3. Verify that the buttons don't get comically large at larger screen sizes

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
