### PR TITLE
fix: return N/A if rent and income is NaN

### DIFF
--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -245,7 +245,7 @@ const hmiData = (units: Units, maxHouseholdSize: number, amiCharts: AmiChart[]) 
 
 const getCurrencyString = (initialValue: string) => {
   const roundedValue = getRoundedNumber(initialValue)
-  if (Number.isNaN(roundedValue)) return "N/A"
+  if (Number.isNaN(roundedValue)) return "t.n/a"
   return usd.format(roundedValue)
 }
 

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -244,7 +244,9 @@ const hmiData = (units: Units, maxHouseholdSize: number, amiCharts: AmiChart[]) 
 }
 
 const getCurrencyString = (initialValue: string) => {
-  return usd.format(getRoundedNumber(initialValue))
+  const roundedValue = getRoundedNumber(initialValue)
+  if (Number.isNaN(roundedValue)) return "N/A"
+  return usd.format(roundedValue)
 }
 
 const getRoundedNumber = (initialValue: string) => {

--- a/shared-helpers/src/summaryTables.tsx
+++ b/shared-helpers/src/summaryTables.tsx
@@ -22,12 +22,16 @@ export const unitSummariesTable = (
     const unitPluralization = unitSummary.totalAvailable == 1 ? t("t.unit") : t("t.units")
     const minIncome =
       unitSummary.minIncomeRange.min == unitSummary.minIncomeRange.max ? (
-        <strong>{getTranslationFromCurrencyString(unitSummary.minIncomeRange.min)}</strong>
+        <>
+          <strong>{getTranslationFromCurrencyString(unitSummary.minIncomeRange.min)}</strong>
+          {unitSummary.minIncomeRange.min !== "t.n/a" && ` ${t("t.perMonth")}`}
+        </>
       ) : (
         <>
           <strong>{getTranslationFromCurrencyString(unitSummary.minIncomeRange.min)}</strong>
           {` ${t("t.to")} `}
           <strong>{getTranslationFromCurrencyString(unitSummary.minIncomeRange.max)}</strong>
+          {` ${t("t.perMonth")}`}
         </>
       )
 
@@ -36,7 +40,7 @@ export const unitSummariesTable = (
       return rentMin == rentMax ? (
         <>
           <strong>{getTranslationFromCurrencyString(rentMin)}</strong>
-          {unit}
+          {rentMin !== "t.n/a" && unit}
         </>
       ) : (
         <>
@@ -85,12 +89,7 @@ export const unitSummariesTable = (
         content: <strong>{t(`listings.unitTypes.${unitSummary.unitType?.name}`)}</strong>,
       },
       minimumIncome: {
-        content: (
-          <span>
-            {minIncome}
-            {` ${t("t.perMonth")}`}
-          </span>
-        ),
+        content: <span>{minIncome}</span>,
       },
       rent: { content: <span>{rent}</span> },
       availability: {

--- a/shared-helpers/src/summaryTables.tsx
+++ b/shared-helpers/src/summaryTables.tsx
@@ -5,8 +5,14 @@ import {
   t,
   numberOrdinal,
   ContentAccordion,
+  getTranslationWithArguments,
 } from "@bloom-housing/ui-components"
 import { MinMax, UnitSummary, Unit, ListingAvailability } from "@bloom-housing/backend-core/types"
+
+const getTranslationFromCurrencyString = (value: string) => {
+  if (value.startsWith("t.")) return getTranslationWithArguments(value)
+  return value
+}
 
 export const unitSummariesTable = (
   summaries: UnitSummary[],
@@ -16,12 +22,12 @@ export const unitSummariesTable = (
     const unitPluralization = unitSummary.totalAvailable == 1 ? t("t.unit") : t("t.units")
     const minIncome =
       unitSummary.minIncomeRange.min == unitSummary.minIncomeRange.max ? (
-        <strong>{unitSummary.minIncomeRange.min}</strong>
+        <strong>{getTranslationFromCurrencyString(unitSummary.minIncomeRange.min)}</strong>
       ) : (
         <>
-          <strong>{unitSummary.minIncomeRange.min}</strong>
+          <strong>{getTranslationFromCurrencyString(unitSummary.minIncomeRange.min)}</strong>
           {` ${t("t.to")} `}
-          <strong>{unitSummary.minIncomeRange.max}</strong>
+          <strong>{getTranslationFromCurrencyString(unitSummary.minIncomeRange.max)}</strong>
         </>
       )
 
@@ -29,14 +35,14 @@ export const unitSummariesTable = (
       const unit = percent ? `% ${t("t.income")}` : ` ${t("t.perMonth")}`
       return rentMin == rentMax ? (
         <>
-          <strong>{rentMin}</strong>
+          <strong>{getTranslationFromCurrencyString(rentMin)}</strong>
           {unit}
         </>
       ) : (
         <>
-          <strong>{rentMin}</strong>
+          <strong>{getTranslationFromCurrencyString(rentMin)}</strong>
           {` ${t("t.to")} `}
-          <strong>{rentMax}</strong>
+          <strong>{getTranslationFromCurrencyString(rentMax)}</strong>
           {unit}
         </>
       )


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3035

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

While not passing rent and income values, we've sent probably `null` value that was processed anyway as valid number, so while formatting `parseFloat` returned `NaN`.
Now instead of `$NaN per month` it displays as `N/A per month` etc.
Not sure if that should also contain `$` before `N/A`

## How Can This Be Tested/Reviewed?

We need to have listing where in listing units we select nothing in `How is Rent Determined?`. While editing listing just remove existing values, at first it can throw error while saving, but after open listing unit and saving it again it should work fine.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
