### PR TITLE
feat: new listing type field

### DIFF
--- a/backend/core/src/email/email.service.ts
+++ b/backend/core/src/email/email.service.ts
@@ -148,14 +148,14 @@ export class EmailService {
       eligibleText = this.polyglot.t("confirmation.eligible.fcfs")
       preferenceText = this.polyglot.t("confirmation.eligible.fcfsPreference")
     }
+    if (listing.reviewOrderType === ListingReviewOrder.lottery) {
+      eligibleText = this.polyglot.t("confirmation.eligible.lottery")
+      preferenceText = this.polyglot.t("confirmation.eligible.lotteryPreference")
+    }
     if (listing.reviewOrderType === ListingReviewOrder.waitlist) {
       eligibleText = this.polyglot.t("confirmation.eligible.waitlist")
       contactText = this.polyglot.t("confirmation.eligible.waitlistContact")
       preferenceText = this.polyglot.t("confirmation.eligible.waitlistPreference")
-    }
-    if (listing.reviewOrderType === ListingReviewOrder.lottery) {
-      eligibleText = this.polyglot.t("confirmation.eligible.lottery")
-      preferenceText = this.polyglot.t("confirmation.eligible.lotteryPreference")
     }
 
     const user = {

--- a/backend/core/src/email/email.service.ts
+++ b/backend/core/src/email/email.service.ts
@@ -6,7 +6,6 @@ import Handlebars from "handlebars"
 import path from "path"
 import Polyglot from "node-polyglot"
 import fs from "fs"
-import dayjs from "dayjs"
 import { ConfigService } from "@nestjs/config"
 import { TranslationsService } from "../translations/services/translations.service"
 import { JurisdictionResolverService } from "../jurisdictions/services/jurisdiction-resolver.service"
@@ -18,7 +17,6 @@ import { Jurisdiction } from "../jurisdictions/entities/jurisdiction.entity"
 import { Language } from "../shared/types/language-enum"
 import { JurisdictionsService } from "../jurisdictions/services/jurisdictions.service"
 import { Translation } from "../translations/entities/translation.entity"
-import { ListingAvailability } from "../listings/types/listing-availability-enum"
 
 @Injectable({ scope: Scope.REQUEST })
 export class EmailService {
@@ -150,7 +148,7 @@ export class EmailService {
       eligibleText = this.polyglot.t("confirmation.eligible.fcfs")
       preferenceText = this.polyglot.t("confirmation.eligible.fcfsPreference")
     }
-    if (listing.listingAvailability === ListingAvailability.openWaitlist) {
+    if (listing.reviewOrderType === ListingReviewOrder.waitlist) {
       eligibleText = this.polyglot.t("confirmation.eligible.waitlist")
       contactText = this.polyglot.t("confirmation.eligible.waitlistContact")
       preferenceText = this.polyglot.t("confirmation.eligible.waitlistPreference")

--- a/backend/core/src/listings/dto/listing-published-create.dto.ts
+++ b/backend/core/src/listings/dto/listing-published-create.dto.ts
@@ -20,7 +20,6 @@ import { OmitType } from "@nestjs/swagger"
 import { UnitCreateDto } from "../../units/dto/unit-create.dto"
 import { EnforceLowerCase } from "../../shared/decorators/enforceLowerCase.decorator"
 import { ListingImageUpdateDto } from "./listing-image-update.dto"
-import { ListingAvailability } from "../types/listing-availability-enum"
 
 export class ListingPublishedCreateDto extends OmitType(ListingCreateDto, [
   "assets",
@@ -39,7 +38,6 @@ export class ListingPublishedCreateDto extends OmitType(ListingCreateDto, [
   "rentalAssistance",
   "reviewOrderType",
   "units",
-  "listingAvailability",
 ] as const) {
   @Expose()
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
@@ -76,10 +74,6 @@ export class ListingPublishedCreateDto extends OmitType(ListingCreateDto, [
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => ListingImageUpdateDto)
   images: ListingImageUpdateDto[]
-
-  @Expose()
-  @IsEnum(ListingAvailability, { groups: [ValidationsGroupsEnum.default] })
-  listingAvailability: ListingAvailability | null
 
   @Expose()
   @IsEmail({}, { groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/src/listings/dto/listing-published-update.dto.ts
+++ b/backend/core/src/listings/dto/listing-published-update.dto.ts
@@ -20,7 +20,6 @@ import { AssetUpdateDto } from "../../assets/dto/asset.dto"
 import { UnitUpdateDto } from "../../units/dto/unit-update.dto"
 import { EnforceLowerCase } from "../../shared/decorators/enforceLowerCase.decorator"
 import { ListingImageUpdateDto } from "./listing-image-update.dto"
-import { ListingAvailability } from "../types/listing-availability-enum"
 
 export class ListingPublishedUpdateDto extends OmitType(ListingUpdateDto, [
   "assets",
@@ -39,7 +38,6 @@ export class ListingPublishedUpdateDto extends OmitType(ListingUpdateDto, [
   "rentalAssistance",
   "reviewOrderType",
   "units",
-  "listingAvailability",
 ] as const) {
   @Expose()
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
@@ -76,10 +74,6 @@ export class ListingPublishedUpdateDto extends OmitType(ListingUpdateDto, [
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => ListingImageUpdateDto)
   images: ListingImageUpdateDto[]
-
-  @Expose()
-  @IsEnum(ListingAvailability, { groups: [ValidationsGroupsEnum.default] })
-  listingAvailability: ListingAvailability | null
 
   @Expose()
   @IsEmail({}, { groups: [ValidationsGroupsEnum.default] })

--- a/backend/core/src/listings/entities/listing.entity.ts
+++ b/backend/core/src/listings/entities/listing.entity.ts
@@ -43,7 +43,6 @@ import { ApplicationMethod } from "../../application-methods/entities/applicatio
 import { UnitsSummarized } from "../../units/types/units-summarized"
 import { UnitsSummary } from "../../units-summary/entities/units-summary.entity"
 import { ListingReviewOrder } from "../types/listing-review-order-enum"
-import { ListingAvailability } from "../types/listing-availability-enum"
 import { ApplicationMethodDto } from "../../application-methods/dto/application-method.dto"
 import { ApplicationMethodType } from "../../application-methods/types/application-method-type-enum"
 import { ListingFeatures } from "./listing-features.entity"
@@ -519,16 +518,6 @@ class Listing extends BaseEntity {
     enumName: "ListingReviewOrder",
   })
   reviewOrderType?: ListingReviewOrder | null
-
-  @Column({ type: "enum", enum: ListingAvailability, nullable: true })
-  @Expose()
-  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @IsEnum(ListingAvailability, { groups: [ValidationsGroupsEnum.default] })
-  @ApiProperty({
-    enum: ListingAvailability,
-    enumName: "ListingAvailability",
-  })
-  listingAvailability?: ListingAvailability | null
 
   @Expose()
   applicationConfig?: Record<string, unknown>

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -6,7 +6,7 @@ import { Interval } from "@nestjs/schedule"
 import { Listing } from "./entities/listing.entity"
 import { getView } from "./views/view"
 import { summarizeUnits, summarizeUnitsByTypeAndRent } from "../shared/units-transformations"
-import { Language, ListingAvailability } from "../../types"
+import { Language, ListingReviewOrder } from "../../types"
 import { AmiChart } from "../ami-charts/entities/ami-chart.entity"
 import { ListingCreateDto } from "./dto/listing-create.dto"
 import { ListingUpdateDto } from "./dto/listing-update.dto"
@@ -111,9 +111,7 @@ export class ListingsService {
     await this.authorizeUserActionForListingId(this.req.user, listing.id, authzActions.update)
 
     const availableUnits =
-      listingDto.listingAvailability === ListingAvailability.availableUnits
-        ? listingDto.units.length
-        : 0
+      listingDto.reviewOrderType !== ListingReviewOrder.waitlist ? listingDto.units.length : 0
     listingDto.units.forEach((unit) => {
       if (!unit.id) {
         delete unit.id

--- a/backend/core/src/listings/types/listing-availability-enum.ts
+++ b/backend/core/src/listings/types/listing-availability-enum.ts
@@ -1,4 +1,0 @@
-export enum ListingAvailability {
-  availableUnits = "availableUnits",
-  openWaitlist = "openWaitlist",
-}

--- a/backend/core/src/listings/types/listing-review-order-enum.ts
+++ b/backend/core/src/listings/types/listing-review-order-enum.ts
@@ -1,4 +1,5 @@
 export enum ListingReviewOrder {
   lottery = "lottery",
   firstComeFirstServe = "firstComeFirstServe",
+  waitlist = "waitlist",
 }

--- a/backend/core/src/listings/views/config.ts
+++ b/backend/core/src/listings/views/config.ts
@@ -52,7 +52,6 @@ const views: Views = {
       "listingImagesImage.id",
       "listingImagesImage.fileId",
       "listingImagesImage.label",
-      "listings.listingAvailability",
       "utilities.id",
       "utilities.water",
       "utilities.gas",

--- a/backend/core/src/migration/1663959354563-new-listing-type-enum.ts
+++ b/backend/core/src/migration/1663959354563-new-listing-type-enum.ts
@@ -1,0 +1,61 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class newListingTypeEnum1663959354563 implements MigrationInterface {
+  name = "newListingTypeEnum1663959354563"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."listings_review_order_type_enum" RENAME TO "listings_review_order_type_enum_old"`
+    )
+    await queryRunner.query(
+      `CREATE TYPE "public"."listings_review_order_type_enum" AS ENUM('lottery', 'firstComeFirstServe', 'waitlist')`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "listings" ALTER COLUMN "review_order_type" TYPE "public"."listings_review_order_type_enum" USING "review_order_type"::"text"::"public"."listings_review_order_type_enum"`
+    )
+    await queryRunner.query(`DROP TYPE "public"."listings_review_order_type_enum_old"`)
+
+    const listings = await queryRunner.query(`SELECT * FROM listings`)
+
+    for (const l of listings) {
+      if (l.listing_availability === "openWaitlist") {
+        await queryRunner.query(`UPDATE listings SET review_order_type = ($1) WHERE id = ($2)`, [
+          "waitlist",
+          l.id,
+        ])
+      }
+    }
+    await queryRunner.query(`ALTER TABLE "listings" DROP COLUMN "listing_availability"`)
+    await queryRunner.query(`DROP TYPE "public"."listings_listing_availability_enum"`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "listings" ADD "listing_availability" "public"."listings_listing_availability_enum"`
+    )
+    await queryRunner.query(
+      `CREATE TYPE "public"."listings_listing_availability_enum" AS ENUM('availableUnits', 'openWaitlist')`
+    )
+    const listings = await queryRunner.query(`SELECT * FROM listings`)
+
+    for (const l of listings) {
+      if (l.review_order_type === "waitlist") {
+        await queryRunner.query(`UPDATE listings SET listing_availability = ($1) WHERE id = ($2)`, [
+          "openWaitlist",
+          l.id,
+        ])
+      }
+    }
+
+    await queryRunner.query(
+      `CREATE TYPE "public"."listings_review_order_type_enum_old" AS ENUM('lottery', 'firstComeFirstServe')`
+    )
+    await queryRunner.query(
+      `ALTER TABLE "listings" ALTER COLUMN "review_order_type" TYPE "public"."listings_review_order_type_enum_old" USING "review_order_type"::"text"::"public"."listings_review_order_type_enum_old"`
+    )
+    await queryRunner.query(`DROP TYPE "public"."listings_review_order_type_enum"`)
+    await queryRunner.query(
+      `ALTER TYPE "public"."listings_review_order_type_enum_old" RENAME TO "listings_review_order_type_enum"`
+    )
+  }
+}

--- a/backend/core/src/migration/1663959354563-new-listing-type-enum.ts
+++ b/backend/core/src/migration/1663959354563-new-listing-type-enum.ts
@@ -15,7 +15,7 @@ export class newListingTypeEnum1663959354563 implements MigrationInterface {
     )
     await queryRunner.query(`DROP TYPE "public"."listings_review_order_type_enum_old"`)
 
-    const listings = await queryRunner.query(`SELECT * FROM listings`)
+    const listings = await queryRunner.query(`SELECT id, listing_availability FROM listings`)
 
     for (const l of listings) {
       if (l.listing_availability === "openWaitlist") {
@@ -36,7 +36,7 @@ export class newListingTypeEnum1663959354563 implements MigrationInterface {
     await queryRunner.query(
       `CREATE TYPE "public"."listings_listing_availability_enum" AS ENUM('availableUnits', 'openWaitlist')`
     )
-    const listings = await queryRunner.query(`SELECT * FROM listings`)
+    const listings = await queryRunner.query(`SELECT id, review_order_type FROM listings`)
 
     for (const l of listings) {
       if (l.review_order_type === "waitlist") {

--- a/backend/core/src/seeder/seeds/listings/listing-coliseum-seed.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-coliseum-seed.ts
@@ -17,7 +17,6 @@ import { ListingReviewOrder } from "../../../listings/types/listing-review-order
 import { ListingStatus } from "../../../listings/types/listing-status-enum"
 import { UnitCreateDto } from "../../../units/dto/unit-create.dto"
 import { Listing } from "../../../listings/entities/listing.entity"
-import { ListingAvailability } from "../../../listings/types/listing-availability-enum"
 
 const coliseumListing: ListingSeedType = {
   jurisdictionName: "Alameda",
@@ -107,7 +106,6 @@ const coliseumListing: ListingSeedType = {
   waitlistOpenSpots: 3000,
   isWaitlistOpen: true,
   whatToExpect: null,
-  listingAvailability: ListingAvailability.availableUnits,
   utilities: {
     water: false,
     gas: false,

--- a/backend/core/src/seeder/seeds/listings/listing-triton-seed.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-triton-seed.ts
@@ -7,7 +7,6 @@ import { ListingReviewOrder } from "../../../listings/types/listing-review-order
 import { ListingStatus } from "../../../listings/types/listing-status-enum"
 import { UnitCreateDto } from "../../../units/dto/unit-create.dto"
 import { Listing } from "../../../listings/entities/listing.entity"
-import { ListingAvailability } from "../../../listings/types/listing-availability-enum"
 import { classToClass } from "class-transformer"
 import dayjs from "dayjs"
 
@@ -96,7 +95,6 @@ const tritonListing: ListingSeedType = {
   waitlistOpenSpots: 200,
   isWaitlistOpen: true,
   whatToExpect: null,
-  listingAvailability: ListingAvailability.availableUnits,
   utilities: {
     water: true,
     gas: true,

--- a/backend/core/src/seeder/seeds/listings/shared.ts
+++ b/backend/core/src/seeder/seeds/listings/shared.ts
@@ -13,7 +13,6 @@ import { UserCreateDto } from "../../../auth/dto/user-create.dto"
 import { CountyCode } from "../../../shared/types/county-code"
 import { ListingReviewOrder } from "../../../listings/types/listing-review-order-enum"
 import { ListingStatus } from "../../../listings/types/listing-status-enum"
-import { ListingAvailability } from "../../../listings/types/listing-availability-enum"
 import { ApplicationSection } from "../../../multiselect-question/types/multiselect-application-section-enum"
 export const getDate = (days: number) => {
   const someDate = new Date()
@@ -220,7 +219,6 @@ export const defaultListing: ListingSeedType = {
   isWaitlistOpen: false,
   waitlistMaxSize: null,
   whatToExpect: "Custom what to expect text",
-  listingAvailability: ListingAvailability.availableUnits,
 }
 
 // Preferences

--- a/backend/core/src/shared/units-transformations.ts
+++ b/backend/core/src/shared/units-transformations.ts
@@ -10,7 +10,7 @@ import { AmiChart } from "../ami-charts/entities/ami-chart.entity"
 import { AmiChartItem } from "../ami-charts/entities/ami-chart-item.entity"
 import { UnitAmiChartOverride } from "../units/entities/unit-ami-chart-override.entity"
 import { Listing } from "../listings/entities/listing.entity"
-import { ListingAvailability } from "../listings/types/listing-availability-enum"
+import { ListingReviewOrder } from "../listings/types/listing-review-order-enum"
 
 export type AnyDict = { [key: string]: unknown }
 type Units = Unit[]
@@ -335,7 +335,7 @@ export const summarizeUnitsByTypeAndRent = (units: Units, listing: Listing): Uni
     const finalSummary = unitMap[key].reduce((summary, unit, index) => {
       return getUnitsSummary(unit, index === 0 ? null : summary)
     }, {} as UnitSummary)
-    if (listing.listingAvailability === ListingAvailability.availableUnits) {
+    if (listing.reviewOrderType !== ListingReviewOrder.waitlist) {
       finalSummary.totalAvailable = unitMap[key].length
     }
     summaries.push(finalSummary)

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -4821,9 +4821,6 @@ export interface Listing {
   reviewOrderType?: ListingReviewOrder
 
   /**  */
-  listingAvailability?: ListingAvailability
-
-  /**  */
   showWaitlist: boolean
 
   /**  */
@@ -5260,9 +5257,6 @@ export interface ListingCreate {
   reviewOrderType?: ListingReviewOrder
 
   /**  */
-  listingAvailability?: ListingAvailability
-
-  /**  */
   applicationMethods: ApplicationMethodCreate[]
 
   /**  */
@@ -5658,9 +5652,6 @@ export interface ListingUpdate {
 
   /**  */
   reviewOrderType?: ListingReviewOrder
-
-  /**  */
-  listingAvailability?: ListingAvailability
 
   /**  */
   id?: string
@@ -6238,11 +6229,7 @@ export enum ListingStatus {
 export enum ListingReviewOrder {
   "lottery" = "lottery",
   "firstComeFirstServe" = "firstComeFirstServe",
-}
-
-export enum ListingAvailability {
-  "availableUnits" = "availableUnits",
-  "openWaitlist" = "openWaitlist",
+  "waitlist" = "waitlist",
 }
 
 export enum ListingEventType {

--- a/shared-helpers/src/summaryTables.tsx
+++ b/shared-helpers/src/summaryTables.tsx
@@ -7,7 +7,7 @@ import {
   ContentAccordion,
   getTranslationWithArguments,
 } from "@bloom-housing/ui-components"
-import { MinMax, UnitSummary, Unit, ListingAvailability } from "@bloom-housing/backend-core/types"
+import { MinMax, UnitSummary, Unit, ListingReviewOrder } from "@bloom-housing/backend-core/types"
 
 const getTranslationFromCurrencyString = (value: string) => {
   if (value.startsWith("t.")) return getTranslationWithArguments(value)
@@ -16,7 +16,7 @@ const getTranslationFromCurrencyString = (value: string) => {
 
 export const unitSummariesTable = (
   summaries: UnitSummary[],
-  listingAvailability: ListingAvailability
+  listingReviewOrder: ListingReviewOrder
 ): StandardTableData => {
   const unitSummaries = summaries?.map((unitSummary) => {
     const unitPluralization =
@@ -63,7 +63,7 @@ export const unitSummariesTable = (
       : getRent(unitSummary.rentRange.min, unitSummary.rentRange.max)
 
     let availability = null
-    if (listingAvailability === ListingAvailability.availableUnits) {
+    if (listingReviewOrder !== ListingReviewOrder.waitlist) {
       availability = (
         <span>
           {unitSummary.totalAvailable > 0 ? (
@@ -77,7 +77,7 @@ export const unitSummariesTable = (
           )}
         </span>
       )
-    } else if (listingAvailability === ListingAvailability.openWaitlist) {
+    } else if (listingReviewOrder === ListingReviewOrder.waitlist) {
       availability = (
         <span>
           <strong>{t("listings.waitlist.open")}</strong>
@@ -104,12 +104,12 @@ export const unitSummariesTable = (
 
 export const getSummariesTable = (
   summaries: UnitSummary[],
-  listingAvailability: ListingAvailability
+  listingReviewOrder: ListingReviewOrder
 ): StandardTableData => {
   let unitSummaries: StandardTableData = []
 
   if (summaries?.length > 0) {
-    unitSummaries = unitSummariesTable(summaries, listingAvailability)
+    unitSummaries = unitSummariesTable(summaries, listingReviewOrder)
   }
   return unitSummaries
 }

--- a/sites/partners/__tests__/PaperListingForm/sections/DetailUnits.test.tsx
+++ b/sites/partners/__tests__/PaperListingForm/sections/DetailUnits.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, within } from "@testing-library/react"
 import { DetailUnits } from "../../../src/listings/PaperListingDetails/sections/DetailUnits"
 import { ListingContext } from "../../../src/listings/ListingContext"
 import { listing, unit } from "../../testHelpers"
-import { ListingAvailability } from "@bloom-housing/backend-core"
+import { ListingReviewOrder } from "@bloom-housing/backend-core"
 
 describe("DetailUnits", () => {
   it("should render the detail units when no units exist", () => {
@@ -32,7 +32,7 @@ describe("DetailUnits", () => {
       <ListingContext.Provider
         value={{
           ...listing,
-          listingAvailability: ListingAvailability.availableUnits,
+          reviewOrderType: ListingReviewOrder.firstComeFirstServe,
           disableUnitsAccordion: true,
         }}
       >

--- a/sites/partners/__tests__/PaperListingForm/sections/DetailUnits.test.tsx
+++ b/sites/partners/__tests__/PaperListingForm/sections/DetailUnits.test.tsx
@@ -8,7 +8,9 @@ import { ListingReviewOrder } from "@bloom-housing/backend-core"
 describe("DetailUnits", () => {
   it("should render the detail units when no units exist", () => {
     const results = render(
-      <ListingContext.Provider value={{ ...listing, units: [] }}>
+      <ListingContext.Provider
+        value={{ ...listing, reviewOrderType: ListingReviewOrder.waitlist, units: [] }}
+      >
         <DetailUnits setUnitDrawer={jest.fn()} />
       </ListingContext.Provider>
     )

--- a/sites/partners/__tests__/testHelpers.ts
+++ b/sites/partners/__tests__/testHelpers.ts
@@ -1,7 +1,6 @@
 import {
   ApplicationSection,
   Listing,
-  ListingAvailability,
   ListingReviewOrder,
   ListingStatus,
   MultiselectQuestion,
@@ -98,7 +97,6 @@ export const unit: Unit = {
 
 export const listing: Listing = {
   id: "Uvbk5qurpB2WI9V6WnNdH",
-  listingAvailability: ListingAvailability.openWaitlist,
   applicationConfig: undefined,
   applicationOpenDate: new Date("2019-12-31T15:22:57.000-07:00"),
   applicationPickUpAddress: undefined,

--- a/sites/partners/cypress/integration/03-listing.spec.ts
+++ b/sites/partners/cypress/integration/03-listing.spec.ts
@@ -198,7 +198,6 @@ describe("Listing Management Tests", () => {
       cy.get("#specialNotes").contains(listing["specialNotes"])
       cy.get("#reviewOrderQuestion").contains("First come first serve")
       cy.get("#dueDateQuestion").contains("No")
-      cy.getByID("waitlist.openQuestion").contains("No")
       cy.get("#whatToExpect").contains(
         "Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents."
       )

--- a/sites/partners/pages/_app.tsx
+++ b/sites/partners/pages/_app.tsx
@@ -33,11 +33,11 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
   }, [locale])
 
   useEffect(() => {
-    // if (process.env.NODE_ENV !== "production") {
-    //   // eslint-disable-next-line @typescript-eslint/no-var-requires
-    //   const axe = require("@axe-core/react")
-    //   void axe(React, ReactDOM, 1000)
-    // }
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const axe = require("@axe-core/react")
+      void axe(React, ReactDOM, 1000)
+    }
   }, [])
 
   return (

--- a/sites/partners/pages/_app.tsx
+++ b/sites/partners/pages/_app.tsx
@@ -33,11 +33,11 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
   }, [locale])
 
   useEffect(() => {
-    if (process.env.NODE_ENV !== "production") {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const axe = require("@axe-core/react")
-      void axe(React, ReactDOM, 1000)
-    }
+    // if (process.env.NODE_ENV !== "production") {
+    //   // eslint-disable-next-line @typescript-eslint/no-var-requires
+    //   const axe = require("@axe-core/react")
+    //   void axe(React, ReactDOM, 1000)
+    // }
   }, [])
 
   return (

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -26,13 +26,15 @@ const DetailRankingsAndResults = () => {
       grid={false}
       inset
     >
-      <GridSection columns={2}>
-        <ViewItem id="reviewOrderQuestion" label={t("listings.reviewOrderQuestion")}>
-          {getReviewOrderType() === ListingReviewOrder.firstComeFirstServe
-            ? t("listings.firstComeFirstServe")
-            : t("listings.lotteryTitle")}
-        </ViewItem>
-      </GridSection>
+      {listing.reviewOrderType !== ListingReviewOrder.waitlist && (
+        <GridSection columns={2}>
+          <ViewItem id="reviewOrderQuestion" label={t("listings.reviewOrderQuestion")}>
+            {getReviewOrderType() === ListingReviewOrder.firstComeFirstServe
+              ? t("listings.firstComeFirstServe")
+              : t("listings.lotteryTitle")}
+          </ViewItem>
+        </GridSection>
+      )}
       {lotteryEvent && (
         <>
           <GridSection columns={3}>

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -62,18 +62,21 @@ const DetailRankingsAndResults = () => {
           </ViewItem>
         </GridSection>
       )}
-      <GridSection columns={2}>
-        <ViewItem id="waitlist.openQuestion" label={t("listings.waitlist.openQuestion")}>
-          {getDetailBoolean(listing.isWaitlistOpen)}
-        </ViewItem>
-      </GridSection>
-      {listing.isWaitlistOpen && (
-        <GridSection columns={3}>
-          <ViewItem id="waitlistOpenSpots" label={t("listings.waitlist.openSize")}>
-            {getDetailFieldNumber(listing.waitlistOpenSpots)}
-          </ViewItem>
-        </GridSection>
+      {listing.reviewOrderType === ListingReviewOrder.waitlist && (
+        <>
+          <GridSection columns={2}>
+            <ViewItem id="waitlist.openQuestion" label={t("listings.waitlist.openQuestion")}>
+              {getDetailBoolean(listing.isWaitlistOpen)}
+            </ViewItem>
+          </GridSection>
+          <GridSection columns={3}>
+            <ViewItem id="waitlistOpenSpots" label={t("listings.waitlist.openSize")}>
+              {getDetailFieldNumber(listing.waitlistOpenSpots)}
+            </ViewItem>
+          </GridSection>
+        </>
       )}
+
       <GridSection columns={1}>
         <GridCell>
           <ViewItem id="whatToExpect" label={t("listings.whatToExpectLabel")}>

--- a/sites/partners/src/listings/PaperListingDetails/sections/DetailUnits.tsx
+++ b/sites/partners/src/listings/PaperListingDetails/sections/DetailUnits.tsx
@@ -9,7 +9,7 @@ import {
 } from "@bloom-housing/ui-components"
 import { ListingContext } from "../../ListingContext"
 import { UnitDrawer } from "../DetailsUnitDrawer"
-import { ListingAvailability } from "@bloom-housing/backend-core"
+import { ListingReviewOrder } from "@bloom-housing/backend-core"
 
 type DetailUnitsProps = {
   setUnitDrawer: (unit: UnitDrawer) => void
@@ -54,9 +54,9 @@ const DetailUnits = ({ setUnitDrawer }: DetailUnitsProps) => {
   )
 
   const listingAvailabilityText = useMemo(() => {
-    if (listing.listingAvailability === ListingAvailability.availableUnits) {
+    if (listing.reviewOrderType !== ListingReviewOrder.waitlist) {
       return t("listings.availableUnits")
-    } else if (listing.listingAvailability === ListingAvailability.openWaitlist) {
+    } else if (listing.reviewOrderType === ListingReviewOrder.waitlist) {
       return t("listings.waitlist.open")
     }
     return t("t.none")

--- a/sites/partners/src/listings/PaperListingForm/formTypes.ts
+++ b/sites/partners/src/listings/PaperListingForm/formTypes.ts
@@ -158,7 +158,6 @@ export const formDefaults: FormListing = {
   urlSlug: undefined,
   showWaitlist: false,
   reviewOrderType: null,
-  listingAvailability: null,
   unitsSummary: [],
   unitsSummarized: {
     unitTypes: [],

--- a/sites/partners/src/listings/PaperListingForm/formatters/AdditionalMetadataFormatter.ts
+++ b/sites/partners/src/listings/PaperListingForm/formatters/AdditionalMetadataFormatter.ts
@@ -50,7 +50,6 @@ export default class AdditionalMetadataFormatter extends Formatter {
         ? ListingReviewOrder.lottery
         : ListingReviewOrder.firstComeFirstServe
 
-    console.log(this.data)
     if (this.data.listingAvailabilityQuestion === "openWaitlist") {
       this.data.reviewOrderType = ListingReviewOrder.waitlist
     }

--- a/sites/partners/src/listings/PaperListingForm/formatters/AdditionalMetadataFormatter.ts
+++ b/sites/partners/src/listings/PaperListingForm/formatters/AdditionalMetadataFormatter.ts
@@ -1,4 +1,4 @@
-import { ListingReviewOrder, ListingAvailability } from "@bloom-housing/backend-core/types"
+import { ListingReviewOrder } from "@bloom-housing/backend-core/types"
 import { listingFeatures, listingUtilities } from "@bloom-housing/shared-helpers"
 import Formatter from "./Formatter"
 
@@ -50,11 +50,11 @@ export default class AdditionalMetadataFormatter extends Formatter {
         ? ListingReviewOrder.lottery
         : ListingReviewOrder.firstComeFirstServe
 
-    if (this.data.listingAvailabilityQuestion === "availableUnits") {
-      this.data.listingAvailability = ListingAvailability.availableUnits
-    } else if (this.data.listingAvailabilityQuestion === "openWaitlist") {
-      this.data.listingAvailability = ListingAvailability.openWaitlist
+    console.log(this.data)
+    if (this.data.listingAvailabilityQuestion === "openWaitlist") {
+      this.data.reviewOrderType = ListingReviewOrder.waitlist
     }
+
     this.data.features = listingFeatures.reduce((acc, current) => {
       return {
         ...acc,

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -84,6 +84,8 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
     }) ?? []
   )
 
+  console.log(listing)
+
   const [latLong, setLatLong] = useState<LatitudeLongitude>({
     latitude: listing?.buildingAddress?.latitude ?? null,
     longitude: listing?.buildingAddress?.longitude ?? null,

--- a/sites/partners/src/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/listings/PaperListingForm/index.tsx
@@ -84,8 +84,6 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
     }) ?? []
   )
 
-  console.log(listing)
-
   const [latLong, setLatLong] = useState<LatitudeLongitude>({
     latitude: listing?.buildingAddress?.latitude ?? null,
     longitude: listing?.buildingAddress?.longitude ?? null,

--- a/sites/partners/src/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -72,31 +72,33 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
         title={t("listings.sections.rankingsResultsTitle")}
         description={t("listings.sections.rankingsResultsSubtitle")}
       >
-        <GridSection columns={2} className={"flex items-center"}>
-          <GridCell>
-            <p className="field-label m-4 ml-0">{t("listings.reviewOrderQuestion")}</p>
-            <FieldGroup
-              name="reviewOrderQuestion"
-              type="radio"
-              register={register}
-              fields={[
-                {
-                  label: t("listings.firstComeFirstServe"),
-                  value: "reviewOrderFCFS",
-                  id: "reviewOrderFCFS",
-                  defaultChecked:
-                    listing?.reviewOrderType === ListingReviewOrder.firstComeFirstServe,
-                },
-                {
-                  label: t("listings.lotteryTitle"),
-                  value: "reviewOrderLottery",
-                  id: "reviewOrderLottery",
-                  defaultChecked: listing?.reviewOrderType === ListingReviewOrder.lottery,
-                },
-              ]}
-            />
-          </GridCell>
-        </GridSection>
+        {availabilityQuestion !== "openWaitlist" && (
+          <GridSection columns={2} className={"flex items-center"}>
+            <GridCell>
+              <p className="field-label m-4 ml-0">{t("listings.reviewOrderQuestion")}</p>
+              <FieldGroup
+                name="reviewOrderQuestion"
+                type="radio"
+                register={register}
+                fields={[
+                  {
+                    label: t("listings.firstComeFirstServe"),
+                    value: "reviewOrderFCFS",
+                    id: "reviewOrderFCFS",
+                    defaultChecked:
+                      listing?.reviewOrderType === ListingReviewOrder.firstComeFirstServe,
+                  },
+                  {
+                    label: t("listings.lotteryTitle"),
+                    value: "reviewOrderLottery",
+                    id: "reviewOrderLottery",
+                    defaultChecked: listing?.reviewOrderType === ListingReviewOrder.lottery,
+                  },
+                ]}
+              />
+            </GridCell>
+          </GridSection>
+        )}
         {reviewOrder === "reviewOrderFCFS" && (
           <GridSection columns={2} className={"flex items-center"}>
             <GridCell>

--- a/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/Units.tsx
@@ -18,7 +18,7 @@ import UnitForm from "../UnitForm"
 import { useFormContext, useWatch } from "react-hook-form"
 import { TempUnit } from "../formTypes"
 import { fieldHasError, fieldMessage } from "../../../../lib/helpers"
-import { ListingAvailability } from "@bloom-housing/backend-core/types"
+import { ListingReviewOrder } from "@bloom-housing/backend-core"
 
 type UnitProps = {
   units: TempUnit[]
@@ -194,15 +194,14 @@ const FormUnits = ({ units, setUnits, disableUnitsAccordion }: UnitProps) => {
                   value: "availableUnits",
                   id: "availableUnits",
                   dataTestId: "listingAvailability.availableUnits",
-                  defaultChecked:
-                    listing?.listingAvailability === ListingAvailability.availableUnits,
+                  defaultChecked: listing?.reviewOrderType !== ListingReviewOrder.waitlist,
                 },
                 {
                   label: t("listings.waitlist.open"),
                   value: "openWaitlist",
                   id: "openWaitlist",
                   dataTestId: "listingAvailability.openWaitlist",
-                  defaultChecked: listing?.listingAvailability === ListingAvailability.openWaitlist,
+                  defaultChecked: listing?.reviewOrderType === ListingReviewOrder.waitlist,
                 },
               ]}
             />

--- a/sites/public/lib/helpers.tsx
+++ b/sites/public/lib/helpers.tsx
@@ -5,7 +5,6 @@ import {
   ListingReviewOrder,
   UnitsSummarized,
   ListingStatus,
-  ListingAvailability,
 } from "@bloom-housing/backend-core/types"
 import {
   t,
@@ -52,10 +51,10 @@ const getListingCardSubtitle = (address: Address) => {
 
 const getListingTableData = (
   unitsSummarized: UnitsSummarized,
-  listingAvailability: ListingAvailability
+  listingReviewOrder: ListingReviewOrder
 ) => {
   return unitsSummarized !== undefined
-    ? getSummariesTable(unitsSummarized.byUnitTypeAndRent, listingAvailability)
+    ? getSummariesTable(unitsSummarized.byUnitTypeAndRent, listingReviewOrder)
     : []
 }
 
@@ -113,13 +112,13 @@ export const getListings = (listings) => {
   }
 
   const generateTableSubHeader = (listing) => {
-    if (listing.listingAvailability === ListingAvailability.availableUnits) {
+    if (listing.reviewOrderType !== ListingReviewOrder.waitlist) {
       return {
         content: t("listings.availableUnits"),
         styleType: AppearanceStyleType.success,
         isPillType: true,
       }
-    } else if (listing.listingAvailability === ListingAvailability.openWaitlist) {
+    } else if (listing.reviewOrderType === ListingReviewOrder.waitlist) {
       return {
         content: t("listings.waitlist.open"),
         styleType: AppearanceStyleType.primary,
@@ -147,7 +146,7 @@ export const getListings = (listings) => {
         }}
         tableProps={{
           headers: unitSummariesHeaders,
-          data: getListingTableData(listing.unitsSummarized, listing.listingAvailability),
+          data: getListingTableData(listing.unitsSummarized, listing.reviewOrderType),
           responsiveCollapse: true,
           cellClassName: "px-5 py-3",
         }}

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -9,9 +9,9 @@ import {
   ApplicationMethod,
   ApplicationMethodType,
   ListingStatus,
-  ListingAvailability,
   Jurisdiction,
   ApplicationSection,
+  ListingReviewOrder,
 } from "@bloom-housing/backend-core/types"
 import {
   AdditionalFees,
@@ -131,7 +131,7 @@ export const ListingView = (props: ListingProps) => {
   if (amiValues.length == 1) {
     groupedUnits = getSummariesTable(
       listing.unitsSummarized.byUnitTypeAndRent,
-      listing.listingAvailability
+      listing.reviewOrderType
     )
   } // else condition is handled inline below
 
@@ -411,15 +411,15 @@ export const ListingView = (props: ListingProps) => {
     return (
       <QuantityRowSection
         quantityRows={
-          listing.listingAvailability === ListingAvailability.openWaitlist ? waitlistRow : unitRow
+          listing.reviewOrderType === ListingReviewOrder.waitlist ? waitlistRow : unitRow
         }
         strings={{
           sectionTitle:
-            listing.listingAvailability === ListingAvailability.openWaitlist
+            listing.reviewOrderType === ListingReviewOrder.waitlist
               ? t("listings.waitlist.isOpen")
               : t("listings.vacantUnitsAvailable"),
           description:
-            listing.listingAvailability === ListingAvailability.openWaitlist
+            listing.reviewOrderType === ListingReviewOrder.waitlist
               ? t("listings.waitlist.submitForWaitlist")
               : t("listings.availableUnitsDescription"),
         }}
@@ -546,7 +546,7 @@ export const ListingView = (props: ListingProps) => {
               })
 
               groupedUnits = byAMI
-                ? getSummariesTable(byAMI.byUnitType, listing.listingAvailability)
+                ? getSummariesTable(byAMI.byUnitType, listing.reviewOrderType)
                 : []
 
               return (


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3081

- [x] This change addresses the issue in full

## Description

At the moment for all the what to expect updates that are based on this new "3 types of listings" model, we are checking 2 different fields in order to determine the full listing’s type which has 3 distinct categories (fcfs, lottery, waitlist) ([slack context](https://exygy.slack.com/archives/C01Q4QG5R8Q/p1663353081218739?thread_ts=1663342872.080439&cid=C01Q4QG5R8Q)). At the moment we have to check `listingAvailability` to see if that is `openWaitlist` and also `reviewOrderType` to see if that's `fcfs` or `lottery`.

We want to consolidate the unit waitlist question with the rankings and results question so we have one field we have to check for listing type, and also disable the lottery/fcfs question if waitlist is selected for units so that we cannot have overlapping states.

## How Can This Be Tested/Reviewed?

In a listing, ensure if you select `open waitlist` on the units section radio that the `fcfs/lottery` question in the rankings and results section no longer appears, and that setting it to `open waitlist` sets the `reviewOrderType` field on the listing.

There are two pieces on a listing view on the public side that uptake this field, which is the quantity row section in the right panel and the summary table (screenshots below, it should still appropriately reflect the waitlist vs available units state).

<img width="353" alt="Screen Shot 2022-09-27 at 2 55 05 PM" src="https://user-images.githubusercontent.com/65367387/192612239-b984107f-d69a-4445-9a2c-84e592441118.png">
<img width="656" alt="Screen Shot 2022-09-27 at 2 55 09 PM" src="https://user-images.githubusercontent.com/65367387/192612241-99995fef-4a3d-42eb-8d59-ecf42f89d7dc.png">


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
