### PR TITLE
fix: replace usage of sanitize-html

### DIFF
--- a/ui-components/package.json
+++ b/ui-components/package.json
@@ -85,7 +85,6 @@
     "@types/react-dom": "^16.9.5",
     "@types/react-text-mask": "^5.4.6",
     "@types/react-transition-group": "^4.4.0",
-    "@types/sanitize-html": "^2.6.2",
     "ag-grid-community": "^26.0.0",
     "ag-grid-react": "^26.0.0",
     "aria-autocomplete": "^1.4.0",

--- a/ui-components/package.json
+++ b/ui-components/package.json
@@ -107,7 +107,6 @@
     "react-tabs": "^3.2.2",
     "react-text-mask": "^5.4.3",
     "react-transition-group": "^4.4.1",
-    "sanitize-html": "^2.7.1",
     "tailwindcss": "2.2.10",
     "ts-jest": "^26.4.1",
     "typesafe-actions": "^5.1.0"

--- a/ui-components/src/helpers/MultiLineAddress.tsx
+++ b/ui-components/src/helpers/MultiLineAddress.tsx
@@ -19,8 +19,8 @@ export interface MultiLineAddressProps {
 const MultiLineAddress = ({ address }: MultiLineAddressProps) => {
   if (!address) return null
 
-  const makeHtmlString = (address) => {
-    const str = ""
+  const makeHtmlString = (address: Address) => {
+    let str = ""
 
     if (address.placeName) {
       str = str += `${address.placeName} <br />`

--- a/ui-components/src/helpers/MultiLineAddress.tsx
+++ b/ui-components/src/helpers/MultiLineAddress.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import sanitizeHtml from "sanitize-html"
+import Markdown from "markdown-to-jsx"
 
 export interface Address {
   city?: string
@@ -20,19 +20,15 @@ const MultiLineAddress = ({ address }: MultiLineAddressProps) => {
   if (!address) return null
 
   return (
-    <span
-      dangerouslySetInnerHTML={{
-        __html: sanitizeHtml(
-          `
-            ${address.placeName ? `${address.placeName} <br />` : ""}
-            ${address.street || ""} ${address.street2 || ""}
-            ${address.street || address.street2 ? `<br />` : ""}
-            ${address.city}
-            ${address.city && (address.state || address.zipCode) ? "," : ""} ${address.state} ${` `}
-            ${address.zipCode}
-          `
-        ),
-      }}
+    <Markdown
+      options={{ disableParsingRawHTML: false }}
+      children={`<span>${address.placeName ? `${address.placeName} <br />` : ""}
+     ${address.street || ""} ${address.street2 || ""}
+     ${address.street || address.street2 ? `<br />` : ""}
+     ${address.city}
+     ${address.city && (address.state || address.zipCode) ? "," : ""} ${address.state} ${` `} ${
+        address.zipCode
+      }</span>`}
     />
   )
 }

--- a/ui-components/src/helpers/MultiLineAddress.tsx
+++ b/ui-components/src/helpers/MultiLineAddress.tsx
@@ -23,15 +23,15 @@ const MultiLineAddress = ({ address }: MultiLineAddressProps) => {
     let str = ""
 
     if (address.placeName) {
-      str = str += `${address.placeName} <br />`
+      str += `${address.placeName} <br />`
     }
 
     if (address.street || address.street2) {
-      str = str += `${address.street || ""} ${address.street2 || ""} <br />`
+      str += `${address.street || ""} ${address.street2 || ""} <br />`
     }
 
     if (address.city || address.state || address.zipCode) {
-      str = str += `${address.city && `${address.city} ,`} ${address.state} ${address.zipCode}`
+      str += `${address.city && `${address.city} ,`} ${address.state} ${address.zipCode}`
     }
 
     return str

--- a/ui-components/src/helpers/MultiLineAddress.tsx
+++ b/ui-components/src/helpers/MultiLineAddress.tsx
@@ -19,16 +19,28 @@ export interface MultiLineAddressProps {
 const MultiLineAddress = ({ address }: MultiLineAddressProps) => {
   if (!address) return null
 
+  const makeHtmlString = (address) => {
+    const str = ""
+
+    if (address.placeName) {
+      str = str += `${address.placeName} <br />`
+    }
+
+    if (address.street || address.street2) {
+      str = str += `${address.street || ""} ${address.street2 || ""} <br />`
+    }
+
+    if (address.city || address.state || address.zipCode) {
+      str = str += `${address.city && `${address.city} ,`} ${address.state} ${address.zipCode}`
+    }
+
+    return str
+  }
+
   return (
     <Markdown
       options={{ disableParsingRawHTML: false }}
-      children={`<span>${address.placeName ? `${address.placeName} <br />` : ""}
-     ${address.street || ""} ${address.street2 || ""}
-     ${address.street || address.street2 ? `<br />` : ""}
-     ${address.city}
-     ${address.city && (address.state || address.zipCode) ? "," : ""} ${address.state} ${` `} ${
-        address.zipCode
-      }</span>`}
+      children={`<span>${makeHtmlString(address)}</span>`}
     />
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7197,13 +7197,6 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/sanitize-html@^2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@types/sanitize-html/-/sanitize-html-2.6.2.tgz#9c47960841b9def1e4c9dfebaaab010a3f6e97b9"
-  integrity sha512-7Lu2zMQnmHHQGKXVvCOhSziQMpa+R2hMHFefzbYoYMHeaXR0uXqNeOc3JeQQQ8/6Xa2Br/P1IQTLzV09xxAiUQ==
-  dependencies:
-    htmlparser2 "^6.0.0"
-
 "@types/serve-static@*":
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.5.tgz#3d25d941a18415d3ab092def846e135a08bbcf53"
@@ -11340,15 +11333,6 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
-dom-serializer@^1.0.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.4.1.tgz#de5d41b1aea290215dc45a6dae8adcf1d32e2d30"
-  integrity sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
-
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
@@ -11374,11 +11358,6 @@ domelementtype@^2.0.1:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
   integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
 
-domelementtype@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
-  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
-
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
@@ -11392,13 +11371,6 @@ domhandler@^2.3.0:
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
     domelementtype "1"
-
-domhandler@^4.0.0, domhandler@^4.2.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
-  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
-  dependencies:
-    domelementtype "^2.2.0"
 
 domutils@1.5.1:
   version "1.5.1"
@@ -11415,15 +11387,6 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
-
-domutils@^2.5.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
-  dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -14134,16 +14097,6 @@ htmlparser2@^3.3.0:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^3.1.1"
-
-htmlparser2@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
-  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
-  dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.0.0"
-    domutils "^2.5.2"
-    entities "^2.0.0"
 
 http-cache-semantics@3.8.1:
   version "3.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17528,11 +17528,6 @@ nanoid@^3.1.12, nanoid@^3.1.23:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.31.tgz#f5b58a1ce1b7604da5f0605757840598d8974dc6"
   integrity sha512-ZivnJm0o9bb13p2Ot5CpgC2rQdzB9Uxm/mFZweqm5eMViqOJe3PV6LU2E30SiLgheesmcPrjquqraoolONSA0A==
 
-nanoid@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -18751,11 +18746,6 @@ parse-path@^4.0.0:
     qs "^6.9.4"
     query-string "^6.13.8"
 
-parse-srcset@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/parse-srcset/-/parse-srcset-1.0.2.tgz#f2bd221f6cc970a938d88556abc589caaaa2bde1"
-  integrity sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==
-
 parse-url@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/parse-url/-/parse-url-6.0.0.tgz#f5dd262a7de9ec00914939220410b66cff09107d"
@@ -19268,15 +19258,6 @@ postcss@^8.1.6, postcss@^8.2.1, postcss@^8.3.6:
     colorette "^1.2.2"
     nanoid "^3.1.23"
     source-map-js "^0.6.2"
-
-postcss@^8.3.11:
-  version "8.4.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
-  integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
-  dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -20976,18 +20957,6 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sanitize-html@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.7.1.tgz#a6c2c1a88054a79eeacfac9b0a43f1b393476901"
-  integrity sha512-oOpe8l4J8CaBk++2haoN5yNI5beekjuHv3JRPKUx/7h40Rdr85pemn4NkvUB3TcBP7yjat574sPlcMAyv4UQig==
-  dependencies:
-    deepmerge "^4.2.2"
-    escape-string-regexp "^4.0.0"
-    htmlparser2 "^6.0.0"
-    is-plain-object "^5.0.0"
-    parse-srcset "^1.0.2"
-    postcss "^8.3.11"
-
 sass-loader@^10.0.3:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.0.3.tgz#9e2f1bfdd6355f2adde4e4835d838b020bf800b0"
@@ -21514,7 +21483,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

A [recent pr](https://github.com/bloom-housing/bloom/pull/2914) replaced the dompurify library (which sanitizes html) with sanitize-html which broke DAHLIA (attached screenshot). This fix uses the <Markdown /> component (which we already have access to via [markdown-to-jsx](https://www.npmjs.com/package/markdown-to-jsx) lib) which does some basic sanitization - although it's a bit hard to find out exactly what sanitization it does when the disableParsingRawHTML is set to false, it at least removes script tags! 

Just because this is blocking uptakes on dahlia, it'd be nice to fast track this! I'm open to reworking this with a different, longer-term solution. Also open to any other quick, potentially temporary fixes.

<img width="1136" alt="Screen Shot 2022-08-10 at 3 15 25 PM" src="https://user-images.githubusercontent.com/5691923/184030154-b1ac0b3b-9eb3-437e-86cb-9ee04864d5da.png">


## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

- Ensure that previews work from partners (it doesn't crash).
- Compare MultiLineAdress components in storybooks (should have a 1:1 visual parity)
- Check a couple examples of <Multiline/> usage in listings (e.g. the component that shows the address in the map on the detailed listing page)
- Updates don't introduce any breaking changes


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
