### PR TITLE
fix: force a release number if one exists

### DIFF
--- a/.github/workflows/pre-release_components.yml
+++ b/.github/workflows/pre-release_components.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.ADMIN_TOKEN }}
       
       - name: Set up Node.js
         uses: actions/setup-node@v1
@@ -31,7 +31,7 @@ jobs:
       - name: Version ui-components
         run: yarn version:prerelease:ui-components
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         
       - name: Publish ui-components
         run: yarn publish:ui-components

--- a/package.json
+++ b/package.json
@@ -49,16 +49,16 @@
     "test:apps:headless": "concurrently \"yarn dev:backend\" \"yarn test:app:public:headless\"",
     "lint": "eslint '**/*.ts' '**/*.tsx' '**/*.js'",
     "publish:ui-components": "cd ui-components && lerna publish from-package --yes --include-merged-tags --no-verify-access",
-    "version:ui-components": "cd ui-components && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags",
+    "version:ui-components": "cd ui-components && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags --force-git-tag",
     "publish:public": "cd sites/public && lerna publish from-package --yes --include-merged-tags --no-verify-access",
-    "version:public": "cd sites/public && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags",
+    "version:public": "cd sites/public && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags --force-git-tag",
     "publish:partners": "cd sites/partners && lerna publish from-package --yes --include-merged-tags --no-verify-access",
-    "version:partners": "cd sites/partners && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags",
+    "version:partners": "cd sites/partners && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags --force-git-tag",
     "publish:backend": "cd backend/core && lerna publish from-package --yes --include-merged-tags --no-verify-access",
-    "version:backend": "cd backend/core && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags",
+    "version:backend": "cd backend/core && lerna version --yes --no-commit-hooks --ignore-scripts --conventional-graduate --include-merged-tags --force-git-tag",
     "publish:all": "yarn publish:ui-components && yarn publish:backend --include-merged-tags --no-verify-access",
-    "version:prerelease:ui-components": "cd ui-components && lerna version prerelease --yes --no-commit-hooks --ignore-scripts --include-merged-tags",
-    "version:all": "yarn version:ui-components && yarn version:public && yarn version:partners && yarn version:backend --include-merged-tags"
+    "version:prerelease:ui-components": "cd ui-components && lerna version prerelease --yes --no-commit-hooks --ignore-scripts --include-merged-tags --force-git-tag",
+    "version:all": "yarn version:ui-components && yarn version:public && yarn version:partners && yarn version:backend --include-merged-tags --force-git-tag"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",


### PR DESCRIPTION
If a pre-release version already exists, bump to the next version