### PR TITLE
fix: fix email from address

### DIFF
--- a/backend/core/src/seeder/seeds/jurisdictions.ts
+++ b/backend/core/src/seeder/seeds/jurisdictions.ts
@@ -10,7 +10,7 @@ export const activeJurisdictions: JurisdictionCreateDto[] = [
     languages: [Language.en],
     programs: [],
     publicUrl: "",
-    emailFromAddress: "Alameda: Housing Bay Area",
+    emailFromAddress: "Alameda: Housing Bay Area <bloom-no-reply@exygy.dev>",
     rentalAssistanceDefault:
       "Housing Choice Vouchers, Section 8 and other valid rental assistance programs will be considered for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.",
     enablePartnerSettings: true,
@@ -23,7 +23,7 @@ export const activeJurisdictions: JurisdictionCreateDto[] = [
     languages: [Language.en],
     programs: [],
     publicUrl: "",
-    emailFromAddress: "SJ: HousingBayArea.org",
+    emailFromAddress: "SJ: HousingBayArea.org <bloom-no-reply@exygy.dev>",
     rentalAssistanceDefault:
       "Housing Choice Vouchers, Section 8 and other valid rental assistance programs will be considered for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.",
     enablePartnerSettings: null,
@@ -36,7 +36,7 @@ export const activeJurisdictions: JurisdictionCreateDto[] = [
     languages: [Language.en],
     programs: [],
     publicUrl: "",
-    emailFromAddress: "SMC: HousingBayArea.org",
+    emailFromAddress: "SMC: HousingBayArea.org <bloom-no-reply@exygy.dev>",
     rentalAssistanceDefault:
       "Housing Choice Vouchers, Section 8 and other valid rental assistance programs will be considered for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.",
     enablePartnerSettings: true,
@@ -49,7 +49,7 @@ export const activeJurisdictions: JurisdictionCreateDto[] = [
     languages: [Language.en],
     programs: [],
     publicUrl: "",
-    emailFromAddress: "Detroit Housing",
+    emailFromAddress: "Detroit Housing <bloom-no-reply@exygy.dev>",
     rentalAssistanceDefault:
       "Housing Choice Vouchers, Section 8 and other valid rental assistance programs will be considered for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.",
     enablePartnerSettings: false,


### PR DESCRIPTION
At the moment on dev you are unable to send emails. This was an existing data issue surfaced by this [commit](https://github.com/bloom-housing/bloom/pull/2843/files#diff-68c2a0379eb7c1ee8cc5467d1333b6f7fe2eca6ee9a12c2b5dfe162180d358a3R69). We slightly changed how jurisdictions are being seeded such that the mock data in that file is now overwriting any jurisdictions we had added in the migrations. The migration files had the correct `emailFromAddress` but this file did not, so I just updated the values.