### PR TITLE
fix: heading size issues on resources page

### DIFF
--- a/ui-components/src/sections/InfoCardGrid.scss
+++ b/ui-components/src/sections/InfoCardGrid.scss
@@ -1,5 +1,5 @@
 .info-cards__header {
-  @apply mb-3;
+  @apply my-3;
 
   @screen md {
     margin-right: 1rem;

--- a/ui-components/src/sections/InfoCardGrid.tsx
+++ b/ui-components/src/sections/InfoCardGrid.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Heading } from "../headers/Heading"
 import "./InfoCardGrid.scss"
 
 export interface InfoCardGridProps {
@@ -10,7 +11,9 @@ export interface InfoCardGridProps {
 const InfoCardGrid = (props: InfoCardGridProps) => (
   <section className="info-cards">
     <header className="info-cards__header">
-      <h2 className="info-cards__title">{props.title}</h2>
+      <Heading style={"sidebarHeader"} priority={2} className={"text-tiny"}>
+        {props.title}
+      </Heading>
       {props.subtitle && <p className="info-cards__subtitle">{props.subtitle}</p>}
     </header>
     <div className="info-cards__grid">{props.children}</div>


### PR DESCRIPTION
Pulling [this](https://github.com/housingbayarea/bloom/pull/494) fix into core - it was a hotfix so no issue was created, happy to make one though!