### PR TITLE
fix: support jsx in EventSection, QuantityRowSection

### DIFF
--- a/ui-components/src/page_components/listing/listing_sidebar/QuantityRowSection.stories.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/QuantityRowSection.stories.tsx
@@ -73,8 +73,8 @@ export const CustomDescription = () => {
   const customDescription = () => {
     return (
       <div>
-        <div className={"italic pb-2"}>Custom styled content.</div>
-        <div className={"underline"}>More custom styled content.</div>
+        <p className={"italic pb-2"}>Custom styled content.</p>
+        <p className={"underline"}>More custom styled content.</p>
       </div>
     )
   }

--- a/ui-components/src/page_components/listing/listing_sidebar/QuantityRowSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/QuantityRowSection.tsx
@@ -39,7 +39,13 @@ const QuantityRowSection = ({ quantityRows, strings }: QuantityRowSectionProps) 
       </Heading>
       <div>
         {strings.description && (
-          <p className="text-tiny text-gray-800 pb-3">{strings.description}</p>
+          <>
+            {typeof strings.description === "string" ? (
+              <p>{strings.description}</p>
+            ) : (
+              strings.description
+            )}
+          </>
         )}
         {quantityRows.length && <ul>{quantityRows.map((row) => getRow(row))}</ul>}
       </div>

--- a/ui-components/src/page_components/listing/listing_sidebar/QuantityRowSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/QuantityRowSection.tsx
@@ -39,13 +39,13 @@ const QuantityRowSection = ({ quantityRows, strings }: QuantityRowSectionProps) 
       </Heading>
       <div>
         {strings.description && (
-          <>
+          <div className="text-tiny text-gray-800 pb-3">
             {typeof strings.description === "string" ? (
               <p>{strings.description}</p>
             ) : (
               strings.description
             )}
-          </>
+          </div>
         )}
         {quantityRows.length && <ul>{quantityRows.map((row) => getRow(row))}</ul>}
       </div>

--- a/ui-components/src/page_components/listing/listing_sidebar/events/EventSection.stories.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/EventSection.stories.tsx
@@ -114,9 +114,9 @@ export const MultipleSections = () => {
 export const FragmentNote = () => {
   const note = () => {
     return (
-      <>
+      <p>
         I'm a <a href={"https://www.exygy.com"}>fragment note</a>.
-      </>
+      </p>
     )
   }
   const events: EventType[] = [

--- a/ui-components/src/page_components/listing/listing_sidebar/events/EventSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/EventSection.tsx
@@ -53,19 +53,11 @@ const EventSection = (props: EventSectionProps) => {
             </p>
           )}
           {event.note && (
-            <>
-              {typeof event.note === "string" ? (
-                <p
-                  className={`text-tiny text-gray-700 ${
-                    index !== props.events.length - 1 && "pb-3"
-                  }`}
-                >
-                  {event.note}
-                </p>
-              ) : (
-                event.note
-              )}
-            </>
+            <div
+              className={`text-tiny text-gray-700 ${index !== props.events.length - 1 && "pb-3"}`}
+            >
+              {typeof event.note === "string" ? <p>{event.note}</p> : event.note}
+            </div>
           )}
         </div>
       ))}

--- a/ui-components/src/page_components/listing/listing_sidebar/events/EventSection.tsx
+++ b/ui-components/src/page_components/listing/listing_sidebar/events/EventSection.tsx
@@ -53,9 +53,19 @@ const EventSection = (props: EventSectionProps) => {
             </p>
           )}
           {event.note && (
-            <p className={`text-tiny text-gray-700 ${index !== props.events.length - 1 && "pb-3"}`}>
-              {event.note}
-            </p>
+            <>
+              {typeof event.note === "string" ? (
+                <p
+                  className={`text-tiny text-gray-700 ${
+                    index !== props.events.length - 1 && "pb-3"
+                  }`}
+                >
+                  {event.note}
+                </p>
+              ) : (
+                event.note
+              )}
+            </>
           )}
         </div>
       ))}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3144

- [x] This change addresses the issue in full

## Description

At the moment in both of these components, we were allowing consumers to pass in custom JSX for certain props, but we were always nesting it in a `<p>` tag, which was causing nesting tag errors if the consumer content also contained `<p>` tags, so we needed to optionally render it with the tag only if the prop type is just a string.

## How Can This Be Tested/Reviewed?

Ensure existing stories have no visual regressions, and that the two custom content stories ([1](https://63729c3df23a7a000826ccf0--amazing-davinci-96c1cd.netlify.app/?path=/story/listing-sidebar-events-event-section--fragment-note) [2](https://63729c3df23a7a000826ccf0--amazing-davinci-96c1cd.netlify.app/?path=/story/listing-sidebar-quantity-row-section--custom-description)) also have no regressions or console errors (they have been updated to include `<p>` tags in the inner content).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
