### PR TITLE
fix: image gradient obscures image on mobile, is harsh in safari (#2267)

### DIFF
--- a/ui-components/src/blocks/ImageCard.scss
+++ b/ui-components/src/blocks/ImageCard.scss
@@ -36,20 +36,22 @@
 }
 
 .image-card__overlay {
-  background: rgb(0, 0, 0);
   background: linear-gradient(
     0deg,
-    rgba(0, 0, 0, 0.9374124649859944) 0%,
-    rgba(0, 0, 0, 0.665703781512605) 80%,
-    rgba(255, 255, 255, 0) 100%
+    rgba(0, 0, 0, 0.9) 0%,
+    rgba(0, 0, 0, 0.8) 10%,
+    rgba(0, 0, 0, 0.7) 50%,
+    rgba(0, 0, 0, 0.3) 90%,
+    rgba(0, 0, 0, 0) 100%
   );
   @screen md {
-    background: rgb(0, 0, 0);
     background: linear-gradient(
       0deg,
-      rgba(0, 0, 0, 0.9374124649859944) 20%,
-      rgba(0, 0, 0, 0.665703781512605) 40%,
-      rgba(255, 255, 255, 0) 60%
+      rgba(0, 0, 0, 0.9) 20%,
+      rgba(0, 0, 0, 0.5) 50%,
+      rgba(0, 0, 0, 0.2) 65%,
+      rgba(0, 0, 0, 0.1) 70%,
+      rgba(0, 0, 0, 0) 80%
     );
   }
   position: absolute;

--- a/ui-components/src/blocks/ImageCard.stories.tsx
+++ b/ui-components/src/blocks/ImageCard.stories.tsx
@@ -32,6 +32,20 @@ export const withShortImageLongTitle = () => {
         imageUrl="https://bit.ly/3jzVfwP
   "
         subtitle="55 Triton Park Lane, Foster City CA, 94404"
+        title="Here is the name of a long listing"
+      />
+    </div>
+  )
+}
+
+export const withShortImageLongerTitle = () => {
+  return (
+    <div style={{ maxWidth: "500px" }}>
+      <ImageCard
+        href="/listings"
+        imageUrl="https://bit.ly/3jzVfwP
+  "
+        subtitle="55 Triton Park Lane, Foster City CA, 94404"
         title="Here is the name of a long listing, it should wrap"
       />
     </div>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2267

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Makes the image card gradient less harsh on mobile and to have it cover less of the image. Also makes both the desktop and mobile versions be less harsh in Firefox and Safari.

There may be some slight color contrast issues when the ImageCard text wraps on three lines on mobile on a shorter image. Since this is a small category of listings (likely less than 5 on DAHLIA, and none of Bloom) and the current solution to that makes all the cards look worse, we are going to accept that in the short term as we are about to pick up the re-design of the ImageCard titles.

This is a blocker for DAHLIA's release of the Listing Directory re-write.

## How Can This Be Tested/Reviewed?

You can look at the stories under ImageCard in the Storybook deploy preview.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
