### PR TITLE
fix: lottery confirmation in email translations

### DIFF
--- a/backend/core/src/email/email.service.spec.ts
+++ b/backend/core/src/email/email.service.spec.ts
@@ -104,9 +104,7 @@ describe("EmailService", () => {
             FCFS:
               "Applicants will be contacted by the property agent on a first come first serve basis until vacancies are filled.",
             lottery:
-              "The lottery will be held on %{lotteryDate}. Applicants will be contacted by the agent in lottery rank order until vacancies are filled.",
-            noLottery:
-              "Applicants will be contacted by the agent in waitlist order until vacancies are filled.",
+              "Applicants will be contacted by the agent in lottery rank order until vacancies are filled.",
           },
         },
         footer: {
@@ -186,7 +184,7 @@ describe("EmailService", () => {
       expect(sendMock.mock.calls[0][0].to).toEqual(user.email)
       expect(sendMock.mock.calls[0][0].subject).toEqual("Your Application Confirmation")
       expect(sendMock.mock.calls[0][0].html).toMatch(
-        /Applicants will be contacted by the agent in waitlist order until vacancies are filled/
+        /Applicants will be contacted by the agent in lottery rank order until vacancies are filled/
       )
       expect(sendMock.mock.calls[0][0].html).toMatch(
         /http:\/\/localhost:3000\/listing\/Uvbk5qurpB2WI9V6WnNdH/

--- a/backend/core/src/email/email.service.spec.ts
+++ b/backend/core/src/email/email.service.spec.ts
@@ -184,7 +184,7 @@ describe("EmailService", () => {
       expect(sendMock.mock.calls[0][0].to).toEqual(user.email)
       expect(sendMock.mock.calls[0][0].subject).toEqual("Your Application Confirmation")
       expect(sendMock.mock.calls[0][0].html).toMatch(
-        /Applicants will be contacted by the agent in lottery rank order until vacancies are filled/
+        /Applicants will be contacted by the property agent on a first come first serve basis until vacancies are filled/
       )
       expect(sendMock.mock.calls[0][0].html).toMatch(
         /http:\/\/localhost:3000\/listing\/Uvbk5qurpB2WI9V6WnNdH/

--- a/backend/core/src/email/email.service.ts
+++ b/backend/core/src/email/email.service.ts
@@ -32,12 +32,12 @@ export class EmailService {
       phrases: {},
     })
     const polyglot = this.polyglot
-    Handlebars.registerHelper("t", function (
-      phrase: string,
-      options?: number | Polyglot.InterpolationOptions
-    ) {
-      return polyglot.t(phrase, options)
-    })
+    Handlebars.registerHelper(
+      "t",
+      function (phrase: string, options?: number | Polyglot.InterpolationOptions) {
+        return polyglot.t(phrase, options)
+      }
+    )
     const parts = this.partials()
     Handlebars.registerPartial(parts)
   }
@@ -129,17 +129,12 @@ export class EmailService {
       )
     }
 
-    if (listing.applicationDueDate) {
-      if (listing.reviewOrderType === ListingReviewOrder.lottery) {
-        whatToExpectText = this.polyglot.t("confirmation.whatToExpect.lottery", {
-          lotteryDate: listing.applicationDueDate,
-        })
-      } else {
-        whatToExpectText = this.polyglot.t("confirmation.whatToExpect.noLottery", {
-          lotteryDate: listing.applicationDueDate,
-        })
-      }
+    if (listing.reviewOrderType === ListingReviewOrder.lottery) {
+      whatToExpectText = this.polyglot.t("confirmation.whatToExpect.lottery", {
+        lotteryDate: listing.applicationDueDate,
+      })
     } else {
+      // for when listing.reviewOrderType === ListingReviewOrder.firstComeFirstServe
       whatToExpectText = this.polyglot.t("confirmation.whatToExpect.FCFS")
     }
     const user = {

--- a/backend/core/src/email/email.service.ts
+++ b/backend/core/src/email/email.service.ts
@@ -32,12 +32,12 @@ export class EmailService {
       phrases: {},
     })
     const polyglot = this.polyglot
-    Handlebars.registerHelper(
-      "t",
-      function (phrase: string, options?: number | Polyglot.InterpolationOptions) {
-        return polyglot.t(phrase, options)
-      }
-    )
+    Handlebars.registerHelper("t", function (
+      phrase: string,
+      options?: number | Polyglot.InterpolationOptions
+    ) {
+      return polyglot.t(phrase, options)
+    })
     const parts = this.partials()
     Handlebars.registerPartial(parts)
   }

--- a/backend/core/src/migration/1646281685647-updateReviewOrderTranslations.ts
+++ b/backend/core/src/migration/1646281685647-updateReviewOrderTranslations.ts
@@ -1,0 +1,76 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import { Language } from "../shared/types/language-enum"
+
+export class updateReviewOrderTranslations1646281685647 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    let sanJoseJurisdiction = await queryRunner.query(
+      `SELECT id FROM jurisdictions WHERE name = 'San Jose' LIMIT 1`
+    )
+
+    if (sanJoseJurisdiction.length === 0) return
+
+    sanJoseJurisdiction = sanJoseJurisdiction[0].id
+
+    let generalTranslation = await queryRunner.query(
+      `SELECT translations FROM translations WHERE jurisdiction_id IS NULL AND language = ($1)`,
+      [Language.en]
+    )
+
+    generalTranslation = generalTranslation["0"]["translations"]
+    generalTranslation.confirmation.whatToExpect.lottery =
+      generalTranslation.confirmation.whatToExpect.noLottery
+    delete generalTranslation.confirmation.whatToExpect.noLottery
+
+    await queryRunner.query(
+      `UPDATE "translations" SET translations = ($1) where jurisdiction_id IS NULL and language = ($2)`,
+      [generalTranslation, Language.en]
+    )
+
+    let sanJoseSpanishTranslation = await queryRunner.query(
+      `SELECT translations FROM translations WHERE jurisdiction_id = ($1) AND language = ($2)`,
+      [sanJoseJurisdiction, Language.es]
+    )
+
+    sanJoseSpanishTranslation = sanJoseSpanishTranslation["0"]["translations"]
+    sanJoseSpanishTranslation.confirmation.whatToExpect.lottery =
+      sanJoseSpanishTranslation.confirmation.whatToExpect.noLottery
+    delete sanJoseSpanishTranslation.confirmation.whatToExpect.noLottery
+
+    await queryRunner.query(
+      `UPDATE "translations" SET translations = ($1) where jurisdiction_id = ($2) AND language = ($3)`,
+      [sanJoseSpanishTranslation, sanJoseJurisdiction, Language.es]
+    )
+
+    let sanJoseChineseTranslation = await queryRunner.query(
+      `SELECT translations FROM translations WHERE jurisdiction_id = ($1) AND language = ($2)`,
+      [sanJoseJurisdiction, Language.zh]
+    )
+
+    sanJoseChineseTranslation = sanJoseChineseTranslation["0"]["translations"]
+    sanJoseChineseTranslation.confirmation.whatToExpect.lottery =
+      sanJoseChineseTranslation.confirmation.whatToExpect.noLottery
+    delete sanJoseChineseTranslation.confirmation.whatToExpect.noLottery
+
+    await queryRunner.query(
+      `UPDATE "translations" SET translations = ($1) where jurisdiction_id = ($2) AND language = ($3)`,
+      [sanJoseChineseTranslation, sanJoseJurisdiction, Language.zh]
+    )
+
+    let sanJoseVietnameseTranslation = await queryRunner.query(
+      `SELECT translations FROM translations WHERE jurisdiction_id = ($1) AND language = ($2)`,
+      [sanJoseJurisdiction, Language.vi]
+    )
+
+    sanJoseVietnameseTranslation = sanJoseVietnameseTranslation["0"]["translations"]
+    sanJoseVietnameseTranslation.confirmation.whatToExpect.lottery =
+      sanJoseVietnameseTranslation.confirmation.whatToExpect.noLottery
+    delete sanJoseVietnameseTranslation.confirmation.whatToExpect.noLottery
+
+    await queryRunner.query(
+      `UPDATE "translations" SET translations = ($1) where jurisdiction_id = ($2) AND language = ($3)`,
+      [sanJoseVietnameseTranslation, sanJoseJurisdiction, Language.vi]
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
## Issue Overview

This PR addresses #2330

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This is a fix—the email confirmation should only have two states, whether a listing is lottery order or FCFS. The previous three states logic was incorrect.

## How Can This Be Tested/Reviewed?

I believe @seanmalbert needs to merge this into dev, like before?

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [x] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
