### PR TITLE
refactor: update backend fields on afs

### DIFF
--- a/backend/core/src/application-flagged-sets/application-flagged-sets.service.ts
+++ b/backend/core/src/application-flagged-sets/application-flagged-sets.service.ts
@@ -116,6 +116,7 @@ export class ApplicationFlaggedSetsService {
         "applications.id",
         "applications.submissionType",
         "applications.confirmationCode",
+        "applications.reviewStatus",
         "applicant.firstName",
         "applicant.lastName",
         "applicant.birthDay",
@@ -142,6 +143,7 @@ export class ApplicationFlaggedSetsService {
     return await getManager().transaction("SERIALIZABLE", async (transactionalEntityManager) => {
       const transAfsRepository = transactionalEntityManager.getRepository(ApplicationFlaggedSet)
       const transApplicationsRepository = transactionalEntityManager.getRepository(Application)
+      // TODO: For each application, set it to the status on that application, then set the set status
       const afs = await this.findOneById(dto.afsId, dto.applications)
 
       if (afs.listing.status !== ListingStatus.closed) {

--- a/backend/core/src/application-flagged-sets/dto/application-flagged-set-resolve.dto.ts
+++ b/backend/core/src/application-flagged-sets/dto/application-flagged-set-resolve.dto.ts
@@ -1,8 +1,8 @@
 import { Expose, Type } from "class-transformer"
-import { ArrayMaxSize, IsArray, IsDefined, IsEnum, IsUUID, ValidateNested } from "class-validator"
+import { IsEnum, IsUUID, IsDefined, IsArray, ArrayMaxSize, ValidateNested } from "class-validator"
 import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enum"
-import { IdDto } from "../../shared/dto/id.dto"
-import { ApplicationReviewStatus } from "../../applications/types/application-review-status-enum"
+import { ApplicationResolve } from "../types/application-resolve"
+import { FlaggedSetStatus } from "../types/flagged-set-status-enum"
 
 export class ApplicationFlaggedSetResolveDto {
   @Expose()
@@ -14,10 +14,10 @@ export class ApplicationFlaggedSetResolveDto {
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(512, { groups: [ValidationsGroupsEnum.default] })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
-  @Type(() => IdDto)
-  applications: IdDto[]
+  @Type(() => ApplicationResolve)
+  applications: ApplicationResolve[]
 
   @Expose()
-  @IsEnum(ApplicationReviewStatus, { groups: [ValidationsGroupsEnum.default] })
-  reviewStatus: ApplicationReviewStatus
+  @IsEnum(FlaggedSetStatus, { groups: [ValidationsGroupsEnum.default] })
+  reviewStatus: FlaggedSetStatus
 }

--- a/backend/core/src/application-flagged-sets/types/application-resolve.ts
+++ b/backend/core/src/application-flagged-sets/types/application-resolve.ts
@@ -1,0 +1,15 @@
+import { Expose, Type } from "class-transformer"
+import { IsEnum } from "class-validator"
+import { ValidationsGroupsEnum } from "../../shared/types/validations-groups-enum"
+import { ApplicationReviewStatus } from "../../applications/types/application-review-status-enum"
+import { IdDto } from "src/shared/dto/id.dto"
+
+export class ApplicationResolve {
+  @Expose()
+  @Type(() => IdDto)
+  application: IdDto
+
+  @Expose()
+  @IsEnum(ApplicationReviewStatus, { groups: [ValidationsGroupsEnum.default] })
+  reviewStatus: ApplicationReviewStatus
+}

--- a/ui-components/src/tables/AgTable.tsx
+++ b/ui-components/src/tables/AgTable.tsx
@@ -32,6 +32,9 @@ export interface AgTableProps {
   pagination?: AgTablePagination
   search: AgTableSearch
   sort?: AgTableSort
+  // If using row selection, these two props are required
+  gridApi?: GridApi | null
+  setGridApi?: React.Dispatch<React.SetStateAction<GridApi | null>>
 }
 
 export interface AgTablePagination {
@@ -93,15 +96,17 @@ export const useAgTable = () => {
 }
 
 const AgTable = ({
-  id,
   className,
+  config: { gridComponents, columns, totalItemsLabel, rowSelection, setSelectedRows },
+  data,
+  gridApi,
+  headerContent,
+  hidePagination,
+  id,
   pagination,
   search: { setSearch, showSearch = true },
+  setGridApi,
   sort: { setSort } = {},
-  headerContent,
-  data,
-  config: { gridComponents, columns, totalItemsLabel, rowSelection, setSelectedRows },
-  hidePagination,
 }: AgTableProps) => {
   // local storage key with column state
   const columnStateLsKey = `column-state_${id}`
@@ -110,7 +115,6 @@ const AgTable = ({
   }
 
   const [gridColumnApi, setGridColumnApi] = useState<ColumnApi | null>(null)
-  const [gridApi, setGridApi] = useState<GridApi | null>(null)
 
   const [validSearch, setValidSearch] = useState<boolean>(true)
 
@@ -193,7 +197,9 @@ const AgTable = ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onGridReady = (params: any) => {
     setGridColumnApi(params.columnApi)
-    setGridApi(params.api)
+    if (setGridApi) {
+      setGridApi(params.api)
+    }
   }
 
   return (


### PR DESCRIPTION
@YazeedLoonat I think these might be the changes we need, will touch base offline

The current issues:

The `resolve` endpoint as is takes in the set id, an array of application ids, and an applications status. The issue I'm running into is on the frontend, when I'm in the `save` modal, the information I have that I want to save is (1) an array of applications with a status on each one mapping to whether or not it is checked, and (2) a status on the set, mapping to which radio in the modal is selected.

With the current endpoint I can only set an array of applications to one status. I'd have to make two calls, to gather the selected rows and the unselected rows to set their statuses, in case I had unchecked a row. I also need to be able to update the status of the set.

Let me know what you think! I added in a piece of the frontend which calls the resolve endpoint so we can test some of it in the browser.

This PR targets: https://github.com/bloom-housing/bloom/pull/3058