### PR TITLE
fix(login): too many login attempts fix

### DIFF
--- a/backend/core/test/user/user.e2e-spec.ts
+++ b/backend/core/test/user/user.e2e-spec.ts
@@ -29,6 +29,7 @@ import { UserRoles } from "../../src/auth/entities/user-roles.entity"
 import { EmailService } from "../../src/email/email.service"
 import { MfaType } from "../../src/auth/types/mfa-type"
 import { UserRepository } from "../../src/auth/repositories/user-repository"
+import dayjs from "dayjs"
 
 // Cypress brings in Chai types for the global expect, but we want to use jest
 // expect here so we need to re-declare it.
@@ -99,6 +100,9 @@ describe("Applications", () => {
   })
 
   it("should not allow user to create an account with weak password", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {
+      // Mute the error console logging
+    })
     const userCreateDto: UserCreateDto = {
       password: "abcdef",
       passwordConfirmation: "abcdef",
@@ -113,6 +117,9 @@ describe("Applications", () => {
   })
 
   it("should not allow user to create an account which is already confirmed nor confirm it using PUT", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {
+      // Mute the error console logging
+    })
     const userCreateDto: UserCreateDto = {
       password: "Abcdef1!",
       passwordConfirmation: "Abcdef1!",
@@ -196,6 +203,9 @@ describe("Applications", () => {
   })
 
   it("should not allow user to sign in before confirming the account", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {
+      // Mute the error console logging
+    })
     const userCreateDto: UserCreateDto = {
       password: "Abcdef1!",
       passwordConfirmation: "Abcdef1!",
@@ -227,6 +237,9 @@ describe("Applications", () => {
   })
 
   it("should not allow user to create an account without matching confirmation", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {
+      // Mute the error console logging
+    })
     const userCreateDto: UserCreateDto = {
       password: "Abcdef1!",
       passwordConfirmation: "abcdef2",
@@ -274,6 +287,9 @@ describe("Applications", () => {
   })
 
   it("should not allow user/anonymous to modify other existing user's data", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {
+      // Mute the error console logging
+    })
     const user2UpdateDto: UserUpdateDto = {
       id: user2Profile.id,
       dob: new Date(),
@@ -945,6 +961,78 @@ describe("Applications", () => {
     await supertest(app.getHttpServer())
       .post("/auth/login")
       .send({ email: userCreateDto.email, password: newPassword })
+      .expect(201)
+  })
+
+  it("should fail login if too many attempts and pass after lockout period", async () => {
+    jest.spyOn(console, "error").mockImplementation(() => {
+      // Mute the error console logging
+    })
+    const userCreateDto: UserCreateDto = {
+      password: "Abcdef1!",
+      passwordConfirmation: "Abcdef1!",
+      email: "password@b.com",
+      emailConfirmation: "password@b.com",
+      firstName: "First",
+      middleName: "Mid",
+      lastName: "Last",
+      dob: new Date(),
+    }
+
+    const userCreateResponse = await supertest(app.getHttpServer())
+      .post(`/user/`)
+      .set("jurisdictionName", "Alameda")
+      .send(userCreateDto)
+      .expect(201)
+    await supertest(app.getHttpServer())
+      .put(`/user/${userCreateResponse.body.id}`)
+      .set(...setAuthorization(adminAccessToken))
+      .send({
+        ...userCreateResponse.body,
+        confirmedAt: new Date(),
+      })
+      .expect(200)
+
+    // first five should fail with not authorized
+    let failedResponse = await supertest(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email: userCreateDto.email, password: "wrong password" })
+      .expect(401)
+    expect(failedResponse.body.failureCountRemaining).toBe(5)
+    failedResponse = await supertest(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email: userCreateDto.email, password: "wrong password2" })
+      .expect(401)
+    expect(failedResponse.body.failureCountRemaining).toBe(4)
+    failedResponse = await supertest(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email: userCreateDto.email, password: "wrong password3" })
+      .expect(401)
+    expect(failedResponse.body.failureCountRemaining).toBe(3)
+    failedResponse = await supertest(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email: userCreateDto.email, password: "wrong password4" })
+      .expect(401)
+    expect(failedResponse.body.failureCountRemaining).toBe(2)
+    failedResponse = await supertest(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email: userCreateDto.email, password: "wrong password5" })
+      .expect(401)
+    expect(failedResponse.body.failureCountRemaining).toBe(1)
+    // 6th fails with too many requests
+    await supertest(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email: userCreateDto.email, password: userCreateDto.password })
+      .expect(429)
+
+    const userRepository = await app.resolve<UserRepository>(UserRepository)
+    const user = await userRepository.findByEmail(userCreateDto.email)
+    user.lastLoginAt = dayjs(new Date()).subtract(31, "minutes").toDate()
+    await usersRepository.save(user)
+
+    await supertest(app.getHttpServer())
+      .post("/auth/login")
+      .send({ email: userCreateDto.email, password: userCreateDto.password })
       .expect(201)
   })
 

--- a/shared-helpers/src/catchNetworkError.ts
+++ b/shared-helpers/src/catchNetworkError.ts
@@ -49,13 +49,17 @@ export const useCatchNetworkError = () => {
     } else if (message === NetworkErrorMessage.MfaUnauthorized) {
       setNetworkError({
         title: t("authentication.signIn.enterValidEmailAndPasswordAndMFA"),
-        description: t("authentication.signIn.afterFailedAttempts"),
+        description: t("authentication.signIn.afterFailedAttempts", {
+          count: error?.response?.data?.failureCountRemaining || 5,
+        }),
         error,
       })
     } else {
       setNetworkError({
         title: t("authentication.signIn.enterValidEmailAndPassword"),
-        description: t("authentication.signIn.afterFailedAttempts"),
+        description: t("authentication.signIn.afterFailedAttempts", {
+          count: error?.response?.data?.failureCountRemaining || 5,
+        }),
         error,
       })
     }

--- a/ui-components/src/locales/es.json
+++ b/ui-components/src/locales/es.json
@@ -371,7 +371,7 @@
   "authentication.forgotPassword.sendEmail": "Enviar correo electrónico",
   "authentication.forgotPassword.success": "Le hemos enviado un correo electrónico con un enlace para restablecer tu contraseña.",
   "authentication.signIn.accountHasBeenLocked": "Por razones de seguridad_ esta cuenta ha sido bloqueada.",
-  "authentication.signIn.afterFailedAttempts": "Por razones de seguridad_ después de 5 intentos fallidos_ deberá esperar 30 minutos antes de volver a intentarlo.",
+  "authentication.signIn.afterFailedAttempts": "Por razones de seguridad_ después de %{count} intentos fallidos_ deberá esperar 30 minutos antes de volver a intentarlo.",
   "authentication.signIn.changeYourPassword": "Puede cambiar su contraseña",
   "authentication.signIn.enterLoginEmail": "Por favor_ escriba su correo electrónico de inicio de sesión",
   "authentication.signIn.enterLoginPassword": "Por favor_ escriba su contraseña de inicio de sesión",

--- a/ui-components/src/locales/general.json
+++ b/ui-components/src/locales/general.json
@@ -495,7 +495,7 @@
   "authentication.forgotPassword.sendEmail": "Send email",
   "authentication.forgotPassword.success": "We've sent you an email. You'll receive an email with a link to reset your password.",
   "authentication.signIn.accountHasBeenLocked": "For security reasons, this account has been locked.",
-  "authentication.signIn.afterFailedAttempts": "For security reasons, after 5 failed attempts, you’ll have to wait 30 minutes before trying again.",
+  "authentication.signIn.afterFailedAttempts": "For security reasons, after %{count} failed attempts, you’ll have to wait 30 minutes before trying again.",
   "authentication.signIn.changeYourPassword": "You can change your password",
   "authentication.signIn.enterLoginEmail": "Please enter your login email",
   "authentication.signIn.enterLoginPassword": "Please enter your login password",

--- a/ui-components/src/locales/tl.json
+++ b/ui-components/src/locales/tl.json
@@ -324,7 +324,7 @@
   "authentication.forgotPassword.sendEmail": "Magpadala ng email",
   "authentication.forgotPassword.success": "Nagpadala kami sa iyo ng email. Makakatanggap ka ng email na may link para i-reset ang iyong password.",
   "authentication.signIn.accountHasBeenLocked": "Para sa mga kadahilanang pangseguridad_ ang account na ito isinara na.",
-  "authentication.signIn.afterFailedAttempts": "Para sa mga kadahilanang pangseguridad_ pagkatapos ng 5 nabigong pagtatangka_ kailangan mong maghintay ng 30 minuto bago subukang muli.",
+  "authentication.signIn.afterFailedAttempts": "Para sa mga kadahilanang pangseguridad_ pagkatapos ng %{count} nabigong pagtatangka_ kailangan mong maghintay ng 30 minuto bago subukang muli.",
   "authentication.signIn.changeYourPassword": "Maaari mong palitan ang iyong password",
   "authentication.signIn.enterLoginEmail": "Pakilagay ang iyong email sa pag-login",
   "authentication.signIn.enterLoginPassword": "Pakilagay ang iyong password sa pag-log in",

--- a/ui-components/src/locales/vi.json
+++ b/ui-components/src/locales/vi.json
@@ -371,7 +371,7 @@
   "authentication.forgotPassword.sendEmail": "Gửi email",
   "authentication.forgotPassword.success": "Chúng tôi đã gửi email cho quý vị. Quý vị sẽ nhận được email có liên kết để đặt lại mật khẩu.",
   "authentication.signIn.accountHasBeenLocked": "Vì lý do bảo mật_ tài khoản này đã bị khóa.",
-  "authentication.signIn.afterFailedAttempts": "Vì lý do bảo mật_ quý vị sẽ phải chờ 30 phút trước khi thử lại sau 5 lần thử không thành công.",
+  "authentication.signIn.afterFailedAttempts": "Vì lý do bảo mật_ quý vị sẽ phải chờ 30 phút trước khi thử lại sau %{count} lần thử không thành công.",
   "authentication.signIn.changeYourPassword": "Quý vị có thể đổi mật khẩu",
   "authentication.signIn.enterLoginEmail": "Vui lòng nhập email đăng nhập của quý vị",
   "authentication.signIn.enterLoginPassword": "Vui lòng nhập mật khẩu đăng nhập của quý vị",

--- a/ui-components/src/locales/zh.json
+++ b/ui-components/src/locales/zh.json
@@ -371,7 +371,7 @@
   "authentication.forgotPassword.sendEmail": "傳送電子郵件",
   "authentication.forgotPassword.success": "我們已向您傳送電子郵件。您會收到具有重設密碼連結的電子郵件。",
   "authentication.signIn.accountHasBeenLocked": "基於安全原因，此帳戶已遭到鎖定。",
-  "authentication.signIn.afterFailedAttempts": "基於安全原因，只要失敗嘗試達 5 次，您就必須等待 30 分鐘才能再試一次。",
+  "authentication.signIn.afterFailedAttempts": "基於安全原因，只要失敗嘗試達 %{count} 次，您就必須等待 30 分鐘才能再試一次。",
   "authentication.signIn.changeYourPassword": "您可以變更密碼",
   "authentication.signIn.enterLoginEmail": "請輸入您的登入電子郵件",
   "authentication.signIn.enterLoginPassword": "請輸入您的登入密碼",


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #2903 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR fixes the incorrect implementation of entering the wrong password too many times. Currently the incorrect count is getting updated correctly and also resetting correctly when a user finally signs in correctly. However, the last login time is not getting updated so the check for if they have waited the 30 minutes is always passing. 

Also this updates the UI to read the remaining attempt count in the error message displayed.
![image](https://user-images.githubusercontent.com/42942267/186223760-4b93d26b-9399-46d7-a02c-c4e78362b532.png)


## How Can This Be Tested/Reviewed?

On the sign in page attempt to log in with a valid email (known user) but the incorrect password. Should get the error message with "5" failed attempts.

Repeat 4 more times and the error message should increment down.

On the sixth wrong one the lockout error should appear and not able to login or get the original error message for an additional 30 minutes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.

## QA Notes:

*When testing in Dev be cognizant of locking out shared accounts.*
 On the sign in page attempt to log in with a valid email (known user) but the incorrect password. Should get the error message with "5" failed attempts.

Repeat 4 more times and the error message should increment down.

On the sixth wrong one the lockout error should appear and not able to login or get the original error message for an additional 30 minutes.