### PR TITLE
test: set store_artifacts false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ workflows:
             yarn test:backend:core:dbsetup
           start: yarn dev:all-cypress
           wait-on: "http://0.0.0.0:3000"
-          store_artifacts: true
+          store_artifacts: false
       - cypress/run:
           name: "cypress-partners"
           requires:
@@ -177,4 +177,4 @@ workflows:
             yarn test:backend:core:dbsetup
           start: yarn dev:all-cypress
           wait-on: "http://0.0.0.0:3001"
-          store_artifacts: true
+          store_artifacts: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,11 @@ executors:
   puppeteer-node:
     docker:
       - image: "cimg/node:14.17.6-browsers"
+      steps:
+        - checkout
+        - setup_remote_docker:
+            docker_layer_caching: true # DLC will explicitly cache layers here and try to avoid rebuilding.
+        - run: docker build .
 
 jobs:
   setup:

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ test-coverage/
 
 # redis dumps
 dump.rdb
+
+# pg dumps
+*.dump


### PR DESCRIPTION
This sets store_artifacts for Circleci to false, since we don't need to store them most of the time. We can turn it back on by a case-by-case basis, if it would be useful.