### PR TITLE
fix: change the cron job logging level

### DIFF
--- a/backend/core/src/application-flagged-sets/application-flagged-sets-cronjob-consumer.ts
+++ b/backend/core/src/application-flagged-sets/application-flagged-sets-cronjob-consumer.ts
@@ -23,7 +23,7 @@ export class ApplicationFlaggedSetsCronjobConsumer {
 
   @Process({ concurrency: 1 })
   async process() {
-    this.logger.log("running the Application flagged sets cron job")
+    this.logger.warn("running the Application flagged sets cron job")
     const outOfDateListings = await this.listingRepository
       .createQueryBuilder("listings")
       .select(["listings.id", "listings.afsLastRunAt"])
@@ -37,7 +37,7 @@ export class ApplicationFlaggedSetsCronjobConsumer {
       )
       .getMany()
 
-    this.logger.log(`updating the flagged sets for ${outOfDateListings.length} listings`)
+    this.logger.warn(`updating the flagged sets for ${outOfDateListings.length} listings`)
     for (const outOfDateListing of outOfDateListings) {
       try {
         await this.generateAFSesForListingRules(outOfDateListing)

--- a/backend/core/src/listings/listings-cron.service.ts
+++ b/backend/core/src/listings/listings-cron.service.ts
@@ -13,7 +13,7 @@ export class ListingsCronService {
 
   @Interval(1000 * 60 * 60)
   public async changeOverdueListingsStatusCron() {
-    this.logger.log("changeOverdueListingsStatusCron job running")
+    this.logger.warn("changeOverdueListingsStatusCron job running")
     const listings = await this.listingRepository
       .createQueryBuilder("listings")
       .select(["listings.id", "listings.applicationDueDate", "listings.status"])
@@ -28,6 +28,6 @@ export class ListingsCronService {
     }
 
     await this.listingRepository.save(listings)
-    this.logger.log(`Changed the status of ${listings?.length} listings`)
+    this.logger.warn(`Changed the status of ${listings?.length} listings`)
   }
 }

--- a/backend/core/src/shared/shared.module.ts
+++ b/backend/core/src/shared/shared.module.ts
@@ -27,7 +27,7 @@ import Joi from "joi"
         TWILIO_PHONE_NUMBER: Joi.string().default("dummy_phone_number"),
         AUTH_LOCK_LOGIN_AFTER_FAILED_ATTEMPTS: Joi.number().default(5),
         AUTH_LOCK_LOGIN_COOLDOWN_MS: Joi.number().default(1000 * 60 * 30),
-        AFS_PROCESSING_CRON_STRING: Joi.string().default("0 * * * *"), // Setting to every hour for testing purposes
+        AFS_PROCESSING_CRON_STRING: Joi.string().default("0 0 * * *"),
       }),
     }),
   ],


### PR DESCRIPTION
The changeOverdueListingsStatusCron in the listings cron service is actually running, but the logging level of non-local development is just "warn" and "error". So this PR changes the logging level for the two cron jobs from "log" to "warn".

Still digging into why the other cron job is not working. I believe it is related to redis, but by having this logging level correct we will know if it is getting triggered