### PR TITLE
2887/fix forgot pwd form

### DIFF
--- a/sites/partners/pages/reset-password.tsx
+++ b/sites/partners/pages/reset-password.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react"
+import React, { useState, useContext, useRef } from "react"
 import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
 import {
@@ -24,8 +24,11 @@ const ResetPassword = () => {
   // This is causing a linting issue with unbound-method, see open issue as of 10/21/2020:
   // https://github.com/react-hook-form/react-hook-form/issues/2887
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, errors } = useForm()
+  const { register, handleSubmit, errors, watch } = useForm()
   const [requestError, setRequestError] = useState<string>()
+
+  const passwordValue = useRef({})
+  passwordValue.current = watch("password", "")
 
   const onSubmit = async (data: { password: string; passwordConfirmation: string }) => {
     const { password, passwordConfirmation } = data
@@ -64,20 +67,24 @@ const ResetPassword = () => {
             <Field
               caps={true}
               name="password"
-              label="Password"
+              label={t("authentication.createAccount.password")}
               validation={{ required: true }}
               error={errors.password}
-              errorMessage="Please enter new login password"
+              errorMessage={t("authentication.forgotPassword.enterNewLoginPassword")}
               register={register}
               type="password"
             />
             <Field
               caps={true}
               name="passwordConfirmation"
-              label="Password Confirmation"
-              validation={{ required: true }}
-              error={errors.password}
-              errorMessage="Password confirmation does not match"
+              label={t("authentication.forgotPassword.passwordConfirmation")}
+              validation={{
+                validate: (value) =>
+                  value === passwordValue.current ||
+                  t("authentication.createAccount.errors.passwordMismatch"),
+              }}
+              error={errors.passwordConfirmation}
+              errorMessage={t("authentication.createAccount.errors.passwordMismatch")}
               register={register}
               type="password"
             />

--- a/sites/public/pages/reset-password.tsx
+++ b/sites/public/pages/reset-password.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useContext } from "react"
+import React, { useEffect, useState, useContext, useRef } from "react"
 import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
 import {
@@ -25,8 +25,11 @@ const ResetPassword = () => {
   // This is causing a linting issue with unbound-method, see open issue as of 10/21/2020:
   // https://github.com/react-hook-form/react-hook-form/issues/2887
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, errors } = useForm()
+  const { register, handleSubmit, errors, watch } = useForm()
   const [requestError, setRequestError] = useState<string>()
+
+  const passwordValue = useRef({})
+  passwordValue.current = watch("password", "")
 
   useEffect(() => {
     pushGtmEvent<PageView>({
@@ -72,20 +75,25 @@ const ResetPassword = () => {
             <Field
               caps={true}
               name="password"
-              label="Password"
+              label={t("authentication.createAccount.password")}
               validation={{ required: true }}
               error={errors.password}
-              errorMessage="Please enter new login password"
+              errorMessage={t("authentication.forgotPassword.enterNewLoginPassword")}
               register={register}
               type="password"
             />
+
             <Field
               caps={true}
               name="passwordConfirmation"
-              label="Password Confirmation"
-              validation={{ required: true }}
-              error={errors.password}
-              errorMessage="Password confirmation does not match"
+              label={t("authentication.forgotPassword.passwordConfirmation")}
+              validation={{
+                validate: (value) =>
+                  value === passwordValue.current ||
+                  t("authentication.createAccount.errors.passwordMismatch"),
+              }}
+              error={errors.passwordConfirmation}
+              errorMessage={t("authentication.createAccount.errors.passwordMismatch")}
               register={register}
               type="password"
             />

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -485,6 +485,8 @@
   "authentication.createAccount.resendAnEmailTo": "Resend an email to",
   "authentication.createAccount.resendEmailInfo": "Please click on the link in the email we send you within 24 hours in order to complete account creation.",
   "authentication.createAccount.resendTheEmail": "Resend the email",
+  "authentication.forgotPassword.passwordConfirmation": "Password Confirmation",
+  "authentication.forgotPassword.enterNewLoginPassword": "Please enter new login password",
   "authentication.forgotPassword.changePassword": "Change Password",
   "authentication.forgotPassword.errors.emailNotFound": "Email not found. Please make sure your email has an account with us and is confirmed.",
   "authentication.forgotPassword.errors.tokenExpired": "Reset password token expired. Please request for a new one.",


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2887

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Fixes the `password confirmation` field validation. Now a password and a password confirmation should be the same to send a form.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

1. Open forgot password page `/forgot-password`
2. Provide your email and submit a form
3. Click on the link from your mailbox
4. Provide a new password and different value in the password confirmation field
5. Try to submit the form -> you should see an error
6. Try to provide the same values for both fields
7. Your password should be updated successfully
8. Do the same in a partners portal

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
