### PR TITLE
feat: add startDate field to listing events

### DIFF
--- a/backend/core/src/listings/entities/listing-event.entity.ts
+++ b/backend/core/src/listings/entities/listing-event.entity.ts
@@ -22,6 +22,13 @@ export class ListingEvent extends AbstractEntity {
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsDate({ groups: [ValidationsGroupsEnum.default] })
   @Type(() => Date)
+  startDate?: Date
+
+  @Column({ type: "timestamptz", nullable: true })
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsDate({ groups: [ValidationsGroupsEnum.default] })
+  @Type(() => Date)
   startTime?: Date
 
   @Column({ type: "timestamptz", nullable: true })

--- a/backend/core/src/migration/1668076003953-add-start-date.ts
+++ b/backend/core/src/migration/1668076003953-add-start-date.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class addStartDate1668076003953 implements MigrationInterface {
+  name = "addStartDate1668076003953"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "listing_events" ADD "start_date" TIMESTAMP WITH TIME ZONE`
+    )
+    await queryRunner.query(`UPDATE "listing_events" SET "start_date" = "start_time"`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "listing_events" DROP COLUMN "start_date"`)
+  }
+}

--- a/backend/core/src/seeder/seeds/listings/listing-default-lottery-pending.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-default-lottery-pending.ts
@@ -13,6 +13,7 @@ export class ListingDefaultLotteryPending extends ListingDefaultSeed {
       events: [
         {
           startTime: getDate(10),
+          startDate: getDate(10),
           endTime: getDate(10),
           note:
             "Custom public lottery event note. This is a long note and should take up more space.",
@@ -22,11 +23,13 @@ export class ListingDefaultLotteryPending extends ListingDefaultSeed {
         },
         {
           startTime: getDate(15),
+          startDate: getDate(15),
           endTime: getDate(15),
           type: ListingEventType.openHouse,
         },
         {
           startTime: getDate(20),
+          startDate: getDate(20),
           endTime: getDate(20),
           note: "Custom open house event note",
           type: ListingEventType.openHouse,
@@ -35,6 +38,7 @@ export class ListingDefaultLotteryPending extends ListingDefaultSeed {
         },
         {
           startTime: getDate(-10),
+          startDate: getDate(-10),
           endTime: getDate(-10),
           type: ListingEventType.publicLottery,
           url: "https://www.example2.com",
@@ -42,6 +46,7 @@ export class ListingDefaultLotteryPending extends ListingDefaultSeed {
         },
         {
           startTime: getDate(15),
+          startDate: getDate(15),
           endTime: getDate(15),
           type: ListingEventType.lotteryResults,
           label: "Custom Event URL Label",

--- a/backend/core/src/seeder/seeds/listings/listing-default-lottery-results.ts
+++ b/backend/core/src/seeder/seeds/listings/listing-default-lottery-results.ts
@@ -13,6 +13,7 @@ export class ListingDefaultLottery extends ListingDefaultSeed {
       events: [
         {
           startTime: getDate(10),
+          startDate: getDate(10),
           endTime: getDate(10),
           note:
             "Custom public lottery event note. This is a long note and should take up more space.",
@@ -22,11 +23,13 @@ export class ListingDefaultLottery extends ListingDefaultSeed {
         },
         {
           startTime: getDate(15),
+          startDate: getDate(15),
           endTime: getDate(15),
           type: ListingEventType.openHouse,
         },
         {
           startTime: getDate(20),
+          startDate: getDate(20),
           endTime: getDate(20),
           note: "Custom open house event note",
           type: ListingEventType.openHouse,
@@ -35,6 +38,7 @@ export class ListingDefaultLottery extends ListingDefaultSeed {
         },
         {
           startTime: getDate(10),
+          startDate: getDate(10),
           endTime: getDate(10),
           type: ListingEventType.publicLottery,
           url: "https://www.example2.com",
@@ -42,6 +46,7 @@ export class ListingDefaultLottery extends ListingDefaultSeed {
         },
         {
           startTime: getDate(15),
+          startDate: getDate(15),
           endTime: getDate(15),
           type: ListingEventType.lotteryResults,
           url: "https://www.example2.com",

--- a/backend/core/src/seeder/seeds/listings/shared.ts
+++ b/backend/core/src/seeder/seeds/listings/shared.ts
@@ -38,6 +38,7 @@ export function getDefaultListingEvents() {
 export const defaultListingEvents: Array<ListingEventCreateDto> = [
   {
     startTime: getDate(10),
+    startDate: getDate(10),
     endTime: getDate(10),
     note: "Custom open house event note",
     type: ListingEventType.openHouse,
@@ -46,6 +47,7 @@ export const defaultListingEvents: Array<ListingEventCreateDto> = [
   },
   {
     startTime: getDate(10),
+    startDate: getDate(10),
     endTime: getDate(10),
     note: "Custom public lottery event note",
     type: ListingEventType.publicLottery,

--- a/backend/core/types/src/backend-swagger.ts
+++ b/backend/core/types/src/backend-swagger.ts
@@ -4431,6 +4431,9 @@ export interface ListingEvent {
   updatedAt: Date
 
   /**  */
+  startDate?: Date
+
+  /**  */
   startTime?: Date
 
   /**  */
@@ -5090,6 +5093,9 @@ export interface ListingEventCreate {
 
   /**  */
   file?: AssetCreate
+
+  /**  */
+  startDate?: Date
 
   /**  */
   startTime?: Date

--- a/shared-helpers/src/events.ts
+++ b/shared-helpers/src/events.ts
@@ -2,6 +2,6 @@ import { Listing, ListingEvent, ListingEventType } from "@bloom-housing/backend-
 
 export const getLotteryEvent = (listing: Listing): ListingEvent | undefined => {
   return listing?.events.find(
-    (event) => event.type === ListingEventType.publicLottery && event.startTime
+    (event) => event.type === ListingEventType.publicLottery && event.startDate
   )
 }

--- a/shared-helpers/src/stringFormatting.ts
+++ b/shared-helpers/src/stringFormatting.ts
@@ -2,8 +2,10 @@ import dayjs from "dayjs"
 
 export const getTimeRangeString = (start: Date, end: Date) => {
   const startTime = dayjs(start).format("hh:mma")
+  const startString = start ? startTime : ""
   const endTime = dayjs(end).format("hh:mma")
-  return startTime === endTime ? startTime : `${startTime} - ${endTime}`
+  const endString = end && start ? ` - ${endTime}` : ""
+  return startTime === endTime ? startString : `${startString}${endString}`
 }
 
 export const getCurrencyRange = (min: number | null, max: number | null) => {

--- a/sites/partners/src/listings/PaperListingForm/formatters/EventsFormatter.ts
+++ b/sites/partners/src/listings/PaperListingForm/formatters/EventsFormatter.ts
@@ -26,6 +26,11 @@ export default class EventsFormatter extends Formatter {
       events.push({
         type: ListingEventType.publicLottery,
         startTime: createTime(createDate(this.data.lotteryDate), this.data.lotteryStartTime),
+        startDate: createTime(createDate(this.data.lotteryDate), {
+          hours: "12",
+          minutes: "00",
+          period: "pm",
+        }),
         endTime: createTime(createDate(this.data.lotteryDate), this.data.lotteryEndTime),
         note: this.data.lotteryDateNotes,
       })

--- a/sites/partners/src/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -134,14 +134,14 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
                   register={register}
                   watch={watch}
                   defaultDate={{
-                    month: lotteryEvent?.startTime
-                      ? dayjs(new Date(lotteryEvent?.startTime)).utc().format("MM")
+                    month: lotteryEvent?.startDate
+                      ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("MM")
                       : null,
-                    day: lotteryEvent?.startTime
-                      ? dayjs(new Date(lotteryEvent?.startTime)).utc().format("DD")
+                    day: lotteryEvent?.startDate
+                      ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("DD")
                       : null,
-                    year: lotteryEvent?.startTime
-                      ? dayjs(new Date(lotteryEvent?.startTime)).utc().format("YYYY")
+                    year: lotteryEvent?.startDate
+                      ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("YYYY")
                       : null,
                   }}
                 />

--- a/sites/public/src/ListingView.tsx
+++ b/sites/public/src/ListingView.tsx
@@ -69,7 +69,6 @@ interface ListingProps {
 export const ListingView = (props: ListingProps) => {
   let buildingSelectionCriteria, preferencesSection
   const { listing } = props
-
   const {
     content: appStatusContent,
     subContent: appStatusSubContent,
@@ -206,7 +205,7 @@ export const ListingView = (props: ListingProps) => {
   const getEvent = (event: ListingEvent, note?: string | React.ReactNode): EventType => {
     return {
       timeString: getTimeRangeString(event.startTime, event.endTime),
-      dateString: dayjs(event.startTime).format("MMMM D, YYYY"),
+      dateString: dayjs(event.startDate).format("MMMM D, YYYY"),
       linkURL: event.url,
       linkText: event.label || t("listings.openHouseEvent.seeVideo"),
       note: note || event.note,
@@ -237,7 +236,7 @@ export const ListingView = (props: ListingProps) => {
 
   let lotterySection
   if (publicLottery && (!lotteryResults || (lotteryResults && !lotteryResults.url))) {
-    lotterySection = (
+    lotterySection = publicLottery.startDate && (
       <EventSection
         headerText={t("listings.publicLottery.header")}
         sectionHeader={true}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3130

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Date and time was stored in one field `startTime` i separated it to `startDate` for just date, and `startTime` for just time. 

## How Can This Be Tested/Reviewed?

Pick one listing and set its application process to lottery. Check if you can pass each date/ time field in section separately (so after saving and going back it will be there). Check public lottery section in public listing view, it should have few states:
- hidden - when no date, start time, and end time irrelevant.
- display only date - date filed, no start time, end time irrelevant
- display date + start time - date filled, only start time (or start time and end time same)
- display date + start time + end time - all filled

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
