### PR TITLE
feat(lottery): add edit lottery results functionality

### DIFF
--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -208,6 +208,8 @@
   "listings.sections.introTitle": "Listing Intro",
   "listings.sections.leasingAgentSubtitle": "Provide details about the leasing agent who will be managing the application process.",
   "listings.sections.leasingAgentTitle": "Leasing Agent",
+  "listings.sections.lotteryResultsAdd": "Add Results",
+  "listings.sections.lotteryResultsEdit": "Edit Results",
   "listings.sections.lotteryResultsHelperText": "Upload Results",
   "listings.sections.openHouse": "Open House",
   "listings.sections.photoSubtitle": "Upload an image for the listing that will be used as a preview.",

--- a/sites/partners/src/listings/Aside.tsx
+++ b/sites/partners/src/listings/Aside.tsx
@@ -163,7 +163,10 @@ const Aside = ({
         )
       }
 
-      if (listing.events.find((event) => event.type === ListingEventType.lotteryResults)) {
+      const lotteryResults = listing.events.find(
+        (event) => event.type === ListingEventType.lotteryResults
+      )
+      if (lotteryResults) {
         elements.push(
           <GridCell className="flex" key="btn-edit-lottery">
             <Button
@@ -174,10 +177,7 @@ const Aside = ({
               onClick={() => showLotteryResultsDrawer && showLotteryResultsDrawer()}
             >
               {t("listings.actions.resultsPosted")}{" "}
-              {dayjs(
-                listing.events.find((event) => event.type === ListingEventType.lotteryResults)
-                  ?.startTime
-              ).format("MMMM DD, YYYY")}
+              {dayjs(lotteryResults?.startTime).format("MMMM DD, YYYY")}
               <Icon size="medium" symbol="edit" className="ml-2" />
             </Button>
           </GridCell>

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailAdditionalFees.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailAdditionalFees.tsx
@@ -18,7 +18,7 @@ const DetailAdditionalFees = () => {
       if (listing?.utilities[utility]) {
         utilitiesExist = true
         return (
-          <li className={"list-disc mx-5 mb-1 md:w-1/3 w-full grow"}>
+          <li key={utility} className={"list-disc mx-5 mb-1 md:w-1/3 w-full grow"}>
             {t(`listings.utilities.${utility}`)}
           </li>
         )


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2463

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

When a Lottery Result already exists and a user clicks to Edit it the page now shows "Edit Results" instead of "Add Results". It also shows the file that is currently uploaded instead of the dropzone.
![image](https://user-images.githubusercontent.com/42942267/184402166-01dd403f-162b-4e72-83e5-4687899d517c.png)

After a user deletes the pdf the dropzone re-appears and the "post" button turns into "save". When it is saved the lottery result event is cleaned up from that listing rather than just deleting the file name associated to it.
![image](https://user-images.githubusercontent.com/42942267/184409303-9048ab50-5cb4-4f4c-b89e-11b3d00e3e44.png)



## How Can This Be Tested/Reviewed?

Select a listing that is closed and has a lottery result already posted. Click "EDIT". Then click on the "Results Posted..." edit link. Should see "Edit Results" and the currently saved results shown. Ability to delete it as well.

There are currently no tests around the lottery results feature. I am willing to add tests but don't know if we want to have a cypress test that uploads a pdf every time

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
