### PR TITLE
chore: add tests back to eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,5 @@ module.exports = {
     "migration/",
     "**/*.stories.tsx",
     "**/.eslintrc.js",
-    "**/*.test.*",
   ],
 }

--- a/shared-helpers/__tests__/RequireLogin.test.tsx
+++ b/shared-helpers/__tests__/RequireLogin.test.tsx
@@ -10,7 +10,7 @@ import { GenericRouter, NavigationContext } from "@bloom-housing/ui-components"
 const mockRouter: GenericRouter = {
   pathname: "",
   asPath: "",
-  back: () => {},
+  back: jest.fn(),
   push(url: string) {
     this.pathname = url
     this.asPath = url
@@ -80,7 +80,7 @@ const itShouldNotRenderChildren = () =>
 
 const itShouldRedirect = () =>
   test("it should redirect", () => {
-    const { container, getByText } = render(
+    render(
       <NavigationContext.Provider
         value={{
           router: mockRouter,
@@ -99,7 +99,7 @@ const itShouldRedirect = () =>
 
 const itShouldNotRedirect = () =>
   test("it should not redirect", () => {
-    const { container, getByText } = render(
+    render(
       <NavigationContext.Provider
         value={{
           router: mockRouter,

--- a/shared-helpers/__tests__/Timeout.test.tsx
+++ b/shared-helpers/__tests__/Timeout.test.tsx
@@ -6,7 +6,7 @@ import { AuthContext } from "../src/AuthContext"
 afterEach(cleanup)
 
 describe("<Timeout>", () => {
-  it("creates element if user is logged in", async () => {
+  it("creates element if user is logged in", () => {
     const onTimeoutSpy = jest.fn()
     const anchorMocked = document.createElement("div")
     const createElementSpy = jest.spyOn(document, "createElement").mockReturnValueOnce(anchorMocked)
@@ -27,7 +27,7 @@ describe("<Timeout>", () => {
             passwordValidForDays: 180,
             agreedToTermsOfService: true,
           },
-          signOut: () => {},
+          signOut: jest.fn(),
         }}
       >
         <LoggedInUserIdleTimeout onTimeout={onTimeoutSpy} />
@@ -37,14 +37,14 @@ describe("<Timeout>", () => {
     createElementSpy.mockRestore()
   })
 
-  it("does not create element if user is not logged in", async () => {
+  it("does not create element if user is not logged in", () => {
     const onTimeoutSpy = jest.fn()
     const anchorMocked = document.createElement("div")
     const createElementSpy = jest.spyOn(document, "createElement").mockReturnValueOnce(anchorMocked)
     render(
       <AuthContext.Provider
         value={{
-          signOut: () => {},
+          signOut: jest.fn(),
         }}
       >
         <LoggedInUserIdleTimeout onTimeout={onTimeoutSpy} />

--- a/sites/partners/__tests__/DatesFormatter.test.ts
+++ b/sites/partners/__tests__/DatesFormatter.test.ts
@@ -1,5 +1,5 @@
 import { TimeFieldPeriod } from "@bloom-housing/ui-components"
-import { createDate, createTime } from "../lib/helpers"
+import { createTime } from "../lib/helpers"
 import { YesNoAnswer } from "../src/applications/PaperApplicationForm/FormTypes"
 import DatesFormatter from "../src/listings/PaperListingForm/formatters/DatesFormatter"
 import { FormMetadata } from "../src/listings/PaperListingForm/formTypes"

--- a/ui-components/__tests__/blocks/ImageCard.test.tsx
+++ b/ui-components/__tests__/blocks/ImageCard.test.tsx
@@ -8,7 +8,7 @@ afterEach(cleanup)
 
 describe("<ImageCard>", () => {
   it("renders title, subtitle, image and alt text", () => {
-    const { getByText, getByAltText } = render(
+    const { getByAltText } = render(
       <ImageCard imageUrl={"/images/listing.jpg"} description={"A description of the image"} />
     )
 
@@ -79,7 +79,7 @@ describe("<ImageCard>", () => {
     portalRoot.setAttribute("id", "__next")
     document.body.appendChild(portalRoot)
 
-    const { getByAltText, getByTestId, container } = render(
+    const { getByAltText, getByTestId } = render(
       <ImageCard
         images={[
           { url: "/images/listing.jpg", description: "A description of the image" },

--- a/ui-components/__tests__/blocks/InfoCard.test.tsx
+++ b/ui-components/__tests__/blocks/InfoCard.test.tsx
@@ -26,7 +26,7 @@ describe("<InfoCard>", () => {
   })
 
   it("if children are JSX, render as inputted", () => {
-    const { container, debug } = render(
+    const { container } = render(
       <InfoCard title={"Info Card Title"} className={"custom-class"}>
         <div>Children go here</div>
       </InfoCard>

--- a/ui-components/__tests__/blocks/StandardCard.test.tsx
+++ b/ui-components/__tests__/blocks/StandardCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, fireEvent } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { StandardCard } from "../../src/blocks/StandardCard"
 import { Button } from "../../src/actions/Button"
 

--- a/ui-components/__tests__/blocks/StatusItem.test.tsx
+++ b/ui-components/__tests__/blocks/StatusItem.test.tsx
@@ -7,7 +7,7 @@ afterEach(cleanup)
 
 describe("<StatusItem>", () => {
   it("renders without error", () => {
-    const { getByText, queryByText } = render(
+    const { getByText } = render(
       <StatusItem
         applicationDueDate={"March 10th, 2022"}
         applicationURL={"application/1234abcd"}

--- a/ui-components/__tests__/forms/DOBField.test.tsx
+++ b/ui-components/__tests__/forms/DOBField.test.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form"
 afterEach(cleanup)
 // Could not figure out how to test the field validations from here given this documentation: https://react-hook-form.com/advanced-usage/#TestingForm
 const Optional = ({ disabled = false }) => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, watch, errors } = useForm({ mode: "onChange" })
   return (
     <DOBField

--- a/ui-components/__tests__/forms/DateField.test.tsx
+++ b/ui-components/__tests__/forms/DateField.test.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form"
 
 afterEach(cleanup)
 const Optional = ({ disabled = false }) => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, watch, errors } = useForm({ mode: "onChange" })
   return (
     <DateField

--- a/ui-components/__tests__/forms/Field.test.tsx
+++ b/ui-components/__tests__/forms/Field.test.tsx
@@ -1,11 +1,12 @@
 import React from "react"
-import { render, cleanup, fireEvent, getByPlaceholderText } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { Field } from "../../src/forms/Field"
 import { useForm } from "react-hook-form"
 
 afterEach(cleanup)
 
 const FieldDefault = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <Field register={register} name={"Test Input"} label={"Test Input Default"} type={"text"} />
@@ -13,6 +14,7 @@ const FieldDefault = () => {
 }
 
 const FieldError = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <Field
@@ -27,6 +29,7 @@ const FieldError = () => {
 }
 
 const FieldCustomProps = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <Field
@@ -46,6 +49,7 @@ const FieldCustomProps = () => {
 }
 
 const FieldCurrency = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, getValues, setValue } = useForm({ mode: "onChange" })
   return (
     <Field
@@ -74,11 +78,11 @@ describe("<Field>", () => {
     expect(getByText("Uh oh!")).toBeTruthy()
     expect(getByLabelText("Test Input Error")).toBeTruthy()
   })
-  it("can render custom state", async () => {
+  it("can render custom state", () => {
     const { getByLabelText } = render(<FieldCustomProps />)
     expect(getByLabelText("Test Input Custom")).toBeTruthy()
   })
-  it("can render currency field", async () => {
+  it("can render currency field", () => {
     const { getByText, getByLabelText, getByPlaceholderText } = render(<FieldCurrency />)
     expect(getByLabelText("Test Input Custom")).toBeTruthy()
     expect(getByText("$")).toBeTruthy()

--- a/ui-components/__tests__/forms/FieldGroup.test.tsx
+++ b/ui-components/__tests__/forms/FieldGroup.test.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form"
 afterEach(cleanup)
 
 const FieldGroupCustom = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <FieldGroup
@@ -26,6 +27,7 @@ const FieldGroupCustom = () => {
 }
 
 const FieldGroupError = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <FieldGroup
@@ -43,6 +45,7 @@ const FieldGroupError = () => {
 }
 
 const FieldGroupDefaultValues = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <FieldGroup
@@ -63,6 +66,7 @@ const FieldGroupDefaultValues = () => {
 }
 
 const FieldGroupSubfieldsUnchecked = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <FieldGroup
@@ -98,6 +102,7 @@ const FieldGroupSubfieldsUnchecked = () => {
 }
 
 const FieldGroupSubfieldsChecked = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <FieldGroup

--- a/ui-components/__tests__/forms/Form.test.tsx
+++ b/ui-components/__tests__/forms/Form.test.tsx
@@ -6,7 +6,7 @@ afterEach(cleanup)
 
 describe("<Form>", () => {
   it("renders without error", () => {
-    const { getByText } = render(<Form onSubmit={() => {}}>Children go here</Form>)
+    const { getByText } = render(<Form onSubmit={jest.fn()}>Children go here</Form>)
     expect(getByText("Children go here")).not.toBeNull()
   })
 })

--- a/ui-components/__tests__/forms/HouseholdMemberForm.test.tsx
+++ b/ui-components/__tests__/forms/HouseholdMemberForm.test.tsx
@@ -6,11 +6,7 @@ import { t } from "../../src/helpers/translator"
 afterEach(cleanup)
 
 describe("<HouseholdMemberForm>", () => {
-  const useContext = jest.spyOn(require("react"), "useContext")
-
   it("renders as a primary applicant", () => {
-    const router = { push: jest.fn().mockImplementation(() => Promise.resolve()) }
-    useContext.mockReturnValue({ router })
     global.scrollTo = jest.fn()
     const editMemberSpy = jest.fn()
 
@@ -29,8 +25,6 @@ describe("<HouseholdMemberForm>", () => {
     expect(editMemberSpy).toHaveBeenCalledTimes(1)
   })
   it("renders as a household member", () => {
-    const router = { push: jest.fn().mockImplementation(() => Promise.resolve()) }
-    useContext.mockReturnValue({ router })
     global.scrollTo = jest.fn()
     const editMemberSpy = jest.fn()
 

--- a/ui-components/__tests__/forms/HouseholdSizeField.test.tsx
+++ b/ui-components/__tests__/forms/HouseholdSizeField.test.tsx
@@ -7,11 +7,12 @@ import { t } from "../../src/helpers/translator"
 afterEach(cleanup)
 
 const DefaultHouseholdSize = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <HouseholdSizeField
       assistanceUrl={""}
-      clearErrors={() => {}}
+      clearErrors={jest.fn()}
       error={null}
       householdSize={3}
       householdSizeMax={3}
@@ -23,10 +24,12 @@ const DefaultHouseholdSize = () => {
 }
 
 type ErrorHouseholdSizeProps = {
-  clearErrorsSpy: jest.Mock<any, any>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  clearErrorsSpy: jest.Mock<unknown, any[]>
 }
 
 const ErrorHouseholdSize = (props: ErrorHouseholdSizeProps) => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <HouseholdSizeField

--- a/ui-components/__tests__/forms/MultiSelectField.test.tsx
+++ b/ui-components/__tests__/forms/MultiSelectField.test.tsx
@@ -14,6 +14,7 @@ for (let i = 0; i < 10; i++) {
 }
 
 const DefaultMultiSelectField = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, getValues, setValue } = useForm({ mode: "onChange" })
 
   return (

--- a/ui-components/__tests__/forms/Select.test.tsx
+++ b/ui-components/__tests__/forms/Select.test.tsx
@@ -8,6 +8,7 @@ afterEach(cleanup)
 const ethnicityKeys = ["hispanicLatino", "notHispanicLatino"]
 
 const DefaultSelect = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <Select
@@ -25,6 +26,7 @@ const DefaultSelect = () => {
 }
 
 const ErrorSelect = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm({ mode: "onChange" })
   return (
     <Select

--- a/ui-components/__tests__/forms/Textarea.test.tsx
+++ b/ui-components/__tests__/forms/Textarea.test.tsx
@@ -6,11 +6,13 @@ import { useForm } from "react-hook-form"
 afterEach(cleanup)
 
 const TextareaDefault = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm()
   return <Textarea name={"textarea-test"} label={"Textarea Label"} register={register} />
 }
 
 const TextareaCustom = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = useForm()
   return (
     <Textarea

--- a/ui-components/__tests__/forms/TimeField.test.tsx
+++ b/ui-components/__tests__/forms/TimeField.test.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form"
 afterEach(cleanup)
 
 const DefaultTimeField = () => {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, watch, errors } = useForm({ mode: "onChange" })
   return (
     <TimeField

--- a/ui-components/__tests__/headers/SiteHeader.test.tsx
+++ b/ui-components/__tests__/headers/SiteHeader.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, getByLabelText } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { SiteHeader } from "../../src/headers/SiteHeader"
 
 afterEach(cleanup)
@@ -44,7 +44,7 @@ describe("<SiteHeader>", () => {
               },
               {
                 title: "Sign Out",
-                onClick: () => {},
+                onClick: jest.fn(),
               },
             ],
           },

--- a/ui-components/__tests__/navigation/LanguageNav.test.tsx
+++ b/ui-components/__tests__/navigation/LanguageNav.test.tsx
@@ -10,12 +10,12 @@ describe("<LanguageNav>", () => {
       {
         label: "English",
         active: true,
-        onClick: () => {},
+        onClick: jest.fn(),
       },
       {
         label: "Spanish",
         active: false,
-        onClick: () => {},
+        onClick: jest.fn(),
       },
     ]
 

--- a/ui-components/__tests__/navigation/SideNav.test.tsx
+++ b/ui-components/__tests__/navigation/SideNav.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, fireEvent } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { SideNav } from "../../src/navigation/SideNav"
 
 afterEach(cleanup)

--- a/ui-components/__tests__/navigation/Tabs.test.tsx
+++ b/ui-components/__tests__/navigation/Tabs.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, fireEvent } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { Tabs, TabList, Tab, TabPanel } from "../../src/navigation/Tabs"
 
 afterEach(cleanup)

--- a/ui-components/__tests__/notifications/SiteAlert.test.tsx
+++ b/ui-components/__tests__/notifications/SiteAlert.test.tsx
@@ -9,6 +9,7 @@ describe("<SiteAlert>", () => {
     jest.spyOn(window.sessionStorage.__proto__, "setItem")
     window.sessionStorage.__proto__.setItem = jest.fn()
     setSiteAlertMessage("Alert Message Goes Here", "success")
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(sessionStorage.setItem).toHaveBeenCalledWith(
       "alert_message_success",
       "Alert Message Goes Here"

--- a/ui-components/__tests__/overlays/Drawer.test.tsx
+++ b/ui-components/__tests__/overlays/Drawer.test.tsx
@@ -13,7 +13,7 @@ describe("<Drawer>", () => {
       <Drawer
         open={true}
         title={"Drawer Title"}
-        onClose={() => {}}
+        onClose={jest.fn()}
         ariaDescription={"My Drawer"}
         actions={[<div key={0}>Action 1</div>, <div key={1}>Action 2</div>]}
       >
@@ -33,7 +33,7 @@ describe("<Drawer>", () => {
       <Drawer
         open={true}
         title={"Drawer Title"}
-        onClose={() => {}}
+        onClose={jest.fn()}
         ariaDescription={"My Drawer"}
         className={"custom-class"}
         direction={DrawerSide.left}

--- a/ui-components/__tests__/overlays/Modal.test.tsx
+++ b/ui-components/__tests__/overlays/Modal.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, getByTestId } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { Modal } from "../../src/overlays/Modal"
 
 afterEach(cleanup)
@@ -9,11 +9,11 @@ describe("<Modal>", () => {
     const portalRoot = document.createElement("div")
     portalRoot.setAttribute("id", "__next")
     document.body.appendChild(portalRoot)
-    const { getByText, debug, getByRole } = render(
+    const { getByText, getByRole } = render(
       <Modal
         open={true}
         title={"Modal Title"}
-        onClose={() => {}}
+        onClose={jest.fn()}
         ariaDescription={"My Modal"}
         actions={[<div key={0}>Action 1</div>, <div key={1}>Action 2</div>]}
       >
@@ -34,7 +34,7 @@ describe("<Modal>", () => {
       <Modal
         open={true}
         title={"Modal Title"}
-        onClose={() => {}}
+        onClose={jest.fn()}
         ariaDescription={"My Modal"}
         actions={[<div key={0}>Action 1</div>, <div key={1}>Action 2</div>]}
       >
@@ -52,7 +52,7 @@ describe("<Modal>", () => {
     portalRoot.setAttribute("id", "__next")
     document.body.appendChild(portalRoot)
     const { queryByTestId } = render(
-      <Modal open={true} title={"Modal Title"} onClose={() => {}} ariaDescription={"My Modal"}>
+      <Modal open={true} title={"Modal Title"} onClose={jest.fn()} ariaDescription={"My Modal"}>
         <strong>Modal Children</strong>
       </Modal>
     )

--- a/ui-components/__tests__/page_components/ContentAccordion.test.tsx
+++ b/ui-components/__tests__/page_components/ContentAccordion.test.tsx
@@ -13,7 +13,7 @@ describe("<ContentAccordion>", () => {
   }
 
   it("toggles content section", () => {
-    const { queryByText, getByTestId, debug } = render(
+    const { queryByText, getByTestId } = render(
       <ContentAccordion customBarContent={barContent()} customExpandedContent={expandedContent()} />
     )
     expect(queryByText("Header Content")).toBeTruthy()

--- a/ui-components/__tests__/page_components/ListingCard.test.tsx
+++ b/ui-components/__tests__/page_components/ListingCard.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, cleanup, getAllByText } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { ListingCard } from "../../src/page_components/listing/ListingCard"
 
 afterEach(cleanup)

--- a/ui-components/__tests__/page_components/ReferralApplication.test.tsx
+++ b/ui-components/__tests__/page_components/ReferralApplication.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { render, cleanup } from "@testing-library/react"
-import ReferralApplication from "../../src/page_components/listing/listing_sidebar/ReferralApplication"
+import { ReferralApplication } from "../../src/page_components/listing/listing_sidebar/ReferralApplication"
 
 afterEach(cleanup)
 

--- a/ui-components/__tests__/tables/AgTable.test.tsx
+++ b/ui-components/__tests__/tables/AgTable.test.tsx
@@ -141,7 +141,7 @@ describe("<AgTable>", () => {
     })
   })
 
-  it("renders loading overlay", async () => {
+  it("renders loading overlay", () => {
     const { getByTestId } = render(<AgTableComponent loading={true} />)
 
     const loadingOverlay = getByTestId("loading-overlay")

--- a/ui-components/__tests__/tables/StandardTable.test.tsx
+++ b/ui-components/__tests__/tables/StandardTable.test.tsx
@@ -28,14 +28,14 @@ const dataWithImage: StandardTableData = [...data]
 dataWithImage[0].image = {
   content: (
     <TableThumbnail>
-      <img src="/images/listing.jpg" />
+      <img src="/images/listing.jpg" alt="sample" />
     </TableThumbnail>
   ),
 }
 dataWithImage[1].image = {
   content: (
     <TableThumbnail>
-      <img src="/images/logo_glyph.svg" />
+      <img src="/images/logo_glyph.svg" alt="sample" />
     </TableThumbnail>
   ),
 }


### PR DESCRIPTION
Removing test files from the eslint task exclusion list. By doing that I needed to cleanup all warnings/errors from test files that fail. 

Most common errors fixed:
- Empty arrow functions
- unused imports/ variables
- useForm being unbound - I just suppressed this like how it is being done in actual code
