### PR TITLE
fix: remove shared-helpers dependency from FormForgotPassword

### DIFF
--- a/ui-components/src/page_components/forgot-password/FormForgotPassword.tsx
+++ b/ui-components/src/page_components/forgot-password/FormForgotPassword.tsx
@@ -15,13 +15,19 @@ import {
 } from "@bloom-housing/ui-components"
 import { NavigationContext } from "../../config/NavigationContext"
 import type { UseFormMethods } from "react-hook-form"
-import type { NetworkErrorReset, NetworkErrorValue } from "@bloom-housing/shared-helpers"
 
 export type FormForgotPasswordProps = {
   control: FormForgotPasswordControl
   onSubmit: (data: FormForgotPasswordValues) => void
   networkError: FormForgotPasswordNetworkError
 }
+
+export type NetworkErrorReset = () => void
+
+export type NetworkErrorValue = {
+  title: string
+  content: string
+} | null
 
 export type FormForgotPasswordNetworkError = {
   error: NetworkErrorValue


### PR DESCRIPTION
# Pull Request Template

## Description

Just copy/pasted two types from our shared-helpers library into a ui-component that was pulling them in because we don't want any shared-helpers dependencies in ui-components. We want shared-helpers have a dependency on our backend and we don't want that for ui-components. This change was also causing a build issue for consumers because we didn't add shared-helpers to ui-components dependencies.

## How Can This Be Tested/Reviewed?

Essentially no change just a copy pasta. You can see the two types I copied [here](https://github.com/bloom-housing/bloom/blob/7faf3a2b382ee2c7840e870e25d22bfc960d1256/shared-helpers/src/catchNetworkError.ts#L5). 

