### PR TITLE
refactor: table a11y dynamic linting until performance issues are resolved

### DIFF
--- a/sites/partners/pages/_app.tsx
+++ b/sites/partners/pages/_app.tsx
@@ -1,7 +1,6 @@
-import React, { useMemo, useEffect } from "react"
+import React, { useMemo } from "react"
 import { SWRConfig } from "swr"
 import type { AppProps } from "next/app"
-import ReactDOM from "react-dom"
 
 import "@bloom-housing/ui-components/src/global/css-imports.scss"
 import "@bloom-housing/ui-components/src/global/app-css.scss"
@@ -32,13 +31,14 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
     }
   }, [locale])
 
-  useEffect(() => {
-    if (process.env.NODE_ENV !== "production") {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const axe = require("@axe-core/react")
-      void axe(React, ReactDOM, 1000)
-    }
-  }, [])
+  // Investigating performance issues in #3051
+  // useEffect(() => {
+  //   if (process.env.NODE_ENV !== "production") {
+  //     // eslint-disable-next-line @typescript-eslint/no-var-requires
+  //     const axe = require("@axe-core/react")
+  //     void axe(React, ReactDOM, 1000)
+  //   }
+  // }, [])
 
   return (
     <SWRConfig

--- a/sites/public/pages/_app.tsx
+++ b/sites/public/pages/_app.tsx
@@ -2,7 +2,6 @@ import "@bloom-housing/ui-components/src/global/css-imports.scss"
 import "@bloom-housing/ui-components/src/global/app-css.scss"
 import React, { useEffect, useMemo, useState } from "react"
 import type { AppProps } from "next/app"
-import ReactDOM from "react-dom"
 import { addTranslation, GenericRouter, NavigationContext } from "@bloom-housing/ui-components"
 import {
   blankApplication,
@@ -64,13 +63,14 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
     }
   })
 
-  useEffect(() => {
-    if (process.env.NODE_ENV !== "production") {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const axe = require("@axe-core/react")
-      void axe(React, ReactDOM, 5000)
-    }
-  }, [])
+  // Investigating performance issues in #3051
+  // useEffect(() => {
+  //   if (process.env.NODE_ENV !== "production") {
+  //     // eslint-disable-next-line @typescript-eslint/no-var-requires
+  //     const axe = require("@axe-core/react")
+  //     void axe(React, ReactDOM, 5000)
+  //   }
+  // }, [])
 
   return (
     <NavigationContext.Provider


### PR DESCRIPTION
I mentioned this in standup ~2-3 weeks ago but the performance of the dynamic a11y linting we added is pretty significant in local development. #3051 was created but hasn't been prioritized. In the meantime I'd love to just comment it out to speed up local dev.