### PR TITLE
fix(paperlistform): adjust padding on add listing form

### DIFF
--- a/sites/partners/src/listings/PaperListingForm/sections/AdditionalDetails.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/AdditionalDetails.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { useFormContext } from "react-hook-form"
-import { t, GridSection, Textarea } from "@bloom-housing/ui-components"
+import { t, GridSection, Textarea, GridCell } from "@bloom-housing/ui-components"
 
 const AdditionalDetails = () => {
   const formMethods = useFormContext()
@@ -11,12 +11,12 @@ const AdditionalDetails = () => {
   return (
     <div>
       <GridSection
-        grid={false}
+        columns={2}
         separator
         title={t("listings.sections.additionalDetails")}
         description={t("listings.sections.additionalDetailsSubtitle")}
       >
-        <GridSection columns={2}>
+        <GridCell>
           <Textarea
             label={t("listings.requiredDocuments")}
             name={"requiredDocuments"}
@@ -25,6 +25,8 @@ const AdditionalDetails = () => {
             register={register}
             maxLength={2000}
           />
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("listings.importantProgramRules")}
             name={"programRules"}
@@ -33,8 +35,8 @@ const AdditionalDetails = () => {
             register={register}
             maxLength={600}
           />
-        </GridSection>
-        <GridSection columns={2}>
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("listings.specialNotes")}
             name={"specialNotes"}
@@ -43,7 +45,7 @@ const AdditionalDetails = () => {
             register={register}
             maxLength={600}
           />
-        </GridSection>
+        </GridCell>
       </GridSection>
     </div>
   )

--- a/sites/partners/src/listings/PaperListingForm/sections/AdditionalEligibility.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/AdditionalEligibility.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react"
 import { useFormContext } from "react-hook-form"
-import { t, GridSection, Textarea } from "@bloom-housing/ui-components"
+import { t, GridSection, Textarea, GridCell } from "@bloom-housing/ui-components"
 import { fieldMessage } from "../../../../lib/helpers"
 import { useJurisdiction } from "../../../../lib/hooks"
 
@@ -32,12 +32,12 @@ const AdditionalEligibility = (props: AdditionalEligibilityProps) => {
   return (
     <div>
       <GridSection
-        grid={false}
         separator
         title={t("listings.sections.additionalEligibilityTitle")}
         description={t("listings.sections.additionalEligibilitySubtext")}
+        columns={2}
       >
-        <GridSection columns={2}>
+        <GridCell>
           <Textarea
             label={t("listings.creditHistory")}
             name={"creditHistory"}
@@ -46,6 +46,8 @@ const AdditionalEligibility = (props: AdditionalEligibilityProps) => {
             register={register}
             maxLength={2000}
           />
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("listings.rentalHistory")}
             name={"rentalHistory"}
@@ -54,8 +56,8 @@ const AdditionalEligibility = (props: AdditionalEligibilityProps) => {
             register={register}
             maxLength={2000}
           />
-        </GridSection>
-        <GridSection columns={2}>
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("listings.criminalBackground")}
             name={"criminalBackground"}
@@ -64,6 +66,8 @@ const AdditionalEligibility = (props: AdditionalEligibilityProps) => {
             register={register}
             maxLength={2000}
           />
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("listings.sections.rentalAssistanceTitle")}
             name={"rentalAssistance"}
@@ -80,7 +84,7 @@ const AdditionalEligibility = (props: AdditionalEligibilityProps) => {
               onChange: () => clearErrors("rentalAssistance"),
             }}
           />
-        </GridSection>
+        </GridCell>
       </GridSection>
     </div>
   )

--- a/sites/partners/src/listings/PaperListingForm/sections/AdditionalFees.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/AdditionalFees.tsx
@@ -1,6 +1,14 @@
 import React, { useContext, useMemo } from "react"
 import { useFormContext } from "react-hook-form"
-import { t, GridSection, Field, Textarea, FieldGroup, ViewItem } from "@bloom-housing/ui-components"
+import {
+  t,
+  GridSection,
+  Field,
+  Textarea,
+  FieldGroup,
+  ViewItem,
+  GridCell,
+} from "@bloom-housing/ui-components"
 import { fieldHasError, fieldMessage } from "../../../../lib/helpers"
 import { AuthContext, listingUtilities } from "@bloom-housing/shared-helpers"
 import { ListingUtilities } from "@bloom-housing/backend-core/types"
@@ -77,22 +85,26 @@ const AdditionalFees = (props: AdditionalFeesProps) => {
           />
         </GridSection>
         <GridSection columns={2}>
-          <Textarea
-            label={t("listings.sections.depositHelperText")}
-            name={"depositHelperText"}
-            id={"depositHelperText"}
-            aria-describedby={"depositHelperText"}
-            fullWidth={true}
-            register={register}
-          />
-          <Textarea
-            label={t("listings.sections.costsNotIncluded")}
-            name={"costsNotIncluded"}
-            id={"costsNotIncluded"}
-            aria-describedby={"costsNotIncluded"}
-            fullWidth={true}
-            register={register}
-          />
+          <GridCell>
+            <Textarea
+              label={t("listings.sections.depositHelperText")}
+              name={"depositHelperText"}
+              id={"depositHelperText"}
+              aria-describedby={"depositHelperText"}
+              fullWidth={true}
+              register={register}
+            />
+          </GridCell>
+          <GridCell>
+            <Textarea
+              label={t("listings.sections.costsNotIncluded")}
+              name={"costsNotIncluded"}
+              id={"costsNotIncluded"}
+              aria-describedby={"costsNotIncluded"}
+              fullWidth={true}
+              register={register}
+            />
+          </GridCell>
         </GridSection>
         {enableUtilitiesIncluded && (
           <GridSection columns={1}>

--- a/sites/partners/src/listings/PaperListingForm/sections/BuildingDetails.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/BuildingDetails.tsx
@@ -208,55 +208,59 @@ const BuildingDetails = ({
           />
           <p className="field-sub-note">{t("listings.requiredToPublish")}</p>
         </GridCell>
-        <ViewItem
-          label={t("application.contact.state")}
-          className={"mb-0"}
-          error={fieldHasError(errors?.buildingAddress?.state)}
-        >
-          <Select
-            id={`buildingAddress.state`}
-            name={`buildingAddress.state`}
-            error={
-              !!getAddressErrorMessage(
+        <GridCell>
+          <ViewItem
+            label={t("application.contact.state")}
+            className={"mb-0"}
+            error={fieldHasError(errors?.buildingAddress?.state)}
+          >
+            <Select
+              id={`buildingAddress.state`}
+              name={`buildingAddress.state`}
+              error={
+                !!getAddressErrorMessage(
+                  "buildingAddress.state",
+                  fieldMessage(errors?.buildingAddress?.state)
+                )
+              }
+              errorMessage={getAddressErrorMessage(
                 "buildingAddress.state",
                 fieldMessage(errors?.buildingAddress?.state)
+              )}
+              label={t("application.contact.state")}
+              labelClassName="sr-only"
+              register={register}
+              controlClassName="control"
+              options={stateKeys}
+              keyPrefix="states"
+              inputProps={{
+                onChange: () => clearErrors("buildingAddress"),
+              }}
+            />
+          </ViewItem>
+        </GridCell>
+        <GridCell>
+          <Field
+            label={t("application.contact.zip")}
+            name={"buildingAddress.zipCode"}
+            id={"buildingAddress.zipCode"}
+            placeholder={t("application.contact.zip")}
+            error={
+              !!getAddressErrorMessage(
+                "buildingAddress.zipCode",
+                fieldMessage(errors?.buildingAddress?.zipCode)
               )
             }
             errorMessage={getAddressErrorMessage(
-              "buildingAddress.state",
-              fieldMessage(errors?.buildingAddress?.state)
+              "buildingAddress.zipCode",
+              fieldMessage(errors?.buildingAddress?.zipCode)
             )}
-            label={t("application.contact.state")}
-            labelClassName="sr-only"
-            register={register}
-            controlClassName="control"
-            options={stateKeys}
-            keyPrefix="states"
             inputProps={{
               onChange: () => clearErrors("buildingAddress"),
             }}
+            register={register}
           />
-        </ViewItem>
-        <Field
-          label={t("application.contact.zip")}
-          name={"buildingAddress.zipCode"}
-          id={"buildingAddress.zipCode"}
-          placeholder={t("application.contact.zip")}
-          error={
-            !!getAddressErrorMessage(
-              "buildingAddress.zipCode",
-              fieldMessage(errors?.buildingAddress?.zipCode)
-            )
-          }
-          errorMessage={getAddressErrorMessage(
-            "buildingAddress.zipCode",
-            fieldMessage(errors?.buildingAddress?.zipCode)
-          )}
-          inputProps={{
-            onChange: () => clearErrors("buildingAddress"),
-          }}
-          register={register}
-        />
+        </GridCell>
         <GridCell span={2}>
           <Field
             label={t("listings.yearBuilt")}

--- a/sites/partners/src/listings/PaperListingForm/sections/BuildingFeatures.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/BuildingFeatures.tsx
@@ -1,6 +1,13 @@
 import React, { useMemo, useContext } from "react"
 import { useFormContext } from "react-hook-form"
-import { t, GridSection, Textarea, ViewItem, FieldGroup } from "@bloom-housing/ui-components"
+import {
+  t,
+  GridSection,
+  Textarea,
+  ViewItem,
+  FieldGroup,
+  GridCell,
+} from "@bloom-housing/ui-components"
 import { listingFeatures, AuthContext } from "@bloom-housing/shared-helpers"
 import { ListingFeatures } from "@bloom-housing/backend-core/types"
 
@@ -31,12 +38,12 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
   return (
     <div>
       <GridSection
-        grid={false}
+        columns={2}
         separator
         title={t("listings.sections.buildingFeaturesTitle")}
         description={t("listings.sections.buildingFeaturesSubtitle")}
       >
-        <GridSection columns={2}>
+        <GridCell>
           <Textarea
             label={t("t.propertyAmenities")}
             name={"amenities"}
@@ -45,6 +52,8 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
             register={register}
             maxLength={600}
           />
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("t.additionalAccessibility")}
             name={"accessibility"}
@@ -53,8 +62,8 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
             register={register}
             maxLength={600}
           />
-        </GridSection>
-        <GridSection columns={2}>
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("t.unitAmenities")}
             name={"unitAmenities"}
@@ -63,6 +72,8 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
             register={register}
             maxLength={600}
           />
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("t.smokingPolicy")}
             name={"smokingPolicy"}
@@ -71,8 +82,8 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
             register={register}
             maxLength={600}
           />
-        </GridSection>
-        <GridSection columns={2}>
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("t.petsPolicy")}
             name={"petPolicy"}
@@ -81,6 +92,8 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
             register={register}
             maxLength={600}
           />
+        </GridCell>
+        <GridCell>
           <Textarea
             label={t("t.servicesOffered")}
             name={"servicesOffered"}
@@ -89,9 +102,9 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
             register={register}
             maxLength={600}
           />
-        </GridSection>
+        </GridCell>
         {!enableAccessibilityFeatures ? null : (
-          <GridSection columns={1}>
+          <GridCell span={2}>
             <ViewItem label={t("listings.sections.accessibilityFeatures")}>
               <FieldGroup
                 type="checkbox"
@@ -101,7 +114,7 @@ const BuildingFeatures = (props: BuildingFeaturesProps) => {
                 fieldGroupClassName="grid grid-cols-3 mt-4"
               />
             </ViewItem>
-          </GridSection>
+          </GridCell>
         )}
       </GridSection>
     </div>


### PR DESCRIPTION
## Issue Overview

This PR addresses #2609 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

The padding issue on the add listing form in mobile has to do with how the grid component is being used in the forms. By removing the additional layer of GridSection the mobile view can switch to the single column and still have the correct padding. Let me know if there is a use case that I am unaware of where the current style is needed

## How Can This Be Tested/Reviewed?

Things to note: 
- This works on both desktop and mobile for "add listing", but if you edit a current listing the width of the form doesn't work properly in mobile due to one of the tables. This is also happening in the dev site.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
