### PR TITLE
fix: fix partner unit tests

### DIFF
--- a/sites/partners/__tests__/pages/settings/index.test.tsx
+++ b/sites/partners/__tests__/pages/settings/index.test.tsx
@@ -24,6 +24,9 @@ describe("settings", () => {
     server.use(
       rest.get("http://localhost:3100/multiselectQuestions", (_req, res, ctx) => {
         return res(ctx.json([]))
+      }),
+      rest.get("http://localhost/api/adapter/multiselectQuestions", (_req, res, ctx) => {
+        return res(ctx.json([multiselectQuestionPreference]))
       })
     )
 
@@ -39,6 +42,9 @@ describe("settings", () => {
   it("should render the preference table", async () => {
     server.use(
       rest.get("http://localhost:3100/multiselectQuestions", (_req, res, ctx) => {
+        return res(ctx.json([multiselectQuestionPreference]))
+      }),
+      rest.get("http://localhost/api/adapter/multiselectQuestions", (_req, res, ctx) => {
         return res(ctx.json([multiselectQuestionPreference]))
       })
     )
@@ -68,13 +74,19 @@ describe("settings", () => {
       rest.get("http://localhost:3100/multiselectQuestions", (_req, res, ctx) => {
         return res(ctx.json([multiselectQuestionPreference]))
       }),
-      rest.get("http://localhost:3100/multiselectQuestions/listings/id1", (_req, res, ctx) => {
-        return res(ctx.json([]))
+      rest.get("http://localhost/api/adapter/multiselectQuestions", (_req, res, ctx) => {
+        return res(ctx.json([multiselectQuestionPreference]))
       }),
-      rest.delete("http://localhost:3100/multiselectQuestions", (_req, res, ctx) => {
+      rest.get(
+        "http://localhost/api/adapter/multiselectQuestions/listings/id1",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      ),
+      rest.delete("http://localhost/api/adapter/multiselectQuestions", (_req, res, ctx) => {
         return res(ctx.json({}))
       }),
-      rest.options("http://localhost:3100/multiselectQuestions", (_req, res, ctx) => {
+      rest.options("http://localhost/api/adapter/multiselectQuestions", (_req, res, ctx) => {
         return res(ctx.json({}))
       })
     )
@@ -105,9 +117,15 @@ describe("settings", () => {
       rest.get("http://localhost:3100/multiselectQuestions", (_req, res, ctx) => {
         return res(ctx.json([multiselectQuestionPreference]))
       }),
-      rest.get("http://localhost:3100/multiselectQuestions/listings/id1", (_req, res, ctx) => {
-        return res(ctx.json([listing]))
-      })
+      rest.get("http://localhost/api/adapter/multiselectQuestions", (_req, res, ctx) => {
+        return res(ctx.json([multiselectQuestionPreference]))
+      }),
+      rest.get(
+        "http://localhost/api/adapter/multiselectQuestions/listings/id1",
+        (_req, res, ctx) => {
+          return res(ctx.json([listing]))
+        }
+      )
     )
 
     const { findByText, getByTestId, findByRole, queryAllByText, getByText } = render(<Settings />)

--- a/sites/partners/__tests__/pages/users/index.test.tsx
+++ b/sites/partners/__tests__/pages/users/index.test.tsx
@@ -1,8 +1,4 @@
-import {
-  ACCESS_TOKEN_LOCAL_STORAGE_KEY,
-  AuthProvider,
-  ConfigProvider,
-} from "@bloom-housing/shared-helpers"
+import { AuthProvider, ConfigProvider } from "@bloom-housing/shared-helpers"
 import { fireEvent, render } from "@testing-library/react"
 import { rest } from "msw"
 import { setupServer } from "msw/node"
@@ -81,9 +77,7 @@ describe("users", () => {
     window.URL.createObjectURL = jest.fn()
     // set a logged in token
     jest.useFakeTimers()
-    const fakeToken =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5ZTMxODNhOC0yMGFiLTRiMDYtYTg4MC0xMmE5NjYwNmYwOWMiLCJpYXQiOjE2Nzc2MDAxNDIsImV4cCI6MjM5NzkwMDc0Mn0.ve1U5tAardpFjNyJ_b85QZLtu12MoMTa2aM25E8D1BQ"
-    window.sessionStorage.setItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY, fakeToken)
+    document.cookie = "access-token-available=True"
     server.use(
       rest.get("http://localhost:3100/listings", (_req, res, ctx) => {
         return res(ctx.json([]))
@@ -92,10 +86,10 @@ describe("users", () => {
         return res(ctx.json({ items: [user], meta: { totalItems: 1, totalPages: 1 } }))
       }),
       // set logged in user as admin
-      rest.get("http://localhost:3100/user", (_req, res, ctx) => {
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
         return res(ctx.json({ id: "user1", roles: { id: "user1", isAdmin: true } }))
       }),
-      rest.get("http://localhost:3100/user/csv", (_req, res, ctx) => {
+      rest.get("http://localhost/api/adapter/user/csv", (_req, res, ctx) => {
         return res(ctx.json(""))
       })
     )
@@ -120,9 +114,7 @@ describe("users", () => {
   it("should render error message csv fails", async () => {
     // set a logged in token
     jest.useFakeTimers()
-    const fakeToken =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI5ZTMxODNhOC0yMGFiLTRiMDYtYTg4MC0xMmE5NjYwNmYwOWMiLCJpYXQiOjE2Nzc2MDAxNDIsImV4cCI6MjM5NzkwMDc0Mn0.ve1U5tAardpFjNyJ_b85QZLtu12MoMTa2aM25E8D1BQ"
-    window.sessionStorage.setItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY, fakeToken)
+    document.cookie = "access-token-available=True"
     server.use(
       rest.get("http://localhost:3100/listings", (_req, res, ctx) => {
         return res(ctx.json([]))
@@ -131,10 +123,10 @@ describe("users", () => {
         return res(ctx.json({ items: [user], meta: { totalItems: 1, totalPages: 1 } }))
       }),
       // set logged in user as admin
-      rest.get("http://localhost:3100/user", (_req, res, ctx) => {
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
         return res(ctx.json({ id: "user1", roles: { id: "user1", isAdmin: true } }))
       }),
-      rest.get("http://localhost:3100/user/csv", (_req, res, ctx) => {
+      rest.get("http://localhost/api/adapter/user/csv", (_req, res, ctx) => {
         return res(ctx.status(500), ctx.json(""))
       })
     )


### PR DESCRIPTION
This fixes the two broken partner unit tests with the auth cookie change. It is pointed to the cookie update PR

1. Update the mock service worker urls to point to the new `/api/adapter/` endpoint
2. The token is no longer set as a session storage. So to simulate a logged in user we now need to set the cookie