### PR TITLE
feat: adds setsAfsLastRunAt1664300247901 migration

### DIFF
--- a/backend/core/src/migration/1664300247901-setsAfsLastRunAt.ts
+++ b/backend/core/src/migration/1664300247901-setsAfsLastRunAt.ts
@@ -1,0 +1,15 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class setsAfsLastRunAt1664300247901 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE listings
+            SET afs_last_run_at = $1
+        `, [new Date()])
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
This sets the afsLastRunAt to "now" so that we don't have re-process everything.