### PR TITLE
feat(errormessage): add classname to errormessage; apply styles to Field

### DIFF
--- a/ui-components/src/forms/Field.tsx
+++ b/ui-components/src/forms/Field.tsx
@@ -120,7 +120,11 @@ const Field = (props: FieldProps) => {
       </div>
       {props.subNote && <p className="field-sub-note">{props.subNote}</p>}
       {props.errorMessage && (
-        <ErrorMessage id={`${idOrName}-error`} error={props.error}>
+        <ErrorMessage
+          id={`${idOrName}-error`}
+          error={props.error}
+          className="mt-2 inline-block leading-5"
+        >
           {props.errorMessage}
         </ErrorMessage>
       )}

--- a/ui-components/src/forms/Field.tsx
+++ b/ui-components/src/forms/Field.tsx
@@ -120,11 +120,7 @@ const Field = (props: FieldProps) => {
       </div>
       {props.subNote && <p className="field-sub-note">{props.subNote}</p>}
       {props.errorMessage && (
-        <ErrorMessage
-          id={`${idOrName}-error`}
-          error={props.error}
-          className="mt-2 inline-block leading-5"
-        >
+        <ErrorMessage id={`${idOrName}-error`} error={props.error}>
           {props.errorMessage}
         </ErrorMessage>
       )}

--- a/ui-components/src/forms/HouseholdSizeField.tsx
+++ b/ui-components/src/forms/HouseholdSizeField.tsx
@@ -55,7 +55,7 @@ const HouseholdSizeField = (props: HouseholdSizeFieldProps) => {
           }
         />
       </span>
-      <ErrorMessage id={"householdsize-error"} error={!!error}>
+      <ErrorMessage id={"householdsize-error"} error={!!error} className="block mt-0 line-normal">
         <AlertBox type="alert" inverted onClose={() => clearErrors()}>
           {t("application.household.dontQualifyHeader")}
         </AlertBox>

--- a/ui-components/src/forms/HouseholdSizeField.tsx
+++ b/ui-components/src/forms/HouseholdSizeField.tsx
@@ -55,7 +55,11 @@ const HouseholdSizeField = (props: HouseholdSizeFieldProps) => {
           }
         />
       </span>
-      <ErrorMessage id={"householdsize-error"} error={!!error} className="block mt-0 line-normal">
+      <ErrorMessage
+        id={"householdsize-error"}
+        error={!!error}
+        className="block mt-0 line-normal text-red-700"
+      >
         <AlertBox type="alert" inverted onClose={() => clearErrors()}>
           {t("application.household.dontQualifyHeader")}
         </AlertBox>

--- a/ui-components/src/forms/Textarea.scss
+++ b/ui-components/src/forms/Textarea.scss
@@ -6,6 +6,7 @@
   @apply p-2;
   @apply text-gray-900;
   @apply bg-gray-200;
+  @apply align-top;
   font-size: 1rem;
 }
 
@@ -26,6 +27,8 @@
   @apply text-xs;
   @apply text-alert;
   @apply block;
+  @apply leading-5;
+  @apply mt-2
 }
 
 .textarea-label {

--- a/ui-components/src/forms/Textarea.scss
+++ b/ui-components/src/forms/Textarea.scss
@@ -28,7 +28,7 @@
   @apply text-alert;
   @apply block;
   @apply leading-5;
-  @apply mt-2
+  @apply mt-2;
 }
 
 .textarea-label {

--- a/ui-components/src/global/forms.scss
+++ b/ui-components/src/global/forms.scss
@@ -326,9 +326,12 @@ input[type="number"] {
 }
 
 .error-message {
+  display:inline-block;
   @apply text-sm;
   @apply text-red-700;
   @apply tracking-wide;
+  @apply leading-5;
+  @apply mt-2
 }
 
 .field-sub-note {

--- a/ui-components/src/global/forms.scss
+++ b/ui-components/src/global/forms.scss
@@ -326,12 +326,12 @@ input[type="number"] {
 }
 
 .error-message {
-  display:inline-block;
+  display: inline-block;
   @apply text-sm;
   @apply text-red-700;
   @apply tracking-wide;
   @apply leading-5;
-  @apply mt-2
+  @apply mt-2;
 }
 
 .field-sub-note {

--- a/ui-components/src/notifications/ErrorMessage.tsx
+++ b/ui-components/src/notifications/ErrorMessage.tsx
@@ -1,11 +1,21 @@
 import React from "react"
 
-const ErrorMessage = (props: { id?: string; error?: boolean; children?: React.ReactNode }) => {
+const ErrorMessage = (props: {
+  id?: string
+  error?: boolean
+  children?: React.ReactNode
+  className?: string
+}) => {
   if (props.error) {
+    const classes = ["error-message"]
+    if (props.className) {
+      classes.push(props.className)
+    }
+
     return (
       <span
         id={props.id}
-        className="error-message"
+        className={classes.join(" ")}
         aria-live="assertive"
         data-test-id={"error-message"}
       >

--- a/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
@@ -27,7 +27,7 @@ const FormSignInErrorBox = ({ networkStatus, errors, errorMessageId }: FormSignI
         <ErrorMessage
           id={`form-sign-in-${errorMessageId}-error`}
           error={!!networkStatus.content}
-          className="block mt-0 leading-normal"
+          className="block mt-0 leading-normal text-red-700"
         >
           <AlertBox type={"alert"} inverted onClose={() => networkStatus.reset()}>
             {networkStatus.content.title}

--- a/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
@@ -24,7 +24,11 @@ const FormSignInErrorBox = ({ networkStatus, errors, errorMessageId }: FormSignI
       )}
 
       {networkStatus.content?.error && Object.entries(errors).length === 0 && (
-        <ErrorMessage id={`form-sign-in-${errorMessageId}-error`} error={!!networkStatus.content}>
+        <ErrorMessage
+          id={`form-sign-in-${errorMessageId}-error`}
+          error={!!networkStatus.content}
+          className="block mt-0 leading-normal"
+        >
           <AlertBox type={"alert"} inverted onClose={() => networkStatus.reset()}>
             {networkStatus.content.title}
           </AlertBox>


### PR DESCRIPTION
increase the margin between error message and input field, add line height to error message text

#2911

# Pull Request Template

## Issue Overview

This PR addresses #issue

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

There's been a request to decrease the line height and increase the top margin of the error message in the Field component. I figured it wouldn't hurt to use a className to increase customization.

## How Can This Be Tested/Reviewed?


![Screen Shot 2022-07-21 at 4 52 13 PM](https://user-images.githubusercontent.com/5691923/181025352-e2a609b0-391d-415f-8e77-701332a73c93.png)
Go into Storybook, look out the Field component example with a Text Field Error, modify the message (either through the debugger or storybook file) to be really long. Compare with the dev storybook and hopefully you can see a smaller line height (1.25 rem) and a top margin that matches the text input's label bottom margin.

Perform the same path above for the TextArea component

Additionally, inside storybook, trigger an error in the following components (by putting gibberish in the inputs) and verify that the on the error message, you can see a smaller line height (1.25 rem) and a top margin that matches the text input's label bottom margin.

- Date of Birth Field
- Date Field
- Time Field

Go into the application, go to the sign in page, trigger a few input errors and verify that the changes feel appropriate (don't need to trigger an error in each box, just a couple to make sure the changes don't mess up any spacing or design spec of surrounding markup).

On the sign in page, trigger an error on the sign in page by trying to sign in with gibberish to cause the error in the screenshot and check that the error box looks the same as it did before this update.

![Screen Shot 2022-07-27 at 5 07 51 PM](https://user-images.githubusercontent.com/5691923/181387657-06d4b11c-7a4b-4e3e-ab3b-0408d7217be8.png)


Lastly, look at the code changes and verify there are no breaking changes. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
