### PR TITLE
2681/listing application back button

### DIFF
--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -50,6 +50,8 @@ const ApplicationAddress = () => {
   const { conductor, application, listing } = useFormConductor("primaryApplicantAddress")
   const currentPageSection = 1
 
+  console.log(conductor)
+
   /* Form Handler */
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { control, register, handleSubmit, setValue, watch, errors } = useForm<Record<string, any>>(
@@ -142,10 +144,11 @@ const ApplicationAddress = () => {
       </FormCard>
       <FormCard>
         <FormBackLink
-          url={conductor.determinePreviousUrl()}
-          onClick={() => conductor.setNavigatedBack(true)}
+          url={verifyAddress ? "#" : conductor.determinePreviousUrl()}
+          onClick={
+            verifyAddress ? () => setVerifyAddress(false) : () => conductor.setNavigatedBack(true)
+          }
         />
-
         <div className="form-card__lead border-b">
           <h2 className="form-card__title is-borderless">
             {verifyAddress

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -141,14 +141,15 @@ const ApplicationAddress = () => {
         />
       </FormCard>
       <FormCard>
-        {verifyAddress ? (
+        {/* Remove back link entirely and see if error persists */}
+        {/* {verifyAddress ? (
           <FormBackLink url={conductor.currentStep.url} onClick={() => setVerifyAddress(false)} />
         ) : (
           <FormBackLink
             url={conductor.determinePreviousUrl()}
             onClick={() => conductor.setNavigatedBack(true)}
           />
-        )}
+        )} */}
         <div className="form-card__lead border-b">
           <h2 className="form-card__title is-borderless">
             {verifyAddress

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -141,12 +141,14 @@ const ApplicationAddress = () => {
         />
       </FormCard>
       <FormCard>
-        <FormBackLink
-          url={verifyAddress ? conductor.currentStep.url : conductor.determinePreviousUrl()}
-          onClick={
-            verifyAddress ? () => setVerifyAddress(false) : () => conductor.setNavigatedBack(true)
-          }
-        />
+        {verifyAddress ? (
+          <FormBackLink url={conductor.currentStep.url} onClick={() => setVerifyAddress(false)} />
+        ) : (
+          <FormBackLink
+            url={conductor.determinePreviousUrl()}
+            onClick={() => conductor.setNavigatedBack(true)}
+          />
+        )}
         <div className="form-card__lead border-b">
           <h2 className="form-card__title is-borderless">
             {verifyAddress

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -130,8 +130,6 @@ const ApplicationAddress = () => {
     })
   }, [profile])
 
-  // console.log(window.location.pathname === conductor.currentStep.url)
-
   return (
     <FormsLayout>
       <FormCard header={listing?.name}>
@@ -143,20 +141,12 @@ const ApplicationAddress = () => {
         />
       </FormCard>
       <FormCard>
-        {verifyAddress ? (
-          <FormBackLink
-            url={window.location.pathname}
-            onClick={() => {
-              setVerifyAddress(false)
-              conductor.setNavigatedBack(false)
-            }}
-          />
-        ) : (
-          <FormBackLink
-            url={conductor.determinePreviousUrl()}
-            onClick={() => conductor.setNavigatedBack(true)}
-          />
-        )}
+        <FormBackLink
+          url={verifyAddress ? window.location.pathname : conductor.determinePreviousUrl()}
+          onClick={
+            verifyAddress ? () => setVerifyAddress(false) : () => conductor.setNavigatedBack(true)
+          }
+        />
         <div className="form-card__lead border-b">
           <h2 className="form-card__title is-borderless">
             {verifyAddress

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -18,7 +18,7 @@ import {
   AuthContext,
 } from "@bloom-housing/ui-components"
 import FormsLayout from "../../../layouts/forms"
-import { useContext, useEffect, useState } from "react"
+import { useContext, useEffect, useState, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { Select } from "@bloom-housing/ui-components/src/forms/Select"
 import { PhoneField } from "@bloom-housing/ui-components/src/forms/PhoneField"
@@ -130,6 +130,11 @@ const ApplicationAddress = () => {
     })
   }, [profile])
 
+  const backUrl = useMemo(() => {
+    console.log("backUrl changed")
+    return verifyAddress ? window.location.pathname : conductor.determinePreviousUrl()
+  }, [verifyAddress])
+
   return (
     <FormsLayout>
       <FormCard header={listing?.name}>
@@ -142,7 +147,7 @@ const ApplicationAddress = () => {
       </FormCard>
       <FormCard>
         <FormBackLink
-          url={verifyAddress ? window.location.pathname : conductor.determinePreviousUrl()}
+          url={backUrl}
           onClick={
             verifyAddress ? () => setVerifyAddress(false) : () => conductor.setNavigatedBack(true)
           }

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -130,6 +130,8 @@ const ApplicationAddress = () => {
     })
   }, [profile])
 
+  // console.log(window.location.pathname === conductor.currentStep.url)
+
   return (
     <FormsLayout>
       <FormCard header={listing?.name}>
@@ -143,8 +145,11 @@ const ApplicationAddress = () => {
       <FormCard>
         {verifyAddress ? (
           <FormBackLink
-            url={"/applications/contact/address"}
-            onClick={() => setVerifyAddress(false)}
+            url={conductor.currentStep.url}
+            onClick={() => {
+              setVerifyAddress(false)
+              conductor.setNavigatedBack(false)
+            }}
           />
         ) : (
           <FormBackLink

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -18,7 +18,7 @@ import {
   AuthContext,
 } from "@bloom-housing/ui-components"
 import FormsLayout from "../../../layouts/forms"
-import { useContext, useEffect, useState, useMemo } from "react"
+import { useContext, useEffect, useState, useMemo, useCallback } from "react"
 import { useForm } from "react-hook-form"
 import { Select } from "@bloom-housing/ui-components/src/forms/Select"
 import { PhoneField } from "@bloom-housing/ui-components/src/forms/PhoneField"
@@ -131,8 +131,11 @@ const ApplicationAddress = () => {
   }, [profile])
 
   const backUrl = useMemo(() => {
-    console.log("backUrl changed")
     return verifyAddress ? window.location.pathname : conductor.determinePreviousUrl()
+  }, [verifyAddress])
+
+  const backFunction = useCallback(() => {
+    return verifyAddress ? setVerifyAddress(false) : conductor.setNavigatedBack(true)
   }, [verifyAddress])
 
   return (
@@ -146,12 +149,7 @@ const ApplicationAddress = () => {
         />
       </FormCard>
       <FormCard>
-        <FormBackLink
-          url={backUrl}
-          onClick={
-            verifyAddress ? () => setVerifyAddress(false) : () => conductor.setNavigatedBack(true)
-          }
-        />
+        <FormBackLink url={backUrl} onClick={backFunction} />
         <div className="form-card__lead border-b">
           <h2 className="form-card__title is-borderless">
             {verifyAddress

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -50,8 +50,6 @@ const ApplicationAddress = () => {
   const { conductor, application, listing } = useFormConductor("primaryApplicantAddress")
   const currentPageSection = 1
 
-  console.log(conductor)
-
   /* Form Handler */
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { control, register, handleSubmit, setValue, watch, errors } = useForm<Record<string, any>>(
@@ -144,7 +142,7 @@ const ApplicationAddress = () => {
       </FormCard>
       <FormCard>
         <FormBackLink
-          url={verifyAddress ? "#" : conductor.determinePreviousUrl()}
+          url={verifyAddress ? conductor.currentStep.url : conductor.determinePreviousUrl()}
           onClick={
             verifyAddress ? () => setVerifyAddress(false) : () => conductor.setNavigatedBack(true)
           }

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -141,9 +141,11 @@ const ApplicationAddress = () => {
         />
       </FormCard>
       <FormCard>
-        {/* Use # instead of current url and see if problem persists */}
         {verifyAddress ? (
-          <FormBackLink url="#" onClick={() => setVerifyAddress(false)} />
+          <FormBackLink
+            url={"/applications/contact/address"}
+            onClick={() => setVerifyAddress(false)}
+          />
         ) : (
           <FormBackLink
             url={conductor.determinePreviousUrl()}

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -141,15 +141,15 @@ const ApplicationAddress = () => {
         />
       </FormCard>
       <FormCard>
-        {/* Remove back link entirely and see if error persists */}
-        {/* {verifyAddress ? (
-          <FormBackLink url={conductor.currentStep.url} onClick={() => setVerifyAddress(false)} />
+        {/* Use # instead of current url and see if problem persists */}
+        {verifyAddress ? (
+          <FormBackLink url="#" onClick={() => setVerifyAddress(false)} />
         ) : (
           <FormBackLink
             url={conductor.determinePreviousUrl()}
             onClick={() => conductor.setNavigatedBack(true)}
           />
-        )} */}
+        )}
         <div className="form-card__lead border-b">
           <h2 className="form-card__title is-borderless">
             {verifyAddress

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -145,7 +145,7 @@ const ApplicationAddress = () => {
       <FormCard>
         {verifyAddress ? (
           <FormBackLink
-            url={conductor.currentStep.url}
+            url={window.location.pathname}
             onClick={() => {
               setVerifyAddress(false)
               conductor.setNavigatedBack(false)


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2681

- [X] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This fixes the back button on the /contact/address page of the application listing. Because both the address form and the verify address form share a url, the back button for both views takes you back to the previous url: /contact/name. This fixes the button so that if you are on the verify form page, the back button takes you back to the address form page, but if you are on the address form page, the back button takes you to the previous url. 

## How Can This Be Tested/Reviewed?

1. Click any listing in public and apply online
2. Once you reach the /applications/contact/address page, fill out the form and click next
3. Once on the verify address page, click back
4. You will be taken back to the correct view - the one you just came from. All of your info will still be populated
5. Click back again and you will be on the /applications/contact/name page 

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

Entry Point: http://localhost:3000/applications/contact/address
- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
