### PR TITLE
fix: authservice.token data null issue

### DIFF
--- a/backend/core/src/auth/controllers/auth.controller.ts
+++ b/backend/core/src/auth/controllers/auth.controller.ts
@@ -21,6 +21,7 @@ import { UserService } from "../services/user.service"
 import { GetMfaInfoDto } from "../dto/get-mfa-info.dto"
 import { GetMfaInfoResponseDto } from "../dto/get-mfa-info-response.dto"
 import { UserErrorExtraModel } from "../user-errors"
+import { TokenDto } from "../dto/token.dto"
 
 @Controller("auth")
 @ApiTags("auth")
@@ -43,6 +44,7 @@ export class AuthController {
 
   @UseGuards(DefaultAuthGuard)
   @Post("token")
+  @ApiBody({ type: TokenDto })
   @ApiOperation({ summary: "Token", operationId: "token" })
   token(@Request() req): LoginResponseDto {
     const accessToken = this.authService.generateAccessToken(req.user)

--- a/backend/core/src/auth/dto/token.dto.ts
+++ b/backend/core/src/auth/dto/token.dto.ts
@@ -1,0 +1,1 @@
+export class TokenDto {}

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -702,13 +702,19 @@ export class AuthService {
   /**
    * Token
    */
-  token(options: IRequestOptions = {}): Promise<LoginResponse> {
+  token(
+    params: {
+      /** requestBody */
+      body?: Token
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<LoginResponse> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/auth/token"
 
       const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
 
-      let data = null
+      let data = params.body
 
       configs.data = data
       axios(configs, resolve, reject)
@@ -3946,6 +3952,8 @@ export interface LoginResponse {
   /**  */
   accessToken: string
 }
+
+export interface Token {}
 
 export interface RequestMfaCode {
   /**  */


### PR DESCRIPTION
## Description

This fixes an issue with the client using the Authservice.token method to refresh the token. The generated token client was passing null in for data, which is not valid JSON. This addresses that by specifying an ApiBody with an empty object, so that the generated client passes an empty object instead of null.

## How Can This Be Tested/Reviewed?

The easiest way to test this locally is to modify the `expiresIn` value on line 35 of `backend/core/src/auth/auth.module.ts` so you don't have to wait the ten minutes. Sign in to the partners portal, watch the network tab and see the calls to /auth/token be successful.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
