### PR TITLE
fix: use translated labels on the progress bar when at the choose lan…

### DIFF
--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -109,15 +109,7 @@ const ApplicationChooseLanguage = () => {
         <ProgressNav
           currentPageSection={currentPageSection}
           completedSections={application.completedSections}
-          labels={
-            listing?.applicationConfig.sections || [
-              "You",
-              "Household",
-              "Income",
-              "Preferences",
-              "Review",
-            ]
-          }
+          labels={conductor.config.sections.map((label) => t(`t.${label}`))}
           mounted={OnClientSide()}
         />
       </FormCard>


### PR DESCRIPTION
…guage step

# Pull Request Template

## Issue Overview

This PR addresses a minor translation bug on the ProgressNav that was found while diving into #3221.

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Other instances of ProgressNav use the conductor to populate labels. this is the only one that got missed. [Example](https://github.com/bloom-housing/bloom/blob/dbe90d5d8749369b3757a9c78a155b306fa4b1a9/sites/public/src/pages/applications/household/members-info.tsx#L58).

## How Can This Be Tested/Reviewed?

Change language to non-English. Start an application on `main`, note that the first screen (choose language) has a progress nav in English

Change language to non-English. Start an application on this branch, note that the first screen (choose language) has a properly translated progress nav. You can also click to different languages and the progress nav will properly change as well.

![image](https://user-images.githubusercontent.com/10789523/215835248-0bcb00c3-71aa-4b4e-a093-2b3206658f1a.png)

![image](https://user-images.githubusercontent.com/10789523/215835228-ca9f257e-08d2-4b45-8bda-26bebd7fda2c.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
