### PR TITLE
fix: migration for application export clean up

### DIFF
--- a/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
+++ b/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
@@ -220,7 +220,7 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
         SELECT
             p.form_metadata,
             mq.text,
-            mppm.juris_name as jurisName,
+            mppm.juris_name as jurisname,
             mppm.program_or_preference_id
         FROM multiselect_programs_preferences_mapper mppm
             LEFT JOIN ${type}s p ON p.id = mppm.program_or_preference_id
@@ -273,7 +273,7 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
                   `${type}s`,
                   selection.key,
                   opt.key === "preferNotToSay" ? "preferNotToSay" : `${opt.key}.label`,
-                  metaKey.jurisName
+                  metaKey.jurisname
                 )
                 return toReturn
               }),

--- a/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
+++ b/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
@@ -1,0 +1,286 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+import https from "https"
+
+export class programAndPreferenceUpdates1661805250707 implements MigrationInterface {
+  translations = {}
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // gather up translations
+    const translationURLs = [
+      {
+        url:
+          "https://raw.githubusercontent.com/bloom-housing/bloom/dev/ui-components/src/locales/general.json",
+        key: "generalCore",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/bloom-housing/bloom/dev/sites/partners/page_content/locale_overrides/general.json",
+        key: "generalPartners",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/bloom-housing/bloom/dev/sites/public/page_content/locale_overrides/general.json",
+        key: "generalPublic",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/housingbayarea/bloom/dev/ui-components/src/locales/general.json",
+        key: "hbaCore",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/housingbayarea/bloom/dev/sites/partners/page_content/locale_overrides/general.json",
+        key: "hbaPartners",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/housingbayarea/bloom/dev/sites/public/page_content/locale_overrides/general.json",
+        key: "hbaPublic",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/CityOfDetroit/bloom/dev/ui-components/src/locales/general.json",
+        key: "detroitCore",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/CityOfDetroit/bloom/dev/sites/partners/page_content/locale_overrides/general.json",
+        key: "detroitPartners",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/CityOfDetroit/bloom/dev/sites/public/page_content/locale_overrides/general.json",
+        key: "detroitPublic",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/housingbayarea/bloom/0.3_alameda/sites/public/page_content/locale_overrides/general.json",
+        key: "alamedaPublic",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/housingbayarea/bloom/0.3_smc/sites/public/page_content/locale_overrides/general.json",
+        key: "smcPublic",
+      },
+      {
+        url:
+          "https://raw.githubusercontent.com/housingbayarea/bloom/san-jose/sites/public/page_content/locale_overrides/general.json",
+        key: "sjPublic",
+      },
+    ]
+
+    for (let i = 0; i < translationURLs.length; i++) {
+      const { url, key } = translationURLs[i]
+      this.translations[key] = await this.getTranslationFile(url)
+    }
+
+    // construct mapper table to make my life easier
+    await queryRunner.query(`
+        CREATE TABLE "multiselect_programs_preferences_mapper" (
+            "multiselect_id" uuid NOT NULL,
+            "program_or_program_id" uuid NOT NULL,
+            "application_section" "public"."multiselect_questions_application_section_enum" NOT NULL,
+            "juris_name" text not null
+        )`)
+
+    // fill mapper table
+    await queryRunner.query(`
+        INSERT INTO multiselect_programs_preferences_mapper (multiselect_id, program_or_program_id, application_section, juris_name)
+        SELECT
+            mq.id,
+            p.id,
+            'programs',
+            (
+                SELECT
+                    j.name
+                FROM jurisdictions_programs_programs jpp
+                    LEFT JOIN jurisdictions j ON j.id = jpp.jurisdictions_id
+                WHERE jpp.programs_id = p.id
+                LIMIT 1
+            ) as jurisName
+        FROM multiselect_questions mq
+            JOIN programs p ON p.title = mq.text
+        WHERE mq.application_section = 'programs';
+
+
+        INSERT INTO multiselect_programs_preferences_mapper (multiselect_id, program_or_program_id, application_section, juris_name)
+        SELECT
+            mq.id,
+            p.id,
+            'preferences',
+            (
+                SELECT
+                    j.name
+                FROM jurisdictions_preferences_preferences jpp
+                    LEFT JOIN jurisdictions j ON j.id = jpp.jurisdictions_id
+                WHERE jpp.preferences_id = p.id
+                LIMIT 1
+            ) as jurisName
+        FROM multiselect_questions mq
+            JOIN preferences p ON p.title = mq.text
+        WHERE mq.application_section = 'preferences';
+    `)
+
+    await this.alterData(queryRunner, "program")
+    await this.alterData(queryRunner, "preference")
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+
+  private getTranslationFile(url) {
+    return new Promise((resolve, reject) =>
+      https
+        .get(url, (res) => {
+          let body = ""
+
+          res.on("data", (chunk) => {
+            body += chunk
+          })
+
+          res.on("end", () => {
+            try {
+              const json = JSON.parse(body)
+              resolve(json)
+            } catch (error) {
+              console.error("on end error:", error.message)
+              reject(`parsing broke: ${url}`)
+            }
+          })
+        })
+        .on("error", (error) => {
+          console.error("on error error:", error.message)
+          reject(`getting broke: ${url}`)
+        })
+    )
+  }
+
+  private getTranslated(type, prefKey, translationKey, juris) {
+    let searchKey = `application.${type}.${prefKey}.${translationKey}`
+    if (translationKey === "preferNotToSay") {
+      searchKey = "t.preferNotToSay"
+    }
+
+    if (juris === "Detroit") {
+      if (this.translations["detroitPublic"][searchKey]) {
+        return this.translations["detroitPublic"][searchKey]
+      } else if (this.translations["detroitPartners"][searchKey]) {
+        return this.translations["detroitPartners"][searchKey]
+      } else if (this.translations["detroitCore"][searchKey]) {
+        return this.translations["detroitCore"][searchKey]
+      }
+    } else if (["Alameda", "San Mateo", "San Jose"].includes(juris)) {
+      if (juris === "Alameda" && this.translations["alamedaPublic"][searchKey]) {
+        return this.translations["alamedaPublic"][searchKey]
+      } else if (juris === "San Mateo" && this.translations["smcPublic"][searchKey]) {
+        return this.translations["smcPublic"][searchKey]
+      } else if (juris === "San Jose" && this.translations["sjPublic"][searchKey]) {
+        return this.translations["sjPublic"][searchKey]
+      } else if (this.translations["hbaPublic"][searchKey]) {
+        return this.translations["hbaPublic"][searchKey]
+      } else if (this.translations["hbaPartners"][searchKey]) {
+        return this.translations["hbaPartners"][searchKey]
+      } else if (this.translations["hbaCore"][searchKey]) {
+        return this.translations["hbaCore"][searchKey]
+      }
+    }
+
+    if (this.translations["generalPublic"][searchKey]) {
+      return this.translations["generalPublic"][searchKey]
+    } else if (this.translations["generalPartners"][searchKey]) {
+      return this.translations["generalPartners"][searchKey]
+    } else if (this.translations["generalCore"][searchKey]) {
+      return this.translations["generalCore"][searchKey]
+    }
+    return "no translation"
+  }
+
+  private isDataAllowed(listingData, listing_id, meta, type) {
+    return listingData.some(
+      (listingInfo) =>
+        listingInfo.listing_id === listing_id && listingInfo[type] === meta.program_or_program_id
+    )
+  }
+
+  private async alterData(queryRunner, type) {
+    // grab the meta info
+    const metaData = await queryRunner.query(`
+        SELECT
+            p.form_metadata,
+            mq.text,
+            mppm.juris_name as jurisName,
+            mppm.program_or_program_id
+        FROM multiselect_programs_preferences_mapper mppm
+            LEFT JOIN ${type}s p ON p.id = mppm.program_or_program_id
+            LEFT JOIN multiselect_questions mq ON mq.id = mppm.multiselect_id
+        WHERE mppm.application_section = '${type}s'
+    `)
+
+    // grab the application data
+    const applicationData = await queryRunner.query(`
+        SELECT
+            id,
+            ${type}s as data,
+            listing_id
+        FROM applications
+        WHERE ${type}s IS NOT NULL AND ${type}s != '[]'
+    `)
+
+    // grab the listing data
+    const listingData = await queryRunner.query(`
+        SELECT
+            listing_id,
+            ${type}_id
+        FROM listing_${type}s
+    `)
+
+    // make alterations
+    for (let i = 0; i < applicationData.length; i++) {
+      let { id, data, listing_id } = applicationData[i]
+
+      data = data.reduce((acc, selection) => {
+        const metaText = metaData.find((meta) => meta.text === selection.key)
+        const metaKey = metaData.find((meta) => meta.form_metadata.key === selection.key)
+
+        if (metaText) {
+          // if found in the new multiselect column
+          if (this.isDataAllowed(listingData, listing_id, metaText, `${type}_id`)) {
+            acc.push(selection)
+          }
+        } else if (metaKey) {
+          // if found in the old program/preference column
+          if (this.isDataAllowed(listingData, listing_id, metaKey, `${type}_id`)) {
+            acc.push({
+              ...selection,
+              key: metaKey.text,
+              options: selection.options.map((opt) => {
+                const toReturn = {
+                  ...opt,
+                }
+                toReturn.key = this.getTranslated(
+                  `${type}s`,
+                  selection.key,
+                  "preferNotToSay" ? "preferNotToSay" : `${opt.key}.label`,
+                  metaKey.jurisName
+                )
+                return toReturn
+              }),
+            })
+          }
+        } else {
+          // if not found at all (to prevent data loss)
+          acc.push(selection)
+        }
+        return acc
+      }, [])
+
+      await queryRunner.query(
+        `
+        UPDATE applications
+        SET
+            ${type}s = $1
+        WHERE id = '${id}'
+    `,
+        [JSON.stringify(data)]
+      )
+    }
+  }
+}

--- a/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
+++ b/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
@@ -100,7 +100,14 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
             ) as jurisName
         FROM multiselect_questions mq
             JOIN programs p ON p.title = mq.text
-        WHERE mq.application_section = 'programs';
+        WHERE mq.application_section = 'programs'
+          AND exists (
+            SELECT
+                1
+            FROM jurisdictions_programs_programs jpp
+            WHERE jpp.programs_id = p.id
+          )
+        ;
 
 
         INSERT INTO multiselect_programs_preferences_mapper (multiselect_id, program_or_preference_id, application_section, juris_name)
@@ -118,7 +125,13 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
             ) as jurisName
         FROM multiselect_questions mq
             JOIN preferences p ON p.title = mq.text
-        WHERE mq.application_section = 'preferences';
+        WHERE mq.application_section = 'preferences'
+          AND exists (
+            SELECT
+                1
+            FROM jurisdictions_preferences_preferences jpp
+            WHERE jpp.preferences_id = p.id
+          )
     `)
 
     await this.alterData(queryRunner, "program")
@@ -259,7 +272,7 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
                 toReturn.key = this.getTranslated(
                   `${type}s`,
                   selection.key,
-                  "preferNotToSay" ? "preferNotToSay" : `${opt.key}.label`,
+                  opt.key === "preferNotToSay" ? "preferNotToSay" : `${opt.key}.label`,
                   metaKey.jurisName
                 )
                 return toReturn

--- a/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
+++ b/backend/core/src/migration/1661805250707-programAndPreferenceUpdates.ts
@@ -77,14 +77,15 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
     await queryRunner.query(`
         CREATE TABLE "multiselect_programs_preferences_mapper" (
             "multiselect_id" uuid NOT NULL,
-            "program_or_program_id" uuid NOT NULL,
+            "program_or_preference_id" uuid NOT NULL,
             "application_section" "public"."multiselect_questions_application_section_enum" NOT NULL,
-            "juris_name" text not null
+            "juris_name" text not null,
+            "created_at" TIMESTAMP NOT NULL DEFAULT now()
         )`)
 
     // fill mapper table
     await queryRunner.query(`
-        INSERT INTO multiselect_programs_preferences_mapper (multiselect_id, program_or_program_id, application_section, juris_name)
+        INSERT INTO multiselect_programs_preferences_mapper (multiselect_id, program_or_preference_id, application_section, juris_name)
         SELECT
             mq.id,
             p.id,
@@ -102,7 +103,7 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
         WHERE mq.application_section = 'programs';
 
 
-        INSERT INTO multiselect_programs_preferences_mapper (multiselect_id, program_or_program_id, application_section, juris_name)
+        INSERT INTO multiselect_programs_preferences_mapper (multiselect_id, program_or_preference_id, application_section, juris_name)
         SELECT
             mq.id,
             p.id,
@@ -196,7 +197,7 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
   private isDataAllowed(listingData, listing_id, meta, type) {
     return listingData.some(
       (listingInfo) =>
-        listingInfo.listing_id === listing_id && listingInfo[type] === meta.program_or_program_id
+        listingInfo.listing_id === listing_id && listingInfo[type] === meta.program_or_preference_id
     )
   }
 
@@ -207,9 +208,9 @@ export class programAndPreferenceUpdates1661805250707 implements MigrationInterf
             p.form_metadata,
             mq.text,
             mppm.juris_name as jurisName,
-            mppm.program_or_program_id
+            mppm.program_or_preference_id
         FROM multiselect_programs_preferences_mapper mppm
-            LEFT JOIN ${type}s p ON p.id = mppm.program_or_program_id
+            LEFT JOIN ${type}s p ON p.id = mppm.program_or_preference_id
             LEFT JOIN multiselect_questions mq ON mq.id = mppm.multiselect_id
         WHERE mppm.application_section = '${type}s'
     `)


### PR DESCRIPTION
## Issue Overview

This PR addresses [#issue](https://github.com/bloom-housing/bloom/issues/3007)

- [x] This change addresses only certain aspects of the issue

## Description
This covers the migration for updating application data for programs and preferences. What we were running into was that old data (program/preference data) and new data (multiselect question data) existing on applications for a listing was causing the application export to create duplicate columns. This migration should merge that data together into the new way

## How Can This Be Tested/Reviewed?
okay so testing this is kind of a pain locally, my recommendation is to go as follows:

1) before checking this branch out run a reseed
2) check this branch out
3) insert data into the following tables: 
```
SELECT
    *
FROM programs;

SELECT
    *
FROM preferences;

SELECT
    *
FROM listing_programs;

SELECT
    *
FROM listing_preferences;
```
4) update data in the following table/colums:
```
SELECT
    id,
    programs,
    preferences
FROM applications;
```
The data that you update into here should have data that is keyed off the program/preference instead of the multiselect question

5) run `yarn db:migration:run`

what you should get is the data you added in gets merged into the new way, and thus the extra columns in the export no longer show!

## Checklist:
- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
