### PR TITLE
refactor: cleanup application error state styles

### DIFF
--- a/shared-helpers/src/multiselectQuestions.tsx
+++ b/shared-helpers/src/multiselectQuestions.tsx
@@ -130,10 +130,14 @@ export const getRadioFields = (
         fieldClassName="ml-0"
         type={"radio"}
         name={fieldName(question?.text, applicationSection)}
-        error={errors && errors[question?.text]}
+        error={
+          errors &&
+          Object.keys(errors).length > 0 &&
+          errors["application"]["programs"][question?.text]
+        }
         errorMessage={errors && t("errors.selectAnOption")}
         register={register}
-        validation={{ required: !!errors }}
+        validation={{ required: true }}
         fields={options?.map((option) => {
           return {
             id: `${question?.text}-${option?.text}`,

--- a/shared-helpers/src/multiselectQuestions.tsx
+++ b/shared-helpers/src/multiselectQuestions.tsx
@@ -130,11 +130,7 @@ export const getRadioFields = (
         fieldClassName="ml-0"
         type={"radio"}
         name={fieldName(question?.text, applicationSection)}
-        error={
-          errors &&
-          Object.keys(errors).length > 0 &&
-          errors["application"]["programs"][question?.text]
-        }
+        error={errors && errors?.application?.programs?.[question?.text]}
         errorMessage={errors && t("errors.selectAnOption")}
         register={register}
         validation={{ required: true }}

--- a/sites/partners/src/applications/Aside.tsx
+++ b/sites/partners/src/applications/Aside.tsx
@@ -114,7 +114,7 @@ const Aside = ({ listingId, type, onDelete, triggerSubmitAndRedirect }: AsidePro
                 type="button"
                 unstyled
                 fullWidth
-                className="bg-opacity-0 text-red-700"
+                className="bg-opacity-0 text-alert"
                 onClick={() => setDeleteModal(true)}
               >
                 {t("t.delete")}

--- a/sites/partners/src/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
+++ b/sites/partners/src/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
@@ -120,7 +120,7 @@ const FormHouseholdMembers = ({
               </Button>
               <Button
                 type="button"
-                className="font-semibold uppercase text-red-700 my-0"
+                className="font-semibold uppercase text-alert my-0"
                 onClick={() => setMembersDeleteModal(member.orderId)}
                 unstyled
               >

--- a/sites/partners/src/listings/PaperListingForm/sections/ApplicationDates.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/ApplicationDates.tsx
@@ -70,7 +70,7 @@ const ApplicationDates = ({
               </Button>
               <Button
                 type="button"
-                className="font-semibold uppercase text-red-700 my-0"
+                className="font-semibold uppercase text-alert my-0"
                 onClick={() => setModalDeleteOpenHouse(event)}
                 unstyled
               >

--- a/sites/partners/src/listings/PaperListingForm/sections/ApplicationTypes.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/ApplicationTypes.tsx
@@ -119,7 +119,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
         content: (
           <Button
             type="button"
-            className="font-semibold uppercase text-red-700 my-0"
+            className="font-semibold uppercase text-alert my-0"
             onClick={() => {
               setCloudinaryData({
                 id: "",
@@ -384,7 +384,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                         <div className="flex">
                           <Button
                             type="button"
-                            className="font-semibold uppercase text-red-700 my-0"
+                            className="font-semibold uppercase text-alert my-0"
                             onClick={() => {
                               const items = methods.paper.paperApplications.filter(
                                 (paperApp) => item !== paperApp

--- a/sites/partners/src/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -88,7 +88,7 @@ const LotteryResults = () => {
         content: (
           <Button
             type="button"
-            className="font-semibold uppercase text-red-700 my-0"
+            className="font-semibold uppercase text-alert my-0"
             onClick={() => {
               setCloudinaryData({
                 id: "",
@@ -136,7 +136,7 @@ const LotteryResults = () => {
             </Button>
             <Button
               type="button"
-              className="font-semibold uppercase text-red-700 my-0"
+              className="font-semibold uppercase text-alert my-0"
               onClick={() => {
                 setCloudinaryData({ ...cloudinaryData, id: "" })
                 deletePDF()
@@ -171,7 +171,7 @@ const LotteryResults = () => {
             </Button>
             <Button
               type="button"
-              className="font-semibold uppercase text-red-700"
+              className="font-semibold uppercase text-alert"
               onClick={() => {
                 setValue("buildingSelectionCriteria", "")
               }}

--- a/sites/partners/src/listings/PaperListingForm/sections/ListingPhoto.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/ListingPhoto.tsx
@@ -80,7 +80,7 @@ const ListingPhoto = () => {
         content: (
           <Button
             type="button"
-            className="font-semibold uppercase text-red-700 my-0"
+            className="font-semibold uppercase text-alert my-0"
             onClick={() => {
               setCloudinaryData({
                 id: "",
@@ -130,7 +130,7 @@ const ListingPhoto = () => {
             </Button>
             <Button
               type="button"
-              className="font-semibold uppercase text-red-700 my-0"
+              className="font-semibold uppercase text-alert my-0"
               onClick={() => {
                 setCloudinaryData({ ...cloudinaryData, id: "" })
                 deletePhoto()

--- a/sites/partners/src/listings/PaperListingForm/sections/LotteryResults.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/LotteryResults.tsx
@@ -109,7 +109,7 @@ const LotteryResults = (props: LotteryResultsProps) => {
         content: (
           <Button
             type="button"
-            className="font-semibold uppercase text-red-700 my-0"
+            className="font-semibold uppercase text-alert my-0"
             onClick={() => {
               setCloudinaryData({
                 id: "",

--- a/sites/partners/src/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -92,7 +92,7 @@ const SelectAndOrder = ({
             <div className="flex">
               <Button
                 type="button"
-                className="front-semibold uppercase text-red-700 my-0"
+                className="front-semibold uppercase text-alert my-0"
                 onClick={() => {
                   deleteItem(item, false)
                 }}
@@ -117,7 +117,7 @@ const SelectAndOrder = ({
             <div className="flex">
               <Button
                 type="button"
-                className="front-semibold uppercase text-red-700 my-0"
+                className="front-semibold uppercase text-alert my-0"
                 onClick={() => {
                   deleteItem(item, true)
                 }}

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -122,7 +122,7 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
               </Button>
               <Button
                 type="button"
-                className="front-semibold uppercase text-red-700 my-0"
+                className="front-semibold uppercase text-alert my-0"
                 onClick={() => setUnitDeleteModal(unit.tempId)}
                 unstyled
               >

--- a/sites/partners/src/users/FormUserManage.tsx
+++ b/sites/partners/src/users/FormUserManage.tsx
@@ -455,7 +455,7 @@ const FormUserManage = ({
           {mode === "edit" && (
             <Button
               type="button"
-              className="bg-opacity-0 text-red-700"
+              className="bg-opacity-0 text-alert"
               onClick={() => setDeleteModalActive(true)}
               unstyled
             >

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -456,9 +456,7 @@ const ApplicationAddress = () => {
             <div className="form-card__group border-b">
               <fieldset>
                 <legend
-                  className={`field-label--caps ${
-                    errors?.contactPreferences ? "text-red-700" : ""
-                  }`}
+                  className={`field-label--caps ${errors?.contactPreferences ? "text-alert" : ""}`}
                 >
                   {t("application.contact.contactPreference")}
                 </legend>
@@ -479,7 +477,7 @@ const ApplicationAddress = () => {
               <fieldset>
                 <legend
                   className={`field-label--caps ${
-                    errors?.applicant?.workInRegion ? "text-red-700" : ""
+                    errors?.applicant?.workInRegion ? "text-alert" : ""
                   }`}
                 >
                   {t("application.contact.doYouWorkIn", { county: listing?.countyCode })}

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -288,7 +288,7 @@ const ApplicationAddress = () => {
             <div className="form-card__group border-b">
               <fieldset>
                 <legend
-                  className={`field-label--caps ${errors.applicant?.address ? "text-red-700" : ""}`}
+                  className={`field-label--caps ${errors.applicant?.address ? "text-alert" : ""}`}
                 >
                   {t("application.contact.address")}
                 </legend>

--- a/sites/public/pages/applications/contact/address.tsx
+++ b/sites/public/pages/applications/contact/address.tsx
@@ -287,7 +287,11 @@ const ApplicationAddress = () => {
 
             <div className="form-card__group border-b">
               <fieldset>
-                <legend className="field-label--caps">{t("application.contact.address")}</legend>
+                <legend
+                  className={`field-label--caps ${errors.applicant?.address ? "text-red-700" : ""}`}
+                >
+                  {t("application.contact.address")}
+                </legend>
 
                 <p className="field-note mb-4">
                   {t("application.contact.addressWhereYouCurrentlyLive")}
@@ -451,7 +455,11 @@ const ApplicationAddress = () => {
             )}
             <div className="form-card__group border-b">
               <fieldset>
-                <legend className="field-label--caps">
+                <legend
+                  className={`field-label--caps ${
+                    errors?.contactPreferences ? "text-red-700" : ""
+                  }`}
+                >
                   {t("application.contact.contactPreference")}
                 </legend>
                 <FieldGroup
@@ -469,7 +477,11 @@ const ApplicationAddress = () => {
 
             <div className="form-card__group">
               <fieldset>
-                <legend className="field-label--caps">
+                <legend
+                  className={`field-label--caps ${
+                    errors?.applicant?.workInRegion ? "text-red-700" : ""
+                  }`}
+                >
                   {t("application.contact.doYouWorkIn", { county: listing?.countyCode })}
                 </legend>
 

--- a/sites/public/pages/applications/contact/alternate-contact-type.tsx
+++ b/sites/public/pages/applications/contact/alternate-contact-type.tsx
@@ -96,7 +96,7 @@ const ApplicationAlternateContactType = () => {
         <Form id="applications-contact-alternate-type" onSubmit={handleSubmit(onSubmit, onError)}>
           <div className="form-card__group">
             <fieldset>
-              <legend className="field-label--caps">
+              <legend className={`field-label--caps ${errors?.type ? "text-red-700" : ""}`}>
                 {t("application.alternateContact.type.label")}
               </legend>
               <p className="field-note mb-4">{t("t.pleaseSelectOne")}</p>

--- a/sites/public/pages/applications/contact/alternate-contact-type.tsx
+++ b/sites/public/pages/applications/contact/alternate-contact-type.tsx
@@ -96,7 +96,7 @@ const ApplicationAlternateContactType = () => {
         <Form id="applications-contact-alternate-type" onSubmit={handleSubmit(onSubmit, onError)}>
           <div className="form-card__group">
             <fieldset>
-              <legend className={`field-label--caps ${errors?.type ? "text-red-700" : ""}`}>
+              <legend className={`field-label--caps ${errors?.type ? "text-alert" : ""}`}>
                 {t("application.alternateContact.type.label")}
               </legend>
               <p className="field-note mb-4">{t("t.pleaseSelectOne")}</p>

--- a/sites/public/pages/applications/contact/name.tsx
+++ b/sites/public/pages/applications/contact/name.tsx
@@ -100,7 +100,9 @@ const ApplicationName = () => {
         <Form onSubmit={handleSubmit(onSubmit, onError)}>
           <div className="form-card__group border-b" data-test-id={"application-initial-page"}>
             <fieldset>
-              <legend className="field-label--caps">
+              <legend
+                className={`field-label--caps ${errors.applicant?.firstName ? "text-red-700" : ""}`}
+              >
                 {t("application.name.yourName")}
                 <LockIcon />
               </legend>
@@ -172,7 +174,11 @@ const ApplicationName = () => {
           </div>
 
           <div className="form-card__group">
-            <legend className="field-label--caps">
+            <legend
+              className={`field-label--caps ${
+                errors.applicant?.emailAddress ? "text-red-700" : ""
+              }`}
+            >
               {t("application.name.yourEmailAddress")}
               <LockIcon />
             </legend>

--- a/sites/public/pages/applications/contact/name.tsx
+++ b/sites/public/pages/applications/contact/name.tsx
@@ -101,7 +101,7 @@ const ApplicationName = () => {
           <div className="form-card__group border-b" data-test-id={"application-initial-page"}>
             <fieldset>
               <legend
-                className={`field-label--caps ${errors.applicant?.firstName ? "text-red-700" : ""}`}
+                className={`field-label--caps ${errors.applicant?.firstName ? "text-alert" : ""}`}
               >
                 {t("application.name.yourName")}
                 <LockIcon />
@@ -175,9 +175,7 @@ const ApplicationName = () => {
 
           <div className="form-card__group">
             <legend
-              className={`field-label--caps ${
-                errors.applicant?.emailAddress ? "text-red-700" : ""
-              }`}
+              className={`field-label--caps ${errors.applicant?.emailAddress ? "text-alert" : ""}`}
             >
               {t("application.name.yourEmailAddress")}
               <LockIcon />

--- a/sites/public/pages/applications/financial/income.tsx
+++ b/sites/public/pages/applications/financial/income.tsx
@@ -207,6 +207,8 @@ const ApplicationIncome = () => {
                 validation={{ required: true }}
                 fields={incomePeriodValues}
                 dataTestId={"app-income-period"}
+                fieldGroupClassName="grid grid-cols-1"
+                fieldClassName="ml-0"
               />
             </fieldset>
           </div>

--- a/sites/public/pages/applications/financial/vouchers.tsx
+++ b/sites/public/pages/applications/financial/vouchers.tsx
@@ -35,7 +35,7 @@ const ApplicationVouchers = () => {
     : 3
   /* Form Handler */
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, errors } = useForm({
+  const { register, handleSubmit, errors, getValues } = useForm({
     defaultValues: { incomeVouchers: application.incomeVouchers?.toString() },
     shouldFocusError: false,
   })
@@ -125,14 +125,20 @@ const ApplicationVouchers = () => {
             <fieldset>
               <legend className="sr-only">{t("application.financial.vouchers.legend")}</legend>
               <FieldGroup
+                fieldGroupClassName="grid grid-cols-1"
+                fieldClassName="ml-0"
                 type="radio"
                 name="incomeVouchers"
                 error={errors.incomeVouchers}
                 errorMessage={t("errors.selectAnOption")}
                 register={register}
-                validation={{ required: true }}
                 fields={incomeVouchersValues}
                 dataTestId={"app-income-vouchers"}
+                validation={{
+                  validate: () => {
+                    return !!Object.values(getValues()).filter((value) => value).length
+                  },
+                }}
               />
             </fieldset>
           </div>

--- a/sites/public/pages/applications/household/changes.tsx
+++ b/sites/public/pages/applications/household/changes.tsx
@@ -26,7 +26,7 @@ const ApplicationHouseholdChanges = () => {
 
   /* Form Handler */
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, errors } = useForm<Record<string, any>>({
+  const { register, handleSubmit, errors, getValues } = useForm<Record<string, any>>({
     defaultValues: { householdExpectingChanges: application.householdExpectingChanges?.toString() },
     shouldFocusError: false,
   })
@@ -107,14 +107,20 @@ const ApplicationHouseholdChanges = () => {
           >
             <fieldset>
               <FieldGroup
+                fieldGroupClassName="grid grid-cols-1"
+                fieldClassName="ml-0"
                 type="radio"
                 name="householdExpectingChanges"
                 error={errors.householdExpectingChanges}
                 errorMessage={t("errors.selectAnOption")}
                 register={register}
-                validation={{ required: true }}
                 fields={householdChangesValues}
                 dataTestId={"app-expecting-changes"}
+                validation={{
+                  validate: () => {
+                    return !!Object.values(getValues()).filter((value) => value).length
+                  },
+                }}
               />
             </fieldset>
           </div>

--- a/sites/public/pages/applications/household/member.tsx
+++ b/sites/public/pages/applications/household/member.tsx
@@ -215,6 +215,8 @@ const ApplicationMember = () => {
                     {t("application.household.member.haveSameAddress")}
                   </legend>
                   <FieldGroup
+                    fieldGroupClassName="grid grid-cols-1"
+                    fieldClassName="ml-0"
                     name="sameAddress"
                     type="radio"
                     register={register}
@@ -311,6 +313,8 @@ const ApplicationMember = () => {
                   </legend>
                   <FieldGroup
                     name="workInRegion"
+                    fieldGroupClassName="grid grid-cols-1"
+                    fieldClassName="ml-0"
                     groupNote={t("application.household.member.workInRegionNote")}
                     type="radio"
                     register={register}

--- a/sites/public/pages/applications/household/preferred-units.tsx
+++ b/sites/public/pages/applications/household/preferred-units.tsx
@@ -110,6 +110,8 @@ const ApplicationPreferredUnits = () => {
               <legend className="sr-only">{t("application.household.preferredUnit.legend")}</legend>
               <FieldGroup
                 type="checkbox"
+                fieldGroupClassName="grid grid-cols-1"
+                fieldClassName="ml-0"
                 name="preferredUnit"
                 groupNote={t("application.household.preferredUnit.optionsLabel")}
                 fields={preferredUnitOptions}

--- a/sites/public/pages/applications/household/student.tsx
+++ b/sites/public/pages/applications/household/student.tsx
@@ -26,7 +26,7 @@ const ApplicationHouseholdStudent = () => {
 
   /* Form Handler */
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, errors } = useForm<Record<string, any>>({
+  const { register, handleSubmit, errors, getValues } = useForm<Record<string, any>>({
     defaultValues: { householdStudent: application.householdStudent?.toString() },
     shouldFocusError: false,
   })
@@ -104,14 +104,20 @@ const ApplicationHouseholdStudent = () => {
           >
             <fieldset>
               <FieldGroup
+                fieldGroupClassName="grid grid-cols-1"
+                fieldClassName="ml-0"
                 type="radio"
                 name="householdStudent"
                 error={errors.householdStudent}
                 errorMessage={t("errors.selectAnOption")}
                 register={register}
-                validation={{ required: true }}
                 fields={householdStudentValues}
                 dataTestId={"app-student"}
+                validation={{
+                  validate: () => {
+                    return !!Object.values(getValues()).filter((value) => value).length
+                  },
+                }}
               />
             </fieldset>
           </div>

--- a/ui-components/src/forms/DOBField.tsx
+++ b/ui-components/src/forms/DOBField.tsx
@@ -44,6 +44,8 @@ const DOBField = (props: DOBFieldProps) => {
     return [name, baseName].filter((item) => item).join(".")
   }
 
+  const hasError = error?.birthMonth || error?.birthDay || error?.birthYear
+
   const birthDay = watch(getFieldName("birthDay")) ?? defaultDOB?.birthDay
   const birthMonth = watch(getFieldName("birthMonth")) ?? defaultDOB?.birthMonth
 
@@ -56,6 +58,7 @@ const DOBField = (props: DOBFieldProps) => {
 
   const labelClasses = ["field-label--caps"]
   if (props.readerOnly) labelClasses.push("sr-only")
+  if (hasError) labelClasses.push("text-red-700")
 
   return (
     <fieldset id={id}>
@@ -132,7 +135,7 @@ const DOBField = (props: DOBFieldProps) => {
         />
       </div>
 
-      {(error?.birthMonth || error?.birthDay || error?.birthYear) && (
+      {hasError && (
         <div className="field error">
           <span id={`${id}-error`} className="error-message">
             {errorMessage ? errorMessage : props.strings?.dateError ?? t("errors.dateOfBirthError")}

--- a/ui-components/src/forms/DOBField.tsx
+++ b/ui-components/src/forms/DOBField.tsx
@@ -58,7 +58,7 @@ const DOBField = (props: DOBFieldProps) => {
 
   const labelClasses = ["field-label--caps"]
   if (props.readerOnly) labelClasses.push("sr-only")
-  if (hasError) labelClasses.push("text-red-700")
+  if (hasError) labelClasses.push("text-alert")
 
   return (
     <fieldset id={id}>

--- a/ui-components/src/forms/Field.tsx
+++ b/ui-components/src/forms/Field.tsx
@@ -77,6 +77,7 @@ const Field = (props: FieldProps) => {
     if (props.type === "radio") {
       labelClasses.push("font-semibold")
     }
+    if (props.error) labelClasses.push("text-red-700")
 
     return (
       <label className={labelClasses.join(" ")} htmlFor={props.id || props.name}>

--- a/ui-components/src/forms/Field.tsx
+++ b/ui-components/src/forms/Field.tsx
@@ -77,7 +77,7 @@ const Field = (props: FieldProps) => {
     if (props.type === "radio") {
       labelClasses.push("font-semibold")
     }
-    if (props.error) labelClasses.push("text-red-700")
+    if (props.error) labelClasses.push("text-alert")
 
     return (
       <label className={labelClasses.join(" ")} htmlFor={props.id || props.name}>

--- a/ui-components/src/forms/FieldGroup.tsx
+++ b/ui-components/src/forms/FieldGroup.tsx
@@ -61,7 +61,7 @@ const FieldGroup = ({
   dataTestId,
   strings,
 }: FieldGroupProps) => {
-  // Always align two-option radio groups side by side
+  // Always default align two-option radio groups side by side
   if (fields?.length === 2) {
     fieldGroupClassName = `${fieldGroupClassName} flex`
     fieldClassName = `${fieldClassName} flex-initial mr-4`

--- a/ui-components/src/forms/HouseholdSizeField.tsx
+++ b/ui-components/src/forms/HouseholdSizeField.tsx
@@ -66,7 +66,7 @@ const HouseholdSizeField = (props: HouseholdSizeFieldProps) => {
       <ErrorMessage
         id={"householdsize-error"}
         error={!!error}
-        className="block mt-0 line-normal text-red-700"
+        className="block mt-0 line-normal text-alert"
       >
         <AlertBox type="alert" inverted onClose={() => clearErrors()}>
           {strings?.dontQualifyHeader ?? t("application.household.dontQualifyHeader")}

--- a/ui-components/src/global/forms.scss
+++ b/ui-components/src/global/forms.scss
@@ -321,7 +321,6 @@ input[type="number"] {
 .field-note {
   @apply text-tiny;
   @apply text-gray-700;
-  @apply font-semibold;
   white-space: pre-line;
 }
 
@@ -331,7 +330,7 @@ input[type="number"] {
   @apply text-red-700;
   @apply tracking-wide;
   @apply leading-5;
-  @apply mt-2;
+  @apply mt-1;
 }
 
 .field-sub-note {

--- a/ui-components/src/global/forms.scss
+++ b/ui-components/src/global/forms.scss
@@ -196,7 +196,7 @@
 
   &.error {
     label {
-      @apply text-red-700;
+      @apply text-alert;
     }
 
     .control {
@@ -208,7 +208,7 @@
       }
 
       .prepend {
-        @apply text-red-700;
+        @apply text-alert;
       }
     }
 
@@ -327,7 +327,7 @@ input[type="number"] {
 .error-message {
   display: inline-block;
   @apply text-sm;
-  @apply text-red-700;
+  @apply text-alert;
   @apply tracking-wide;
   @apply leading-5;
   @apply mt-1;

--- a/ui-components/src/notifications/AlertBox.scss
+++ b/ui-components/src/notifications/AlertBox.scss
@@ -12,7 +12,7 @@
   --warn-invert-background-color: var(--bloom-color-warn);
   --text-color: var(--bloom-color-gray-900);
   --close-icon-color: var(--bloom-color-gray-900);
-  --font-weight: 600;
+  --font-weight: 500;
   --max-width: var(--bloom-width-5xl);
   --line-height: 1.375;
 

--- a/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
+++ b/ui-components/src/page_components/sign-in/FormSignInErrorBox.tsx
@@ -27,7 +27,7 @@ const FormSignInErrorBox = ({ networkStatus, errors, errorMessageId }: FormSignI
         <ErrorMessage
           id={`form-sign-in-${errorMessageId}-error`}
           error={!!networkStatus.content}
-          className="block mt-0 leading-normal text-red-700"
+          className="block mt-0 leading-normal text-alert"
         >
           <AlertBox type={"alert"} inverted onClose={() => networkStatus.reset()}>
             {networkStatus.content.title}

--- a/ui-components/src/tables/StandardTable.stories.tsx
+++ b/ui-components/src/tables/StandardTable.stories.tsx
@@ -65,7 +65,7 @@ export const preferenceHeaders = {
 const getDeleteButton = () => {
   return (
     <div className={"text-right"}>
-      <Button type="button" className="front-semibold uppercase text-red-700 m-0" unstyled>
+      <Button type="button" className="front-semibold uppercase text-alert m-0" unstyled>
         Delete
       </Button>
     </div>


### PR DESCRIPTION


#3078 Just noticed a few visual discrepancies we have in the application on error states when I was walking through page by page comparing to SF, and fixing a bug for SF around showing error states in field labels.

To test: Walk through the application and at every page, try to submit without filling anything out.
Ensure that when a required field is in an error state, that the field itself as well as its label is red.
Additionally, ensure that when data is entered into a field in an error state, that updating the field removes the error state.