### PR TITLE
fix: remove next dependency from ui-components

### DIFF
--- a/sites/public/pages/forgot-password.tsx
+++ b/sites/public/pages/forgot-password.tsx
@@ -64,7 +64,7 @@ const ForgotPassword = () => {
             <Field
               caps={true}
               name="email"
-              label="Email"
+              label={t("t.email")}
               validation={{ required: true, pattern: emailRegex }}
               error={errors.email}
               errorMessage={errors.email ? t("authentication.signIn.loginError") : undefined}

--- a/ui-components/src/page_components/sign-in/FormSignIn.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignIn.tsx
@@ -1,5 +1,4 @@
-import React from "react"
-import Link from "next/link"
+import React, { useContext } from "react"
 import {
   AppearanceStyleType,
   Button,
@@ -16,6 +15,8 @@ import {
 } from "@bloom-housing/ui-components"
 import type { UseFormMethods } from "react-hook-form"
 import type { NetworkErrorValue, NetworkErrorReset } from "@bloom-housing/shared-helpers"
+
+import { NavigationContext } from "../../config/NavigationContext"
 
 export type FormSignInProps = {
   control: FormSignInControl
@@ -49,6 +50,7 @@ const FormSignIn = ({
   const onError = () => {
     window.scrollTo(0, 0)
   }
+  const { LinkComponent } = useContext(NavigationContext)
 
   return (
     <FormCard>
@@ -90,9 +92,9 @@ const FormSignIn = ({
           />
 
           <aside className="float-right text-tiny font-semibold">
-            <Link href="/forgot-password">
+            <LinkComponent href="/forgot-password">
               <a>{t("authentication.signIn.forgotPassword")}</a>
-            </Link>
+            </LinkComponent>
           </aside>
 
           <Field


### PR DESCRIPTION
# Pull Request Template

## Description

Consumers are currently unable to uptake ui-components because we re-added a nextjs dependency - this PR just removes it.

## How Can This Be Tested/Reviewed?

Ensure the forgot password link still works as expected.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
