### PR TITLE
fix: cannot clear some fields in listings management

### DIFF
--- a/sites/partners/src/listings/PaperListingDetails/sections/helpers.ts
+++ b/sites/partners/src/listings/PaperListingDetails/sections/helpers.ts
@@ -25,18 +25,14 @@ export const getReadableErrorMessage = (errorMessage: string | undefined) => {
   const errorDetails = errorMessage.substr(errorMessage.indexOf(" ") + 1)
   let readableMessage = null
   switch (errorDetails) {
-    case "should not be null or undefined":
-    case "must be a string":
-    case "must be an UUID":
-    case "must contain at least 1 elements":
-    case "must be a boolean value":
-      readableMessage = t("errors.requiredFieldError")
-      break
     case "must be an email":
       readableMessage = t("errors.emailAddressError")
       break
     case "must be a valid phone number":
       readableMessage = t("errors.phoneNumberError")
+      break
+    default:
+      readableMessage = t("errors.requiredFieldError")
   }
   return readableMessage
 }

--- a/sites/partners/src/listings/PaperListingForm/formatters/AdditionalMetadataFormatter.ts
+++ b/sites/partners/src/listings/PaperListingForm/formatters/AdditionalMetadataFormatter.ts
@@ -11,11 +11,14 @@ export default class AdditionalMetadataFormatter extends Formatter {
       return { program: { ...program }, ordinal: index + 1 }
     })
 
-    this.data.buildingAddress = {
-      ...this.data.buildingAddress,
-      latitude: this.metadata.latLong.latitude ?? null,
-      longitude: this.metadata.latLong.longitude ?? null,
+    if (this.data.buildingAddress) {
+      this.data.buildingAddress = {
+        ...this.data.buildingAddress,
+        latitude: this.metadata.latLong.latitude ?? null,
+        longitude: this.metadata.latLong.longitude ?? null,
+      }
     }
+
     this.data.customMapPin = this.metadata.customMapPositionChosen
     this.data.yearBuilt = this.data.yearBuilt ? Number(this.data.yearBuilt) : null
     if (!this.data.reservedCommunityType.id) this.data.reservedCommunityType = null

--- a/sites/partners/src/listings/PaperListingForm/formatters/BooleansFormatter.ts
+++ b/sites/partners/src/listings/PaperListingForm/formatters/BooleansFormatter.ts
@@ -41,7 +41,26 @@ export default class BooleansFormatter extends Formatter {
         this.data.whereApplicationsMailedIn === addressTypes.anotherAddress,
       trueCase: () => this.data.applicationMailingAddress,
     })
-
+    this.processBoolean("leasingAgentAddress", {
+      when:
+        !!this.data.leasingAgentAddress.street &&
+        !!this.data.leasingAgentAddress.city &&
+        !!this.data.leasingAgentAddress.state &&
+        !!this.data.leasingAgentAddress.zipCode,
+      trueCase: () => this.data.leasingAgentAddress,
+    })
+    this.processBoolean("buildingAddress", {
+      when:
+        !!this.data.buildingAddress.street &&
+        !!this.data.buildingAddress.city &&
+        !!this.data.buildingAddress.state &&
+        !!this.data.buildingAddress.zipCode,
+      trueCase: () => this.data.buildingAddress,
+    })
+    this.processBoolean("image", {
+      when: !!this.data.image.fileId && !!this.data.image.label,
+      trueCase: () => this.data.image,
+    })
     this.processBoolean("digitalApplication", {
       when: this.data.digitalApplicationChoice === YesNoAnswer.Yes,
       falseCase: () => (this.data.digitalApplicationChoice === YesNoAnswer.No ? false : null),

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -236,11 +236,21 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
               const readableError = getReadableErrorMessage(errorMessage)
               if (readableError) {
                 setError(fieldName, { message: readableError })
-                if (fieldName === "buildingAddress") {
-                  setError(`${fieldName}.city`, { message: readableError })
-                  setError(`${fieldName}.state`, { message: readableError })
-                  setError(`${fieldName}.street`, { message: readableError })
-                  setError(`${fieldName}.zipCode`, { message: readableError })
+                if (fieldName === "buildingAddress" || fieldName === "buildingAddress.nested") {
+                  const setIfEmpty = (
+                    fieldName: string,
+                    fieldValue: string,
+                    errorMessage: string
+                  ) => {
+                    if (!fieldValue) {
+                      setError(fieldName, { message: errorMessage })
+                    }
+                  }
+                  const address = formData.buildingAddress
+                  setIfEmpty(`buildingAddress.city`, address.city, readableError)
+                  setIfEmpty(`buildingAddress.state`, address.state, readableError)
+                  setIfEmpty(`buildingAddress.street`, address.street, readableError)
+                  setIfEmpty(`buildingAddress.zipCode`, address.zipCode, readableError)
                 }
               }
             })


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2371

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

You can now remove a leasing agent address in any state, and a photo and a building address in a draft state.

For an address to save, it must be a valid address (street, city, state, zip).

## How Can This Be Tested/Reviewed?

Create a new listing and save it as a draft with a building address, photo, and leasing agent address. Then remove the fields and ensure they are removed.

Edit an existing published listing and try to remove building address or photo - you should not be able to, it validates them as required fields, but you should be able to remove the leasing agent address. Also check here that removing just one of the building address fields only highlights that field in red (previously it was highlighting every field in the address, even ones that were valid).

Possible Cypress followup: https://github.com/bloom-housing/bloom/issues/2454
## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
