### PR TITLE
2891/add sign up to beginning of application flow

### DIFF
--- a/sites/public/cypress/integration/pages/application/start/choose-language.spec.ts
+++ b/sites/public/cypress/integration/pages/application/start/choose-language.spec.ts
@@ -1,9 +1,0 @@
-describe("applications/start/choose-language", function () {
-  it("should redirect to create account page", function () {
-    cy.visit("/listings")
-    cy.get(".is-card-link").contains("Test: Coliseum").click()
-    cy.getByTestId("listing-view-apply-button").eq(1).click()
-    cy.getByTestId("app-choose-language-create-account-button").click()
-    cy.location("pathname").should("equals", "/create-account")
-  })
-})

--- a/sites/public/cypress/integration/pages/application/start/choose-language.spec.ts
+++ b/sites/public/cypress/integration/pages/application/start/choose-language.spec.ts
@@ -1,0 +1,9 @@
+describe("applications/start/choose-language", function () {
+  it("should redirect to create account page", function () {
+    cy.visit("/listings")
+    cy.get(".is-card-link").contains("Test: Coliseum").click()
+    cy.getByTestId("listing-view-apply-button").eq(1).click()
+    cy.getByTestId("app-choose-language-create-account-button").click()
+    cy.location("pathname").should("equals", "/create-account")
+  })
+})

--- a/sites/public/pages/applications/start/choose-language.tsx
+++ b/sites/public/pages/applications/start/choose-language.tsx
@@ -1,8 +1,8 @@
 /*
-0.1 - Choose Language
-Applicants are given the option to start the Application in one of a number of languages via button group. Once inside the application the applicant can use the language selection at the top of the page.
-https://github.com/bloom-housing/bloom/issues/277
-*/
+ 0.1 - Choose Language
+ Applicants are given the option to start the Application in one of a number of languages via button group. Once inside the application the applicant can use the language selection at the top of the page.
+ https://github.com/bloom-housing/bloom/issues/277
+ */
 import axios from "axios"
 import { useRouter } from "next/router"
 import {
@@ -155,22 +155,20 @@ const ApplicationChooseLanguage = () => {
 
           {initialStateLoaded && !profile && (
             <>
-              <div className="form-card__pager-row primary px-4 border-t border-gray-450">
-                <h2 className="form-card__title w-full border-none pt-0 mt-0">
-                  {t("account.haveAnAccount")}
-                </h2>
-
-                <p className="my-6">{t("application.chooseLanguage.signInSaveTime")}</p>
-
-                <div>
+              <ActionBlock
+                className="border-t border-gray-450"
+                header={t("account.haveAnAccount")}
+                subheader={t("application.chooseLanguage.signInSaveTime")}
+                background="primary-lighter"
+                actions={[
                   <LinkButton
                     href={`/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listingId?.toString()}`}
                     dataTestId={"app-choose-language-sign-in-button"}
                   >
                     {t("nav.signIn")}
-                  </LinkButton>
-                </div>
-              </div>
+                  </LinkButton>,
+                ]}
+              />
               <ActionBlock
                 className="border-t border-gray-450"
                 header={t("authentication.createAccount.noAccount")}

--- a/sites/public/pages/applications/start/choose-language.tsx
+++ b/sites/public/pages/applications/start/choose-language.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   ImageCard,
   LinkButton,
+  ActionBlock,
   FormCard,
   ProgressNav,
   t,
@@ -153,22 +154,37 @@ const ApplicationChooseLanguage = () => {
           </div>
 
           {initialStateLoaded && !profile && (
-            <div className="form-card__pager-row primary px-4 border-t border-gray-450">
-              <h2 className="form-card__title w-full border-none pt-0 mt-0">
-                {t("account.haveAnAccount")}
-              </h2>
+            <>
+              <div className="form-card__pager-row primary px-4 border-t border-gray-450">
+                <h2 className="form-card__title w-full border-none pt-0 mt-0">
+                  {t("account.haveAnAccount")}
+                </h2>
 
-              <p className="my-6">{t("application.chooseLanguage.signInSaveTime")}</p>
+                <p className="my-6">{t("application.chooseLanguage.signInSaveTime")}</p>
 
-              <div>
-                <LinkButton
-                  href={`/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listingId?.toString()}`}
-                  dataTestId={"app-choose-language-sign-in-button"}
-                >
-                  {t("nav.signIn")}
-                </LinkButton>
+                <div>
+                  <LinkButton
+                    href={`/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listingId?.toString()}`}
+                    dataTestId={"app-choose-language-sign-in-button"}
+                  >
+                    {t("nav.signIn")}
+                  </LinkButton>
+                </div>
               </div>
-            </div>
+              <ActionBlock
+                className="border-t border-gray-450"
+                header={t("authentication.createAccount.noAccount")}
+                background="primary-lighter"
+                actions={[
+                  <LinkButton
+                    href={"/create-account"}
+                    dataTestId={"app-choose-language-create-account-button"}
+                  >
+                    {t("account.createAccount")}
+                  </LinkButton>,
+                ]}
+              />
+            </>
           )}
         </div>
       </FormCard>

--- a/sites/public/pages/applications/start/choose-language.tsx
+++ b/sites/public/pages/applications/start/choose-language.tsx
@@ -13,6 +13,7 @@ import {
   FormCard,
   ProgressNav,
   t,
+  Heading,
 } from "@bloom-housing/ui-components"
 import {
   imageUrlFromListing,
@@ -130,13 +131,14 @@ const ApplicationChooseLanguage = () => {
         )}
 
         <div className="form-card__pager">
-          <div className="form-card__pager-row primary px-4">
+          <div className="form-card__pager-row px-4">
             {listing?.applicationConfig.languages.length > 1 && (
               <>
-                <h3 className="mb-4 font-alt-sans field-label--caps block text-base text-black">
-                  {t("application.chooseLanguage.chooseYourLanguage")}
-                </h3>
-
+                <div className="w-full">
+                  <Heading style="sidebarHeader">
+                    {t("application.chooseLanguage.chooseYourLanguage")}
+                  </Heading>
+                </div>
                 {listing.applicationConfig.languages.map((lang, index) => (
                   <Button
                     className="language-select mx-1 mb-2"


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Main scope of task was to add create account panel to start of application flow. I used for that `ActionBlock` component. To unify both login and create account panels, changed login to also use `ActionBlock`. 
Updated also `change your language` to match designs recommendations.

Using `background` as string in `ActionBlock` generates warnings because we're using enums in it. That's the way they're implemented in storybook so i followed the pattern. Let me know if i should use enums there.

## How Can This Be Tested/Reviewed?

Start new application being logged out (f.e. http://localhost:3000/applications/start/choose-language?listingId=fba78bf7-24cb-460a-8c6c-8caf6b1d1b42). Check again after log in.

Test goes to application, press the create-account button and checks if we redirected to `/create-account` 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
