### PR TITLE
Add optional prop for Language Nav aria label

### DIFF
--- a/ui-components/__tests__/headers/SiteHeader.test.tsx
+++ b/ui-components/__tests__/headers/SiteHeader.test.tsx
@@ -1,14 +1,15 @@
 import React from "react"
-import { render, cleanup } from "@testing-library/react"
+import { render, cleanup, getByLabelText } from "@testing-library/react"
 import { SiteHeader } from "../../src/headers/SiteHeader"
 
 afterEach(cleanup)
 
 describe("<SiteHeader>", () => {
   it("renders default state", () => {
-    const { getByText, queryByText } = render(
+    const { getByLabelText, getByText, queryByText } = render(
       <SiteHeader
         homeURL={"/"}
+        languageNavLabel='Choose a language'
         languages={[
           { label: "English", onClick: () => console.log("Clicked English"), active: true },
           { label: "Español", onClick: () => console.log("Clicked Español"), active: false },
@@ -62,5 +63,6 @@ describe("<SiteHeader>", () => {
     expect(getByText("English")).toBeTruthy()
     expect(getByText("中文")).toBeTruthy()
     expect(getByText("Español")).toBeTruthy()
+    expect(getByLabelText("Choose a language")).toBeTruthy()
   })
 })

--- a/ui-components/__tests__/headers/SiteHeader.test.tsx
+++ b/ui-components/__tests__/headers/SiteHeader.test.tsx
@@ -9,7 +9,7 @@ describe("<SiteHeader>", () => {
     const { getByLabelText, getByText, queryByText } = render(
       <SiteHeader
         homeURL={"/"}
-        languageNavLabel='Choose a language'
+        languageNavLabel="Choose a language"
         languages={[
           { label: "English", onClick: () => console.log("Clicked English"), active: true },
           { label: "Español", onClick: () => console.log("Clicked Español"), active: false },

--- a/ui-components/src/headers/SiteHeader.stories.tsx
+++ b/ui-components/src/headers/SiteHeader.stories.tsx
@@ -25,6 +25,7 @@ export const withLanguage = () => (
       { label: "Español", onClick: () => console.log("Clicked Español"), active: false },
       { label: "中文", onClick: () => console.log("Clicked 中文"), active: false },
     ]}
+    languageNavLabel='Choose a Language'
     logoSrc="/images/logo_glyph.svg"
     title="Alameda County Housing Portal"
     menuLinks={[]}

--- a/ui-components/src/headers/SiteHeader.stories.tsx
+++ b/ui-components/src/headers/SiteHeader.stories.tsx
@@ -25,7 +25,7 @@ export const withLanguage = () => (
       { label: "Español", onClick: () => console.log("Clicked Español"), active: false },
       { label: "中文", onClick: () => console.log("Clicked 中文"), active: false },
     ]}
-    languageNavLabel='Choose a Language'
+    languageNavLabel="Choose a Language"
     logoSrc="/images/logo_glyph.svg"
     title="Alameda County Housing Portal"
     menuLinks={[]}

--- a/ui-components/src/headers/SiteHeader.tsx
+++ b/ui-components/src/headers/SiteHeader.tsx
@@ -24,6 +24,7 @@ export interface SiteHeaderProps {
   dropdownItemClassName?: string
   homeURL: string
   imageOnly?: boolean
+  languageNavLabel?: string
   languages?: LangItem[]
   logoClass?: string
   logoSrc: string
@@ -423,7 +424,9 @@ const SiteHeader = (props: SiteHeaderProps) => {
 
   return (
     <header className={"site-header"}>
-      {props.languages && <LanguageNav languages={props.languages} />}
+      {props.languages && (
+        <LanguageNav ariaLabel={props.languageNavLabel} languages={props.languages} />
+      )}
 
       <div className={`navbar-notice ${!props.noticeMobile && `navbar-notice-hide`}`}>
         <div className="navbar-notice__text">{props.notice ?? ""}</div>


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

One more small change to fix accessibility issue on home page Language Nav component. Adding an optional `languageNavLabel` prop to the SiteHeader component which will include an `aria-label` attribute on the LanguageNav component

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
Related to https://github.com/bloom-housing/bloom/pull/2624 We need the ability to pass the aria label to the Language Nav component which is called by the Site Header component.

## How Can This Be Tested/Reviewed?
Inspect the Site Header with Language story in storybook. You should now see an aria-label
`<nav aria-label="Choose a Language" class="language-nav">`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
