### PR TITLE
feat: get rid of ui-component prerelease

### DIFF
--- a/.github/workflows/release_components.yml
+++ b/.github/workflows/release_components.yml
@@ -1,9 +1,9 @@
 name: Pre-release ui-components
 
 on:
-  # Triggers the workflow on push only for the dev branch
+  # Triggers the workflow on push only for the main branch
   push:
-    branches: [ dev ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -29,7 +29,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Version ui-components
-        run: yarn version:prerelease:ui-components
+        run: yarn version:ui-components
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Once staging has been QAed, we manually update `production`.
 
 ### Pull Requests
 
-Pull requests are opened to the dev branch, not to master. When opening a pull request please fill out the entire pull request template which includes tagging the issue your PR is related to, a description of your PR, indicating the type of change, including details for the reviewer about how to test your PR, and a testing checklist. Additionally, officially link the issue to the PR using GitHub's linking UI.
+Pull requests are opened to the main branch. When opening a pull request please fill out the entire pull request template which includes tagging the issue your PR is related to, a description of your PR, indicating the type of change, including details for the reviewer about how to test your PR, and a testing checklist. Additionally, officially link the issue to the PR using GitHub's linking UI.
 
 When your PR is ready for review, add the `needs review(s)` label to help surface it to our internal team. You can assign people as reviewers to surface the work further. If you put up a PR that is not yet ready for eyes, add the `wip` label.
 


### PR DESCRIPTION
This triggers the release step on merges to the `main` branch. Currently releases are currently only made when things get merged to `dev`. However, with the change of not using the dev branch we need to change it to the `main` branch. Along with this we also want to not do the pre-release and instead just do a full release of ui-components when a change is merged