### PR TITLE
feat(preferenceslist): move ordinal at mobile bp; update text color f…

### DIFF
--- a/ui-components/src/lists/PreferencesList.scss
+++ b/ui-components/src/lists/PreferencesList.scss
@@ -7,10 +7,10 @@
       @apply ml-2;
     }
 
-     @media (max-width: $screen-sm){
+    @media (max-width: $screen-sm) {
       margin-left: 0px;
-      margin-top:var(--bloom-s3);
-     }
+      margin-top: var(--bloom-s3);
+    }
   }
 }
 
@@ -45,9 +45,9 @@
     margin-left: -2.65rem;
   }
 
-   @media (max-width: $screen-sm){
+  @media (max-width: $screen-sm) {
     margin-left: 0px;
-    float:none ;
+    float: none;
   }
 
   sup {
@@ -64,10 +64,9 @@
   @screen md {
     @apply ml-2;
   }
- @media (max-width: $screen-sm){
-      margin-left: 0px;
+  @media (max-width: $screen-sm) {
+    margin-left: 0px;
   }
-
 }
 
 .preferences-list__description {

--- a/ui-components/src/lists/PreferencesList.scss
+++ b/ui-components/src/lists/PreferencesList.scss
@@ -6,6 +6,11 @@
     @screen md {
       @apply ml-2;
     }
+
+     @media (max-width: $screen-sm){
+      margin-left: 0px;
+      margin-top:var(--bloom-s3);
+     }
   }
 }
 
@@ -40,6 +45,11 @@
     margin-left: -2.65rem;
   }
 
+   @media (max-width: $screen-sm){
+    margin-left: 0px;
+    float:none ;
+  }
+
   sup {
     @apply font-normal;
     top: -0.35em;
@@ -47,17 +57,21 @@
 }
 
 .preferences-list__subtitle {
-  @apply text-gray-700;
+  @apply text-gray-750;
   @apply text-tiny;
   @apply ml-4;
 
   @screen md {
     @apply ml-2;
   }
+ @media (max-width: $screen-sm){
+      margin-left: 0px;
+  }
+
 }
 
 .preferences-list__description {
-  @apply text-gray-700;
+  @apply text-gray-750;
   @apply text-sm;
   @apply mt-3;
 }

--- a/ui-components/src/lists/PreferencesList.scss
+++ b/ui-components/src/lists/PreferencesList.scss
@@ -1,11 +1,6 @@
 .preferences-list__item {
   .info-card__title {
     @apply mb-0;
-    @apply ml-4;
-
-    @screen md {
-      @apply ml-2;
-    }
 
     @media (max-width: $screen-sm) {
       margin-left: 0px;
@@ -42,7 +37,7 @@
   width: 2.5rem;
 
   @screen md {
-    margin-left: -2.65rem;
+    margin-left: -3rem;
   }
 
   @media (max-width: $screen-sm) {
@@ -59,11 +54,7 @@
 .preferences-list__subtitle {
   @apply text-gray-750;
   @apply text-tiny;
-  @apply ml-4;
 
-  @screen md {
-    @apply ml-2;
-  }
   @media (max-width: $screen-sm) {
     margin-left: 0px;
   }

--- a/ui-components/src/lists/PreferencesList.stories.tsx
+++ b/ui-components/src/lists/PreferencesList.stories.tsx
@@ -11,7 +11,6 @@ const listingPreferences = [
     ordinal: 1,
     links: [],
     title: "Title 1",
-    subtitle: "Subtitle 1",
     description: "Description 1",
   },
   {


### PR DESCRIPTION
…or contrast


# Pull Request Template

## Issue Overview

This PR addresses Issue #2827

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

To meet accessibility standards of contrast and allow for more room in preference list item on mobile views:

- increase contrast in description text  #767676 -> #555555
- increase contrast in subtitle  #767676 -> #555555
- move ordinal above the rest of the content in mobile view

## How Can This Be Tested/Reviewed?

- In storybook, verify that the subtitle and description text are the value's above and ensure that at < mobile bp (640px), the list item matches the ![new design](https://user-images.githubusercontent.com/5691923/175102587-065b08c1-5c33-4973-87db-f57ca19aa1f5.png)
- Verify that subtitle, description, and title 
are all vertically aligned, and omitting subtitle (see example in storybook) keeps title and description vertically aligned on desktop and mobile. ![image](https://user-images.githubusercontent.com/5691923/175426912-ea5af95e-99a9-4c93-9936-c2d4def8cfd5.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:


Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
