### PR TITLE
fix: limit hmi table to min and max occupancy

### DIFF
--- a/backend/core/src/shared/units-transformations.spec.ts
+++ b/backend/core/src/shared/units-transformations.spec.ts
@@ -1,63 +1,202 @@
 import { AmiChart } from "../ami-charts/entities/ami-chart.entity"
 import { UnitAmiChartOverride } from "../units/entities/unit-ami-chart-override.entity"
-import { mergeAmiChartWithOverrides } from "./units-transformations"
-import { Language } from "./types/language-enum"
+import { generateHmiData, mergeAmiChartWithOverrides } from "./units-transformations"
+import { Unit } from "../units/entities/unit.entity"
+import { AmiChartItem } from "../ami-charts/entities/ami-chart-item.entity"
+
+const defaultValues = {
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const unit: Unit = {
+  ...defaultValues,
+  id: "unit1",
+  listing: null,
+  amiChartId: "ami1",
+  amiPercentage: "30",
+  maxOccupancy: 2,
+}
+
+const generateAmiChartItems = (
+  maxHousehold: number,
+  percentage: number,
+  baseAmount: number
+): AmiChartItem[] => {
+  return [...Array(maxHousehold).keys()].map((value: number) => {
+    return {
+      percentOfAmi: percentage,
+      householdSize: value + 1,
+      income: baseAmount + 1000 * value,
+    }
+  })
+}
+
+const generateAmiChart = (): AmiChart => {
+  return {
+    ...defaultValues,
+    id: "ami1",
+    name: "ami1",
+    jurisdiction: null,
+    items: generateAmiChartItems(8, 30, 30_000),
+  }
+}
 
 describe("Unit Transformations", () => {
-  it("Ami chart items are correctly overwritten", () => {
-    let amiChart: AmiChart = {
-      id: "id",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      name: "name",
-      items: [
-        {
-          percentOfAmi: 1,
-          householdSize: 1,
-          income: 1,
-        },
-        {
-          percentOfAmi: 2,
-          householdSize: 2,
-          income: 2,
-        },
-        {
-          percentOfAmi: 3,
-          householdSize: 3,
-          income: 3,
-        },
-      ],
-      jurisdiction: {
+  describe("mergeAmiChartWithOverrides", () => {
+    it("Ami chart items are correctly overwritten", () => {
+      const amiChartOverride: UnitAmiChartOverride = {
         id: "id",
         createdAt: new Date(),
         updatedAt: new Date(),
-        name: "name",
-        multiselectQuestions: [],
-        languages: [Language.en],
-        publicUrl: "",
-        emailFromAddress: "email from address",
-        rentalAssistanceDefault: "",
-        enableAccessibilityFeatures: false,
-        enableUtilitiesIncluded: false,
-      },
-    }
+        items: [
+          {
+            percentOfAmi: 30,
+            householdSize: 2,
+            income: 20,
+          },
+        ],
+      }
+      const result = mergeAmiChartWithOverrides(generateAmiChart(), amiChartOverride)
+      expect(result.items.length).toBe(8)
+      expect(result.items[0].income).toBe(30000)
+      expect(result.items[1].income).toBe(20)
+      expect(result.items[2].income).toBe(32000)
+    })
+  })
 
-    const amiChartOverride: UnitAmiChartOverride = {
-      id: "id",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      items: [
-        {
-          percentOfAmi: 2,
-          householdSize: 2,
-          income: 20,
+  describe("generateHmiData", () => {
+    it("should generate HMI data for one unit and amiChart", () => {
+      const result = generateHmiData([unit], [{ min: 2, max: 5 }], [generateAmiChart()])
+
+      expect(result).toEqual({
+        columns: {
+          maxIncomeMonth: "listings.maxIncomeMonth",
+          maxIncomeYear: "listings.maxIncomeYear",
+          sizeColumn: "listings.householdSize",
         },
-      ],
-    }
-    amiChart = mergeAmiChartWithOverrides(amiChart, amiChartOverride)
-    expect(amiChart.items.length).toBe(3)
-    expect(amiChart.items[0].income).toBe(1)
-    expect(amiChart.items[1].income).toBe(20)
-    expect(amiChart.items[2].income).toBe(3)
+        rows: [
+          {
+            maxIncomeMonth: "listings.monthlyIncome*income:$2,583",
+            maxIncomeYear: "listings.annualIncome*income:$31,000",
+            sizeColumn: 2,
+          },
+          {
+            maxIncomeMonth: "listings.monthlyIncome*income:$2,667",
+            maxIncomeYear: "listings.annualIncome*income:$32,000",
+            sizeColumn: 3,
+          },
+          {
+            maxIncomeMonth: "listings.monthlyIncome*income:$2,750",
+            maxIncomeYear: "listings.annualIncome*income:$33,000",
+            sizeColumn: 4,
+          },
+          {
+            maxIncomeMonth: "listings.monthlyIncome*income:$2,833",
+            maxIncomeYear: "listings.annualIncome*income:$34,000",
+            sizeColumn: 5,
+          },
+        ],
+      })
+    })
+    it("should only have the highest chart data if min household is larger", () => {
+      const result = generateHmiData([unit], [{ min: 9, max: 11 }], [generateAmiChart()])
+
+      expect(result).toEqual({
+        columns: {
+          maxIncomeMonth: "listings.maxIncomeMonth",
+          maxIncomeYear: "listings.maxIncomeYear",
+          sizeColumn: "listings.householdSize",
+        },
+        rows: [
+          {
+            maxIncomeMonth: "listings.monthlyIncome*income:$3,083",
+            maxIncomeYear: "listings.annualIncome*income:$37,000",
+            sizeColumn: 8,
+          },
+        ],
+      })
+    })
+    it("should generate for more than 1 unit and amiChart ", () => {
+      const result = generateHmiData(
+        [unit, { ...unit, amiPercentage: "40", amiChartId: "ami2" }],
+        [
+          { min: 1, max: 3 },
+          { min: 5, max: 7 },
+        ],
+        [
+          generateAmiChart(),
+          { ...generateAmiChart(), id: "ami2", items: generateAmiChartItems(8, 40, 40_000) },
+        ]
+      )
+
+      expect(result).toEqual({
+        columns: {
+          ami30: "listings.percentAMIUnit*percent:30",
+          ami40: "listings.percentAMIUnit*percent:40",
+          sizeColumn: "listings.householdSize",
+        },
+        rows: [
+          {
+            ami30: "listings.annualIncome*income:$30,000",
+            ami40: "listings.annualIncome*income:$40,000",
+            sizeColumn: 1,
+          },
+          {
+            ami30: "listings.annualIncome*income:$31,000",
+            ami40: "listings.annualIncome*income:$41,000",
+            sizeColumn: 2,
+          },
+          {
+            ami30: "listings.annualIncome*income:$32,000",
+            ami40: "listings.annualIncome*income:$42,000",
+            sizeColumn: 3,
+          },
+          {
+            ami30: "listings.annualIncome*income:$34,000",
+            ami40: "listings.annualIncome*income:$44,000",
+            sizeColumn: 5,
+          },
+          {
+            ami30: "listings.annualIncome*income:$35,000",
+            ami40: "listings.annualIncome*income:$45,000",
+            sizeColumn: 6,
+          },
+          {
+            ami30: "listings.annualIncome*income:$36,000",
+            ami40: "listings.annualIncome*income:$46,000",
+            sizeColumn: 7,
+          },
+        ],
+      })
+    })
+    it("should have bmr values", () => {
+      const result = generateHmiData(
+        [
+          {
+            ...unit,
+            bmrProgramChart: true,
+            unitType: { ...defaultValues, id: "oneBed", name: "oneBdrm", numBedrooms: 1 },
+          },
+        ],
+        [{ min: 1, max: 3 }],
+        [generateAmiChart()]
+      )
+
+      expect(result).toEqual({
+        columns: {
+          maxIncomeMonth: "listings.maxIncomeMonth",
+          maxIncomeYear: "listings.maxIncomeYear",
+          sizeColumn: "t.unitType",
+        },
+        rows: [
+          {
+            maxIncomeMonth: "listings.monthlyIncome*income:$2,583",
+            maxIncomeYear: "listings.annualIncome*income:$31,000",
+            sizeColumn: "listings.unitTypes.oneBdrm",
+          },
+        ],
+      })
+    })
   })
 })


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses [586](https://github.com/housingbayarea/bloom/issues/586)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

The HMI table on the public listing details page currently shows a table for all housing sizes up to the max household all units have. It does not take in to account that units also have a minimum occupancy count. So for example a property that has a minimum household of size 4 is still showing the rows for household of size 1, 2, and 3. 

This change takes the minimum into account and only displays the range that are eligible. There is also one edge case that is handled where the minimum is larger than 8 (or the largest value in the table) we will still show 8 (or largest value). This case hasn't come up yet, but could in the future. A follow up PR will tackle the language change to "8+".

Additionally if there is a gap in the ranges between units there will also be a gap in the HMI table. For example if there is a studio that can have 1-3 occupants and a 2 bedroom that can have 5-8 the 4 occupant row will be hidden.

Also added tests to the units-transformation file. This file is ripe for a lot more unit test coverage to all of the functions in that file.

## How Can This Be Tested/Reviewed?

*This cannot be tested using the preview links as the changes are all backend changes*

In partners edit a listing to have a range of household size and make sure the appropriate table appears on the public site for that listing. Make sure to test with multiple units having different values and also when the different units have different percentages (different headers and columns appear in that case)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
