### PR TITLE
2468/adding dublin preferences

### DIFF
--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -268,6 +268,29 @@
           "description": "Al menos un miembro de mi hogar es empleado del Distrito Escolar Unificado de Alameda"
         }
       },
+      "dublinHousing": {
+        "liveInDublin": {
+          "label": "Al menos un miembro de mi hogar vive en Dublín (3 puntos)"
+        },
+        "immediateFamily": {
+          "label": "Al menos un miembro de mi hogar tiene un familiar directo en Dublín (1 punto)"
+        },
+        "displacedResident": {
+          "label": "Se requirió que al menos un miembro de mi hogar se mudara de la residencia actual de Dublín debido a la demolición de la vivienda o la conversión de la vivienda de alquiler a unidad de venta (1 punto)"
+        },
+        "worksInDublin": {
+          "label": "Al menos un miembro de mi hogar trabaja a tiempo completo en Dublín (3 puntos)"
+        },
+        "publicServiceEmployee": {
+          "label": "Al menos un miembro de mi hogar es un empleado del servicio público en Dublín (1 punto adicional)"
+        },
+        "permanentlyDisabled": {
+          "label": "Al menos un miembro de mi hogar tiene una discapacidad permanente (1 punto)"
+        },
+        "senior": {
+          "label": "Al menos un miembro de mi hogar es una persona mayor, definida como de 62 años o más (1 punto)"
+        }
+      },
       "terminationOfAffordability": {
         "atLeastOne": {
           "label": "Al menos un miembro de mi hogar está sujeto a la terminación de las restricciones de asequibilidad"

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -671,6 +671,30 @@
           "label": "At least one member of my household is an Alameda Unified School District employee",
           "description": "At least one member of my household is an Alameda Unified School District employee."
         }
+      },
+      "dublinHousing": {
+        "title": "Alameda Unified School District (AUSD) employee",
+        "liveInDublin": {
+          "label": "At least one member of my household lives in Dublin (3 points)"
+        },
+        "immediateFamily": {
+          "label": "At least one member of my household has an immediate family member in Dublin (1 point)"
+        },
+        "displacedResident": {
+          "label": "At least one member of my household was required to relocate from current Dublin residence due to demolition of dwelling or conversation of dwelling from rental to for-sale unit (1 point)"
+        },
+        "worksInDublin": {
+          "label": "At least one member of my household works full-time in Dublin (3 points)"
+        },
+        "publicServiceEmployee": {
+          "label": "At least one member of my household is a public service employee in Dublin (1 additional point)"
+        },
+        "permanentlyDisabled": {
+          "label": "At least one member of my household is permanently disabled (1 point)"
+        },
+        "senior": {
+          "label": "At least one member of my household is a senior, defined as age 62 and older (1 point)"
+        }
       }
     },
     "review": {

--- a/ui-components/src/locales/vi.json
+++ b/ui-components/src/locales/vi.json
@@ -265,9 +265,32 @@
           "description": "Ít nhất một thành viên trong gia đình tôi là nhân viên của Học khu Thống nhất Alameda"
         }
       },
+      "dublinHousing": {
+        "liveInDublin": {
+          "label": "Ít nhất một thành viên trong gia đình tôi sống ở Dublin (3 điểm)"
+        },
+        "immediateFamily": {
+          "label": "Ít nhất một thành viên trong gia đình của tôi có người thân trong gia đình ở Dublin (1 điểm)"
+        },
+        "displacedResident": {
+          "label": "Ít nhất một thành viên trong gia đình tôi đã phải di dời khỏi nơi ở hiện tại ở Dublin do việc phá dỡ nhà ở hoặc chuyển nhà từ cho thuê sang bán (1 điểm)"
+        },
+        "worksInDublin": {
+          "label": "Ít nhất một thành viên trong gia đình tôi làm việc toàn thời gian ở Dublin (3 điểm)"
+        },
+        "publicServiceEmployee": {
+          "label": "Ít nhất một thành viên trong gia đình tôi là nhân viên dịch vụ công cộng ở Dublin (1 điểm bổ sung)"
+        },
+        "permanentlyDisabled": {
+          "label": "Ít nhất một thành viên trong gia đình tôi bị tàn tật vĩnh viễn (1 điểm)"
+        },
+        "senior": {
+          "label": "Ít nhất một thành viên trong gia đình tôi là người cao tuổi, được xác định là từ 62 tuổi trở lên (1 điểm)"
+        }
+      },
       "terminationOfAffordability": {
         "atLeastOne": {
-          "label": "Ít nhất một thành viên trong gia đình tôi phải chấm dứt các hạn chế về khả năng chi trả"
+          "label": "Ít nhất một thành viên trong gia đình, tôi phải sử dụng các hạn chế về chi trả khả năng"
         }
       },
       "liveWorkFosterCity": {

--- a/ui-components/src/locales/zh.json
+++ b/ui-components/src/locales/zh.json
@@ -265,6 +265,29 @@
           "description": "我的至少一名家庭成员是阿拉米达联合学区的雇员"
         }
       },
+      "dublinHousing": {
+        "liveInDublin": {
+          "label": "我的至少一名家庭成员住在都柏林 (3 分)"
+        },
+        "immediateFamily": {
+          "label": "我的至少一名家庭成员在都柏林有直系亲属 (1 分)"
+        },
+        "displacedResident": {
+          "label": "由于住宅被拆除或住宅从出租转为出售单位的谈话, 我的至少一名家庭成员需要从目前都柏林的住宅搬迁 (1 分)"
+        },
+        "worksInDublin": {
+          "label": "我的至少一名家庭成员在都柏林全职工作 (3 分)"
+        },
+        "publicServiceEmployee": {
+          "label": "我的至少一名家庭成员是都柏林的公共服务人员 (加分)"
+        },
+        "permanentlyDisabled": {
+          "label": "我的家庭中至少有一名成员永久残疾 (1 分)"
+        },
+        "senior": {
+          "label": "我的家庭中至少一名成员是老年人, 定义为 62 岁及以上 (1 分)"
+        }
+      },
       "terminationOfAffordability": {
         "atLeastOne": {
           "label": "我的至少一名家庭成员受到终止负担能力限制"


### PR DESCRIPTION
This adds the preferences for: https://github.com/bloom-housing/bloom/issues/2468

below is the query to add them:


```
INSERT INTO preferences (Title, subtitle, description, links, form_metadata)
SELECT 
    'City of Dublin Housing Preferences' as Title,
    '' as subtitle,
    'Does anyone in your household satisfy any of the following preferences?' as description,
    '[]' as links,
    '{"key":"dublinHousing","options":[{"key":"liveInDublin","extraData":[],"description":false},{"key":"immediateFamily","extraData":[],"description":false},{"key":"displacedResident","extraData":[{"key":"address","type":"address"}],"description":false},{"key":"worksInDublin","extraData":[{"key":"address","type":"address"}],"description":false},{"key":"publicServiceEmployee","extraData":[],"description":false},{"key":"permanentlyDisabled","extraData":[],"description":false},{"key":"senior","extraData":[],"description":false}]}' as form_metadata
;

SELECT
    id
FROM preferences
WHERE title = 'City of Dublin Housing Preferences'
;

SELECT
    id
FROM jurisdictions
WHERE name = 'Alameda'
;

INSERT INTO jurisdictions_preferences_preferences
SELECT '219fd1a5-2f81-4c0b-a027-7b3a4efdb1bd' as jurisdictions_id,
'3e1d2981-d553-4665-a76f-88e71fc316e8' as preferences_id
;

```