### PR TITLE
fix: allow jsx in expandable section

### DIFF
--- a/ui-components/src/page_components/listing/listing_sidebar/ExpandableSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/ExpandableSection.tsx
@@ -4,7 +4,7 @@ import { ExpandableContent } from "../../../actions/ExpandableContent"
 
 export interface ExpandableSectionProps {
   content: string | React.ReactNode
-  expandableContent?: string
+  expandableContent?: string | React.ReactNode
   strings: {
     title: string
     readMore?: string
@@ -14,19 +14,27 @@ export interface ExpandableSectionProps {
 
 const ExpandableSection = ({ content, expandableContent, strings }: ExpandableSectionProps) => {
   if (!content) return null
+
+  const getTextContent = (textContent: string | React.ReactNode) => {
+    return (
+      <>
+        {typeof textContent === "string" ? (
+          <Markdown options={{ disableParsingRawHTML: false }}>{textContent}</Markdown>
+        ) : (
+          textContent
+        )}
+      </>
+    )
+  }
   return (
     <section className="aside-block">
       <h4 className="text-caps-underline">{strings.title}</h4>
       <div className="text-tiny text-gray-750">
-        {typeof content === "string" ? (
-          <Markdown options={{ disableParsingRawHTML: false }}>{content}</Markdown>
-        ) : (
-          content
-        )}
+        {getTextContent(content)}
         {expandableContent && (
           <div className={"mt-2"}>
             <ExpandableContent strings={{ readMore: strings.readMore, readLess: strings.readLess }}>
-              <Markdown options={{ disableParsingRawHTML: false }}>{expandableContent}</Markdown>
+              {getTextContent(expandableContent)}
             </ExpandableContent>
           </div>
         )}


### PR DESCRIPTION
No related issue, but a quick fix to unblock SF to allow for custom React styling in the expandable section. There are no breaking changes (see [existing stories](https://deploy-preview-2902--dev-storybook-bloom.netlify.app/?path=/story/listing-sidebar-expandable-section--default)).