### PR TITLE
fix: resolves issues around markedAsDuplicate

### DIFF
--- a/backend/core/src/application-flagged-sets/application-flagged-sets.service.ts
+++ b/backend/core/src/application-flagged-sets/application-flagged-sets.service.ts
@@ -172,18 +172,21 @@ export class ApplicationFlaggedSetsService {
           await transApplicationsRepository
             .createQueryBuilder()
             .update(Application)
-            .set({ reviewStatus: ApplicationReviewStatus.pendingAndValid })
+            .set({
+              reviewStatus: ApplicationReviewStatus.pendingAndValid,
+              markedAsDuplicate: false,
+            })
             .where("id IN (:...selectedApps)", {
               selectedApps,
             })
             .execute()
         }
 
-        // mark those that were not selected as duplicate
+        // mark those that were not selected as pending
         const qb = transApplicationsRepository
           .createQueryBuilder()
           .update(Application)
-          .set({ reviewStatus: ApplicationReviewStatus.pending })
+          .set({ reviewStatus: ApplicationReviewStatus.pending, markedAsDuplicate: false })
           .where(
             "exists (SELECT 1 FROM application_flagged_set_applications_applications WHERE applications_id = id AND application_flagged_set_id = :afsId)",
             { afsId: dto.afsId }
@@ -209,12 +212,12 @@ export class ApplicationFlaggedSetsService {
           .where("id = :afsId", { afsId: dto.afsId })
           .execute()
       } else if (dto.status === FlaggedSetStatus.resolved) {
-        // mark selected a valid
+        // mark selected as valid
         if (selectedApps.length) {
           await transApplicationsRepository
             .createQueryBuilder()
             .update(Application)
-            .set({ reviewStatus: ApplicationReviewStatus.valid })
+            .set({ reviewStatus: ApplicationReviewStatus.valid, markedAsDuplicate: false })
             .where("id IN (:...selectedApps)", {
               selectedApps,
             })
@@ -225,7 +228,7 @@ export class ApplicationFlaggedSetsService {
         const qb = transApplicationsRepository
           .createQueryBuilder()
           .update(Application)
-          .set({ reviewStatus: ApplicationReviewStatus.duplicate })
+          .set({ reviewStatus: ApplicationReviewStatus.duplicate, markedAsDuplicate: true })
           .where(
             "exists (SELECT 1 FROM application_flagged_set_applications_applications WHERE applications_id = id AND application_flagged_set_id = :afsId)",
             { afsId: dto.afsId }

--- a/backend/core/src/applications/services/applications.service.ts
+++ b/backend/core/src/applications/services/applications.service.ts
@@ -27,7 +27,6 @@ import { ApplicationUpdateDto } from "../dto/application-update.dto"
 import { ApplicationsCsvListQueryParams } from "../dto/applications-csv-list-query-params"
 import { ListingRepository } from "../../listings/db/listing.repository"
 import { Listing } from "../../listings/entities/listing.entity"
-import { ApplicationReviewStatus } from "../types/application-review-status-enum"
 
 @Injectable({ scope: Scope.REQUEST })
 export class ApplicationsService {
@@ -109,11 +108,6 @@ export class ApplicationsService {
     )
     const flags = await Promise.all(promiseArray)
     result.forEach((application, index) => {
-      if (flags[index].status) {
-        application.markedAsDuplicate = flags[index].status === ApplicationReviewStatus.duplicate
-      } else {
-        application.markedAsDuplicate = false
-      }
       application.flagged = !!flags[index].id
     })
 

--- a/backend/core/src/migration/1680216626425-fixing-marked-as-duplicate-flag.ts
+++ b/backend/core/src/migration/1680216626425-fixing-marked-as-duplicate-flag.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class fixingMarkedAsDuplicateFlag1680216626425 implements MigrationInterface {
+  name = "fixingMarkedAsDuplicateFlag1680216626425"
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // if review status is duplicate markedAsDuplicate should be true
+    await queryRunner.query(`
+            UPDATE applications
+            SET marked_as_duplicate = true
+            WHERE review_status = 'duplicate'
+        `)
+    // if review status is not duplicate markedAsDuplicate should be false
+    await queryRunner.query(`
+            UPDATE applications
+            SET marked_as_duplicate = false
+            WHERE review_status != 'duplicate'
+        `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses [#issue](https://github.com/bloom-housing/bloom/issues/3227)

- [x] This change addresses the issue in full

## Description
There was an issue where MarkedAsDuplicate on applications was not correctly capturing if the application had been marked as a duplicate or not. 

This has 2 pieces, 1st is a fix for new data coming in to markAsDuplicate correctly. The 2nd piece is a fix for existing applications data to set that field properly

## How Can This Be Tested/Reviewed?
Go to the partner's site
head to a listing with flagged applications
resolve an application, you should now see that marked as duplicate is set properly for the record that was selected, and for the record that was not selected
go back and set that record to be pending, you should see the marked as duplicate field updated properly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] I have exported any new pieces added to ui-components
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
