### PR TITLE
chore: run commit message formatter before linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "echo '\n(1) Linting...\n----------' && lint-staged && echo '\n(2) Verifying conventional commit format... \n   (If this fails, install commitizen and commit with 'git cz' to automate the formatting!)\n----------' && commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "echo '\n(1) Verifying conventional commit format... \n   (If this fails, install commitizen and commit with 'git cz' to automate the formatting!)\n----------' && commitlint -E HUSKY_GIT_PARAMS && echo '\n(2) Linting...\n----------' && lint-staged"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -92,8 +92,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "echo '\n(1) Linting...\n----------' && lint-staged",
-      "commit-msg": "echo '\n(2) Verifying conventional commit format... \n   (If this fails, install commitizen and commit with 'git cz' to automate the formatting!)\n----------' && commitlint -E HUSKY_GIT_PARAMS"
+      "commit-msg": "echo '\n(1) Linting...\n----------' && lint-staged && echo '\n(2) Verifying conventional commit format... \n   (If this fails, install commitizen and commit with 'git cz' to automate the formatting!)\n----------' && commitlint -E HUSKY_GIT_PARAMS"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Changes the order of our commit message linting - now runs the conventional commit formatter before the linter. Previously, if linting failed, sometimes the only way to get past [failures from ignored files](https://github.com/eslint/eslint/issues/15010) was to commit with `--no-verify` which then skipped the conventional commit check linter.

To test this, in a component file locally, add a variable you don't use and try to commit with a valid conventional commit formatted message. Linting should run and the commit should fail.

Then try to commit in a not-conventional-commit format w/out a lint error (i.e. just `test`) and that should fail.