### PR TITLE
fix: remove shared-helpers dependency from ui-components

### DIFF
--- a/sites/partners/pages/forgot-password.tsx
+++ b/sites/partners/pages/forgot-password.tsx
@@ -39,7 +39,10 @@ const ForgotPassword = () => {
       <FormForgotPassword
         onSubmit={onSubmit}
         control={{ register, errors, handleSubmit }}
-        networkError={{ error: networkError, reset: resetNetworkError }}
+        networkError={{
+          error: { ...networkError, error: !!networkError?.error },
+          reset: resetNetworkError,
+        }}
       />
     </FormsLayout>
   )

--- a/sites/partners/pages/sign-in.tsx
+++ b/sites/partners/pages/sign-in.tsx
@@ -99,7 +99,7 @@ const SignIn = () => {
         )}
         control={{ register, errors, handleSubmit }}
         networkStatus={{
-          content: networkStatusContent,
+          content: { ...networkStatusContent, error: !!networkStatusContent?.error },
           type: networkStatusType,
           reset: () => {
             reset()
@@ -124,7 +124,10 @@ const SignIn = () => {
           resetNetworkError
         )}
         control={{ register, errors, handleSubmit, setValue }}
-        networkError={{ content: networkError, reset: resetNetworkError }}
+        networkError={{
+          content: { ...networkError, error: !!networkError?.error },
+          reset: resetNetworkError,
+        }}
       />
     )
   } else if (renderStep === EnumRenderStep.phoneNumber) {
@@ -141,7 +144,10 @@ const SignIn = () => {
           resetNetworkError
         )}
         control={{ errors, handleSubmit, control }}
-        networkError={{ content: networkError, reset: resetNetworkError }}
+        networkError={{
+          content: { ...networkError, error: !!networkError?.error },
+          reset: resetNetworkError,
+        }}
         phoneNumber={phoneNumber}
       />
     )
@@ -158,7 +164,10 @@ const SignIn = () => {
           resetNetworkError
         )}
         control={{ register, errors, handleSubmit }}
-        networkError={{ content: networkError, reset: resetNetworkError }}
+        networkError={{
+          content: { ...networkError, error: !!networkError?.error },
+          reset: resetNetworkError,
+        }}
         mfaType={mfaType}
         allowPhoneNumberEdit={allowPhoneNumberEdit}
         phoneNumber={phoneNumber}

--- a/sites/public/pages/forgot-password.tsx
+++ b/sites/public/pages/forgot-password.tsx
@@ -48,7 +48,10 @@ const ForgotPassword = () => {
       <FormForgotPassword
         onSubmit={onSubmit}
         control={{ register, errors, handleSubmit }}
-        networkError={{ error: networkError, reset: resetNetworkError }}
+        networkError={{
+          error: { ...networkError, error: !!networkError?.error },
+          reset: resetNetworkError,
+        }}
       />
     </FormsLayout>
   )

--- a/sites/public/pages/sign-in.tsx
+++ b/sites/public/pages/sign-in.tsx
@@ -42,7 +42,10 @@ const SignIn = () => {
       <FormSignIn
         onSubmit={onSubmit}
         control={{ register, errors, handleSubmit }}
-        networkStatus={{ content: networkError, reset: resetNetworkError }}
+        networkStatus={{
+          content: { ...networkError, error: !!networkError?.error },
+          reset: resetNetworkError,
+        }}
         showRegisterBtn={true}
       />
     </FormsLayout>

--- a/ui-components/src/page_components/forgot-password/FormForgotPassword.tsx
+++ b/ui-components/src/page_components/forgot-password/FormForgotPassword.tsx
@@ -13,7 +13,7 @@ import {
   ErrorMessage,
   emailRegex,
 } from "@bloom-housing/ui-components"
-import { NetworkErrorReset, NetworkStatusContent } from "@bloom-housing/shared-helpers"
+import { NetworkErrorReset, NetworkStatusContent } from "../sign-in/FormSignIn"
 import { NavigationContext } from "../../config/NavigationContext"
 import type { UseFormMethods } from "react-hook-form"
 

--- a/ui-components/src/page_components/sign-in/FormSignIn.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignIn.tsx
@@ -12,9 +12,25 @@ import {
 } from "@bloom-housing/ui-components"
 import type { UseFormMethods } from "react-hook-form"
 import { NavigationContext } from "../../config/NavigationContext"
-import { NetworkStatus } from "@bloom-housing/shared-helpers"
+import { AlertTypes } from "../../notifications/alertTypes"
 
 export type NetworkErrorDetermineError = (status: number, error: Error) => void
+
+export type NetworkStatusType = AlertTypes
+
+export type NetworkErrorReset = () => void
+
+export type NetworkStatusContent = {
+  title: string
+  description: string
+  error?: boolean
+} | null
+
+export type NetworkStatus = {
+  content: NetworkStatusContent
+  type?: NetworkStatusType
+  reset: NetworkErrorReset
+}
 
 export type FormSignInProps = {
   control: FormSignInControl

--- a/ui-components/src/page_components/sign-in/FormSignInAddPhone.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignInAddPhone.tsx
@@ -11,7 +11,7 @@ import {
   FormSignInErrorBox,
 } from "@bloom-housing/ui-components"
 import type { UseFormMethods } from "react-hook-form"
-import { NetworkStatus } from "@bloom-housing/shared-helpers"
+import { NetworkStatus } from "./FormSignIn"
 
 export type FormSignInAddPhoneProps = {
   control: FormSignInAddPhoneControl

--- a/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { t, AlertBox, SiteAlert, AlertNotice, ErrorMessage } from "@bloom-housing/ui-components"
 import type { UseFormMethods } from "react-hook-form"
-import { NetworkStatus } from "@bloom-housing/shared-helpers"
+import { NetworkStatus } from "./FormSignIn"
 
 export type FormSignInErrorBoxProps = {
   errors: FormSignInErrorBoxControl["errors"]

--- a/ui-components/src/page_components/sign-in/FormSignInMFACode.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignInMFACode.tsx
@@ -10,8 +10,7 @@ import {
   SiteAlert,
   FormSignInErrorBox,
 } from "@bloom-housing/ui-components"
-import { NetworkStatus } from "@bloom-housing/shared-helpers"
-import { FormSignInControl } from "./FormSignIn"
+import { NetworkStatus, FormSignInControl } from "./FormSignIn"
 import { EnumRequestMfaCodeMfaType } from "@bloom-housing/backend-core/types"
 
 export type FormSignInMFACodeProps = {

--- a/ui-components/src/page_components/sign-in/FormSignInMFAType.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignInMFAType.tsx
@@ -11,7 +11,7 @@ import {
   FormSignInErrorBox,
 } from "@bloom-housing/ui-components"
 import type { UseFormMethods } from "react-hook-form"
-import { NetworkStatus } from "@bloom-housing/shared-helpers"
+import { NetworkStatus } from "./FormSignIn"
 import { EnumRequestMfaCodeMfaType } from "@bloom-housing/backend-core/types"
 
 export type FormSignInMFAProps = {


### PR DESCRIPTION
Removes shared-helper and axios dependencies from ui-components

(1) We don’t want shared-helpers to be used in ui-components at all because we need shared-helpers to have our backend as a dependency and we don’t want the backend in the component library, and (2) if we were going to add shared-helpers to the component library it would also need to be added explicitly to the ui-component package json, and since it isn’t, that is what right now is breaking consumers with errors “could not resolve shared-helpers”. The long term fix is to refactor those components to use much more generic props that don’t relate to network status, and to get our build CI job up and running.