### PR TITLE
feat: only show MapBox map when it's in the viewport

### DIFF
--- a/ui-components/.jest/setup-tests.js
+++ b/ui-components/.jest/setup-tests.js
@@ -18,6 +18,14 @@ window.matchMedia = jest.fn().mockImplementation((query) => {
   }
 })
 
+window.IntersectionObserver = class {
+  constructor(root, options) {
+    // no-op
+  }
+  observe = jest.fn()
+  disconnect = jest.fn()
+}
+
 addTranslation(general)
 
 configure({ testIdAttribute: "data-test-id" })

--- a/ui-components/index.ts
+++ b/ui-components/index.ts
@@ -66,6 +66,7 @@ export * from "./src/helpers/formatYesNoLabel"
 export * from "./src/helpers/getTranslationWithArguments"
 export * from "./src/helpers/preferences"
 export * from "./src/helpers/resolveObject"
+export * from "./src/helpers/useIntersect"
 export * from "./src/helpers/useMutate"
 export * from "./src/helpers/tableSummaries"
 

--- a/ui-components/src/helpers/useIntersect.ts
+++ b/ui-components/src/helpers/useIntersect.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react"
+
+interface useIntersectProps {
+  root?: Element | null
+  rootMargin?: string
+  threshold?: number
+}
+
+/**
+ * Use this hook to obtain state when an element is visible or not relative to
+ * an ancestor element (or by default the browser viewport)
+ */
+export const useIntersect = ({
+  root = null,
+  rootMargin = "0px",
+  threshold = 0,
+}: useIntersectProps) => {
+  // broadly based on this source code:
+  // https://non-traditional.dev/how-to-use-an-intersectionobserver-in-a-react-hook-9fb061ac6cb5
+
+  const [intersecting, setIntersecting] = useState(false)
+  const [element, setIntersectingElement] = useState<Element | null>(null)
+
+  const observer = useRef<IntersectionObserver | null>(null)
+
+  // Instantiate the observer upon element mount
+  useEffect(() => {
+    if (observer.current) observer.current.disconnect()
+
+    if (element) {
+      observer.current = new IntersectionObserver(
+        ([entry]) => setIntersecting(entry.isIntersecting),
+        {
+          root,
+          rootMargin,
+          threshold,
+        }
+      )
+
+      observer.current.observe(element)
+    }
+
+    // Unmount callback
+    return () => observer?.current?.disconnect()
+  }, [element, root, rootMargin, threshold])
+
+  return { setIntersectingElement, intersecting }
+}

--- a/ui-components/src/page_components/listing/ListingMap.scss
+++ b/ui-components/src/page_components/listing/ListingMap.scss
@@ -1,3 +1,7 @@
+.listing-map {
+  min-height: 12rem;
+}
+
 .pin {
   @apply absolute;
   width: 30px;

--- a/ui-components/src/page_components/listing/ListingMap.stories.tsx
+++ b/ui-components/src/page_components/listing/ListingMap.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 const listing = Object.assign({}, Archer) as any
 
-export const showBWMapWithPin = () => {
+export const showMapWithPin = () => {
   return <ListingMap address={listing.buildingAddress} listingName={listing.name} />
 }

--- a/ui-components/src/page_components/listing/ListingMap.tsx
+++ b/ui-components/src/page_components/listing/ListingMap.tsx
@@ -36,8 +36,12 @@ const isValidLongitude = (longitude: number) => {
 }
 
 const ListingMap = (props: ListingMapProps) => {
-  // Lazy load the map component only when it's visible on screen
-  const { setIntersectingElement, intersecting } = useIntersect({ rootMargin: "500px" })
+  // Lazy load the map component only when it will become visible on screen
+  const { setIntersectingElement, intersecting } = useIntersect({
+    // `window` isn't set for SSR, so we'll use `global` instead—doesn't really
+    // matter because the map won't ever get rendered in SSR anyway
+    rootMargin: `${global.innerHeight || 0}px`,
+  })
   const [hasIntersected, setHasIntersected] = useState(false)
   if (intersecting && !hasIntersected) setHasIntersected(true)
 

--- a/ui-components/src/page_components/listing/ListingMap.tsx
+++ b/ui-components/src/page_components/listing/ListingMap.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useCallback, useEffect } from "react"
+import React, { useState, useCallback, useEffect, useMemo } from "react"
 import "mapbox-gl/dist/mapbox-gl.css"
 import MapGL, { Marker } from "react-map-gl"
 
 import "./ListingMap.scss"
 import { MultiLineAddress, Address } from "../../helpers/address"
+import { useIntersect } from "../../.."
 
 export interface ListingMapProps {
   address?: Address
@@ -35,6 +36,11 @@ const isValidLongitude = (longitude: number) => {
 }
 
 const ListingMap = (props: ListingMapProps) => {
+  // Lazy load the map component only when it's visible on screen
+  const { setIntersectingElement, intersecting } = useIntersect({ rootMargin: "500px" })
+  const [hasIntersected, setHasIntersected] = useState(false)
+  if (intersecting && !hasIntersected) setHasIntersected(true)
+
   const [marker, setMarker] = useState({
     latitude: props.address?.latitude,
     longitude: props.address?.longitude,
@@ -95,12 +101,12 @@ const ListingMap = (props: ListingMapProps) => {
     return null
 
   return (
-    <div className="listing-map">
+    <div className="listing-map" ref={setIntersectingElement}>
       <div className="addressPopup">
         {props.listingName && <h3 className="text-caps-tiny">{props.listingName}</h3>}
         <MultiLineAddress address={props.address} />
       </div>
-      {(process.env.mapBoxToken || process.env.MAPBOX_TOKEN) && (
+      {(process.env.mapBoxToken || process.env.MAPBOX_TOKEN) && hasIntersected && (
         <MapGL
           mapboxApiAccessToken={process.env.mapBoxToken || process.env.MAPBOX_TOKEN}
           mapStyle="mapbox://styles/mapbox/streets-v11"


### PR DESCRIPTION
## Issue Overview

This PR addresses #2413 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR adds a new `useIntersect` React hook which will supply state to control the visibility of an element relative to
an ancestor element (or by default the browser viewport). The map widget on listings then uses this so the map is only initialized once the browser scrolls down close to the map region (there's an extra buffer of 500 pixels).

## How Can This Be Tested/Reviewed?

Wait a beat after the listing has loaded, then scroll as fast as possible to the bottom of the listing, and you'll notice the map loads once it has become visible. Also you can reload & start at the top of the listing, and scroll down slowly, and likely by the time you get to the map it will have already loaded.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
