### PR TITLE
fix: duplicates ux issues

### DIFF
--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -52,6 +52,8 @@
   "application.details.workInRegion": "Work in Region",
   "applications.allApplications": "All Applications",
   "applications.duplicate": "Duplicate",
+  "applications.duplicatesAlert": "Preview applications that are pending review. Duplicates can be resolved when applications close.",
+  "applications.duplicatesAlertDate": "Preview applications that are pending review. Duplicates can be resolved when applications close on %{date}.",
   "applications.duplicates.duplicateApplications": "Duplicate Applications",
   "applications.duplicates.validApplications": "Valid Applications",
   "applications.duplicates.duplicateGroup": "Duplicate group",

--- a/sites/partners/pages/application/[id]/applicationsCols.tsx
+++ b/sites/partners/pages/application/[id]/applicationsCols.tsx
@@ -16,7 +16,11 @@ export const getCols = () => [
     checkboxSelection: true,
     cellRendererFramework: ({ data }) => {
       if (!data?.id && !data?.confirmationCode) return ""
-      return <Link href={`/application/${data.id}`}>{data.confirmationCode || data.id}</Link>
+      return (
+        <span className={"text-blue-900"}>
+          <Link href={`/application/${data.id}`}>{data.confirmationCode || data.id}</Link>
+        </span>
+      )
     },
     width: 180,
   },

--- a/sites/partners/pages/listings/[id]/applications/pending/index.tsx
+++ b/sites/partners/pages/listings/[id]/applications/pending/index.tsx
@@ -157,11 +157,11 @@ const ApplicationsList = () => {
               <div className="w-full">
                 {isListingOpen && (
                   <AlertBox type="notice" className="mb-3" customIcon={"lock"} closeable>
-                    Preview applications that are pending review. Duplicates can be resolved when
-                    applications close
-                    {listingDto?.applicationDueDate &&
-                      ` on ${formatDateTime(listingDto.applicationDueDate, true)}`}
-                    .
+                    {listingDto?.applicationDueDate
+                      ? t("applications.duplicatesAlertDate", {
+                          date: formatDateTime(listingDto.applicationDueDate, true),
+                        })
+                      : t("applications.duplicatesAlert")}
                   </AlertBox>
                 )}
                 <AgTable

--- a/ui-components/src/global/vendor/ag_grid.scss
+++ b/ui-components/src/global/vendor/ag_grid.scss
@@ -11,6 +11,12 @@
     )
   );
 
+  --ag-selected-row-background-color: var(--bloom-color-primary-light);
+
+  a {
+    color: var(--bloom-color-primary-dark);
+  }
+
   .ag-row {
     height: ag-param(row-height);
   }


### PR DESCRIPTION
Two small frontend issues from the duplicates bash
(1) Use a translation string for the closed listing alert
(2) Accessibility color contrast issue on the application link when the row is selected