### PR TITLE
fix: use the correct AlertBox component for preview listing notice

### DIFF
--- a/sites/public/pages/preview/listings/[id].tsx
+++ b/sites/public/pages/preview/listings/[id].tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import Head from "next/head"
 import axios from "axios"
 import { Listing } from "@bloom-housing/backend-core/types"
-import { t } from "@bloom-housing/ui-components"
+import { AlertBox, t } from "@bloom-housing/ui-components"
 import { imageUrlFromListing } from "@bloom-housing/shared-helpers"
 
 import Layout from "../../../layouts/application"
@@ -15,7 +15,6 @@ interface ListingProps {
 
 export default function ListingPage(props: ListingProps) {
   const { listing } = props
-  const [previewBarVisible, setPreviewBarVisible] = useState(true)
   const pageTitle = `${listing.name} - ${t("nav.siteTitle")}`
   const metaDescription = t("pageDescription.listing", {
     regionName: t("region.name"),
@@ -29,19 +28,15 @@ export default function ListingPage(props: ListingProps) {
         <title>{pageTitle}</title>
       </Head>
       <MetaTags title={listing.name} image={metaImage} description={metaDescription} />
-      {previewBarVisible && (
-        <div className="pt-6 pb-4 bg-red-700 text-white font-bold text-sm">
-          <div className="max-w-5xl m-auto">{t("listings.listingPreviewOnly")}</div>
-          <button
-            className="-mt-8 alert-box__close text-white"
-            onClick={() => {
-              setPreviewBarVisible(false)
-            }}
-          >
-            &times;
-          </button>
-        </div>
-      )}
+      <AlertBox
+        className="pt-5 pb-8 bg-red-700 font-bold text-sm"
+        type="alert"
+        boundToLayoutWidth
+        inverted
+        closeable
+      >
+        {t("listings.listingPreviewOnly")}
+      </AlertBox>
       <ListingView listing={listing} preview={false} />
     </Layout>
   )

--- a/ui-components/src/notifications/AlertBox.scss
+++ b/ui-components/src/notifications/AlertBox.scss
@@ -13,6 +13,7 @@
     @apply flex-1;
     @apply flex;
     @apply items-center;
+    line-height: 1rem;
   }
 
   &.narrow {
@@ -79,7 +80,6 @@
 
 .alert-box__close {
   @apply text-3xl;
-  line-height: 1rem;
   right: 1rem;
   @apply ml-3;
   @apply p-0;

--- a/ui-components/src/notifications/AlertBox.tsx
+++ b/ui-components/src/notifications/AlertBox.tsx
@@ -52,6 +52,7 @@ const AlertBox = (props: AlertBoxProps) => {
               size="medium"
               symbol={icons[props.type || "alert"]}
               fill={props.inverted ? IconFillColors.white : undefined}
+              ariaHidden={true}
             />
           </span>
           <span className="alert-box__body">
@@ -63,8 +64,9 @@ const AlertBox = (props: AlertBoxProps) => {
           <button
             className={`alert-box__close ${props.inverted ? "text-white" : ""}`}
             onClick={onClose}
+            aria-label="close alert"
           >
-            &times;
+            <span aria-hidden={true}>&times;</span>
           </button>
         )}
       </div>


### PR DESCRIPTION
## Issue Overview

This PR addresses #2157 & #2249

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

There was an accessibility improvement to be made to the `AlertBox` component. In addition, the preview notice bar when previewing a listing being edited wasn't actually using a real `AlertBox` at all, so now it is.

## How Can This Be Tested/Reviewed?

You can view the `AlertBox` in Storybook, or if you try to log in on public/partners and use the wrong credentials. Using VoiceOver, you can verify the alert icon isn't announced by the screen reader, and that the X close button is announced as "close alert".

In addition, you can verify the correct visuals of the preview bar when [previewing a listing](https://deploy-preview-2497--dev-bloom.netlify.app/preview/listings/b832fd76-b212-46ec-9a07-18ac795a5c54).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
