### PR TITLE
fix: ami charts without all households

### DIFF
--- a/backend/core/src/seeder/seeds/ami-charts/default-ami-chart.ts
+++ b/backend/core/src/seeder/seeds/ami-charts/default-ami-chart.ts
@@ -12,6 +12,9 @@ export function getDefaultAmiChart() {
 export const defaultAmiChart: Omit<AmiChartCreateDto, "jurisdiction"> = {
   name: "AlamedaCountyTCAC2021",
   items: [
+    { income: 140900, percentOfAmi: 120, householdSize: 3 },
+    { income: 156600, percentOfAmi: 120, householdSize: 4 },
+    { income: 169140, percentOfAmi: 120, householdSize: 5 },
     {
       percentOfAmi: 80,
       householdSize: 1,

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -159,14 +159,19 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
   const resetAmiTableValues = (defaultAmiChart?: AmiChartItem[], defaultAmiPercentage?: string) => {
     const chart = defaultAmiChart ?? currentAmiChart
     const percentage = defaultAmiPercentage ?? amiPercentage
-    const newPercentages = chart
+    const newPercentagesByHouseHold = chart
       .filter((item: AmiChartItem) => item.percentOfAmi === parseInt(percentage))
-      .sort(function (a: AmiChartItem, b: AmiChartItem) {
-        return a.householdSize - b.householdSize
-      })
-    newPercentages.forEach((amiValue: AmiChartItem, index: number) => {
-      setValue(`maxIncomeHouseholdSize${index + 1}`, amiValue.income.toString())
-    })
+      .reduce((acc, item) => {
+        acc[item.householdSize] = item
+        return acc
+      }, {})
+
+    for (let i = 1; i < 9; i++) {
+      setValue(
+        `maxIncomeHouseholdSize${i}`,
+        newPercentagesByHouseHold[i] ? newPercentagesByHouseHold[i].income.toString() : ""
+      )
+    }
   }
 
   useEffect(() => {
@@ -214,8 +219,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
           (item: AmiChartItem) =>
             item.householdSize === index + 1 && item.percentOfAmi === parseInt(amiPercentage)
         )[0]
+
         if (
           data[`maxIncomeHouseholdSize${index + 1}`] &&
+          existingChartValue &&
           parseInt(data[`maxIncomeHouseholdSize${index + 1}`]) === existingChartValue.income
         ) {
           delete data[`maxIncomeHouseholdSize${index + 1}`]

--- a/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/listings/PaperListingForm/UnitForm.tsx
@@ -159,12 +159,12 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
   const resetAmiTableValues = (defaultAmiChart?: AmiChartItem[], defaultAmiPercentage?: string) => {
     const chart = defaultAmiChart ?? currentAmiChart
     const percentage = defaultAmiPercentage ?? amiPercentage
-    const newPercentagesByHouseHold = chart
-      .filter((item: AmiChartItem) => item.percentOfAmi === parseInt(percentage))
-      .reduce((acc, item) => {
+    const newPercentagesByHouseHold = chart.reduce((acc, item: AmiChartItem) => {
+      if (item.percentOfAmi === parseInt(percentage)) {
         acc[item.householdSize] = item
-        return acc
-      }, {})
+      }
+      return acc
+    }, {})
 
     for (let i = 1; i < 9; i++) {
       setValue(


### PR DESCRIPTION
This PR addresses #2364 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This updates the unit form so that ami charts correctly populate the household data (before it assumed that all household sizes (1-8) had a value for each ami percentage. This also adds 120 percentages to one of the seeds.

## How Can This Be Tested/Reviewed?
Pull this down and reseed. Edit or create a new listing and add a unit and select `AlamedaCountyTCAC2021` with `120` as the percentage. You should see incomes for household sizes of 3, 4 and 5. You should be able to enter overrides and save.


Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
