### PR TITLE
feat(proxy): add nginx config for jurisdictions

### DIFF
--- a/backend/proxy/Dockerfile
+++ b/backend/proxy/Dockerfile
@@ -32,6 +32,7 @@ RUN NGINX_VERSION=`nginx -V 2>&1 | grep "nginx version" | awk -F/ '{ print $2}'`
 
 ## move copy to here so the above can build from cache
 COPY ./default.conf /etc/nginx/conf.d/default.conf.template
+COPY ./shared-location.conf /etc/nginx/conf.d/shared-location.conf.template
 COPY ./proxy.conf /etc/nginx/conf.d/proxy.conf
 
 # configure and build
@@ -39,6 +40,8 @@ RUN cd /tmp/nginx && \
     BASE_CONFIGURE_ARGS=`nginx -V 2>&1 | grep "configure arguments" | cut -d " " -f 3-` && \
     /bin/sh -c "./configure ${BASE_CONFIGURE_ARGS} --add-module=/tmp/ngx_cache_purge" && \
     make && make install && \
-    rm -rf /tmp/nginx*
+    rm -rf /tmp/nginx* \
 
-CMD /bin/bash -c "envsubst '\$PORT,\$BACKEND_HOSTNAME' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf" && nginx -g 'daemon off;'
+ENV PROTOCOL=https
+
+CMD /bin/bash -c "envsubst '\$PORT,\$BACKEND_HOSTNAME,\$PROTOCOL' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf && envsubst '\$PORT,\$BACKEND_HOSTNAME,\$PROTOCOL' < /etc/nginx/conf.d/shared-location.conf.template > /etc/nginx/shared-location.conf" && nginx -g 'daemon off;'

--- a/backend/proxy/default.conf
+++ b/backend/proxy/default.conf
@@ -56,6 +56,63 @@ server {
     proxy_pass https://$BACKEND_HOSTNAME;
   }
 
+  location /jurisdictions {
+    proxy_cache_min_uses 1;
+    proxy_cache_revalidate on;
+    proxy_cache_background_update on;
+    proxy_cache_lock on;
+    proxy_ssl_server_name on;
+    proxy_cache webapp_cache;
+    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+    proxy_cache_key $uri$is_args$args$http_language;
+    if ($request_method = 'PURGE') {
+      # TODO: make vairable that's passed in for allow origin purge
+      add_header Access-Control-Allow-Origin *;
+    }
+    add_header X-Cache-Status $upstream_cache_status;
+    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
+    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
+    proxy_pass https://$BACKEND_HOSTNAME;
+  }
+
+  location ~* "\/jurisdictions\/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}" {
+    proxy_cache_min_uses 1;
+    proxy_cache_revalidate on;
+    proxy_cache_background_update on;
+    proxy_cache_lock on;
+    proxy_ssl_server_name on;
+    proxy_cache webapp_cache;
+    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+    proxy_cache_key $uri$is_args$args$http_language;
+    if ($request_method = 'PURGE') {
+      # TODO: make vairable that's passed in for allow origin purge
+      add_header Access-Control-Allow-Origin *;
+    }
+    add_header X-Cache-Status $upstream_cache_status;
+    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
+    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
+    proxy_pass https://$BACKEND_HOSTNAME;
+  }
+
+  location ~* "\/jurisdictions\/byName/.*" {
+    proxy_cache_min_uses 1;
+    proxy_cache_revalidate on;
+    proxy_cache_background_update on;
+    proxy_cache_lock on;
+    proxy_ssl_server_name on;
+    proxy_cache webapp_cache;
+    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+    proxy_cache_key $uri$is_args$args$http_language;
+    if ($request_method = 'PURGE') {
+      # TODO: make vairable that's passed in for allow origin purge
+      add_header Access-Control-Allow-Origin *;
+    }
+    add_header X-Cache-Status $upstream_cache_status;
+    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
+    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
+    proxy_pass https://$BACKEND_HOSTNAME;
+  }
+
   location / {
     proxy_pass https://$BACKEND_HOSTNAME;
   }

--- a/backend/proxy/default.conf
+++ b/backend/proxy/default.conf
@@ -19,101 +19,26 @@ server {
   proxy_cache_valid 500 0s;
 
   location ~* "\/listings\/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}" {
-    proxy_cache_min_uses 1;
-    proxy_cache_revalidate on;
-    proxy_cache_background_update on;
-    proxy_cache_lock on;
-    proxy_ssl_server_name on;
-    proxy_cache webapp_cache;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-    proxy_cache_key $uri$is_args$args$http_language;
-    if ($request_method = 'PURGE') {
-      # TODO: make vairable that's passed in for allow origin purge
-      add_header Access-Control-Allow-Origin *;
-    }
-    add_header X-Cache-Status $upstream_cache_status;
-    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
-    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
-    proxy_pass https://$BACKEND_HOSTNAME;
+    include shared-location.conf;
   }
 
   location /listings {
-    proxy_cache_min_uses 1;
-    proxy_cache_revalidate on;
-    proxy_cache_background_update on;
-    proxy_cache_lock on;
-    proxy_ssl_server_name on;
-    proxy_cache webapp_cache;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-    proxy_cache_key $uri$is_args$args$http_language;
-    if ($request_method = 'PURGE') {
-      # TODO: make vairable that's passed in for allow origin purge
-      add_header Access-Control-Allow-Origin *;
-    }
-    add_header X-Cache-Status $upstream_cache_status;
-    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
-    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
-    proxy_pass https://$BACKEND_HOSTNAME;
+    include shared-location.conf;
   }
 
   location /jurisdictions {
-    proxy_cache_min_uses 1;
-    proxy_cache_revalidate on;
-    proxy_cache_background_update on;
-    proxy_cache_lock on;
-    proxy_ssl_server_name on;
-    proxy_cache webapp_cache;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-    proxy_cache_key $uri$is_args$args$http_language;
-    if ($request_method = 'PURGE') {
-      # TODO: make vairable that's passed in for allow origin purge
-      add_header Access-Control-Allow-Origin *;
-    }
-    add_header X-Cache-Status $upstream_cache_status;
-    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
-    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
-    proxy_pass https://$BACKEND_HOSTNAME;
+    include shared-location.conf;
   }
 
   location ~* "\/jurisdictions\/[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}" {
-    proxy_cache_min_uses 1;
-    proxy_cache_revalidate on;
-    proxy_cache_background_update on;
-    proxy_cache_lock on;
-    proxy_ssl_server_name on;
-    proxy_cache webapp_cache;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-    proxy_cache_key $uri$is_args$args$http_language;
-    if ($request_method = 'PURGE') {
-      # TODO: make vairable that's passed in for allow origin purge
-      add_header Access-Control-Allow-Origin *;
-    }
-    add_header X-Cache-Status $upstream_cache_status;
-    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
-    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
-    proxy_pass https://$BACKEND_HOSTNAME;
+    include shared-location.conf;
   }
 
   location ~* "\/jurisdictions\/byName/.*" {
-    proxy_cache_min_uses 1;
-    proxy_cache_revalidate on;
-    proxy_cache_background_update on;
-    proxy_cache_lock on;
-    proxy_ssl_server_name on;
-    proxy_cache webapp_cache;
-    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
-    proxy_cache_key $uri$is_args$args$http_language;
-    if ($request_method = 'PURGE') {
-      # TODO: make vairable that's passed in for allow origin purge
-      add_header Access-Control-Allow-Origin *;
-    }
-    add_header X-Cache-Status $upstream_cache_status;
-    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
-    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
-    proxy_pass https://$BACKEND_HOSTNAME;
+    include shared-location.conf;
   }
 
   location / {
-    proxy_pass https://$BACKEND_HOSTNAME;
+    proxy_pass $PROTOCOL://$BACKEND_HOSTNAME;
   }
 }

--- a/backend/proxy/shared-location.conf
+++ b/backend/proxy/shared-location.conf
@@ -1,0 +1,16 @@
+    proxy_cache_min_uses 1;
+    proxy_cache_revalidate on;
+    proxy_cache_background_update on;
+    proxy_cache_lock on;
+    proxy_ssl_server_name on;
+    proxy_cache webapp_cache;
+    proxy_cache_use_stale error timeout http_500 http_502 http_503 http_504;
+    proxy_cache_key $uri$is_args$args$http_language;
+    if ($request_method = 'PURGE') {
+      # TODO: make vairable that's passed in for allow origin purge
+      add_header Access-Control-Allow-Origin *;
+    }
+    add_header X-Cache-Status $upstream_cache_status;
+    add_header Access-Control-Allow-Headers 'Content-Type, X-Language, X-JurisdictionName, Authorization';
+    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE, PURGE';
+    proxy_pass $PROTOCOL://$BACKEND_HOSTNAME;


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2710

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This change adds nginx proxy caching configuration for GET `/jurisdictions/*` endpoints. 

## How Can This Be Tested/Reviewed?

Set up local nginx + backend:

1. Start backend with `yarn dev` on 3100 port (default)
2. in `backend/proxy/default.conf` change https to http in every `proxy_pass` config 
3. Go to backend/proxy directory and build nginx image with `docker build . -t bloom_nginx`
4. Start nginx proxy with `docker run -it --expose 80 -p 9000:80 -e PORT='80' -e BACKEND_HOSTNAME='[my ip]:3100' bloom:latest` where [my ip] can be retrieved from `ipconfig getifaddr en0` on MacOS.
5. Fetch GET /jurisdictions with `curl http://localhost:9000/jurisdictions` and observe first request in backend log, then fetch for the second time and you should not see any new logs as nginx should serve next response
6. Purge cache with `curl -XPURGE localhost:9000/jurisdictions` and fetch  jurisdictions again `curl http://localhost:9000/jurisdictions` - now you should see backend log the request again.                                                                                                        

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
