### PR TITLE
fix: react type errors

### DIFF
--- a/shared-helpers/package.json
+++ b/shared-helpers/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bloom-housing/backend-core": "^7.13.0",
-    "@bloom-housing/ui-components": "^12.0.0",
+    "@bloom-housing/ui-components": "^12.0.2",
     "axios-cookiejar-support": "4.0.6",
     "tough-cookie": "4.1.2"
   },

--- a/shared-helpers/src/auth/AuthContext.ts
+++ b/shared-helpers/src/auth/AuthContext.ts
@@ -128,7 +128,7 @@ const axiosConfig = (router: GenericRouter) => {
 }
 
 export const AuthContext = createContext<Partial<ContextProps>>({})
-export const AuthProvider: FunctionComponent = ({ children }) => {
+export const AuthProvider: FunctionComponent<React.PropsWithChildren> = ({ children }) => {
   const { apiUrl } = useContext(ConfigContext)
   const { router } = useContext(NavigationContext)
   const [state, dispatch] = useReducer(reducer, {

--- a/shared-helpers/src/auth/ConfigContext.tsx
+++ b/shared-helpers/src/auth/ConfigContext.tsx
@@ -19,6 +19,7 @@ export const ConfigProvider: FunctionComponent<{
   apiUrl: string
   storageType?: ConfigContextProps["storageType"]
   idleTimeout?: number
+  children?: React.ReactNode
 }> = ({ apiUrl, storageType = "session", idleTimeout = defaultTimeout, children }) => {
   return createElement(
     ConfigContext.Provider,

--- a/shared-helpers/src/auth/RequireLogin.tsx
+++ b/shared-helpers/src/auth/RequireLogin.tsx
@@ -15,6 +15,7 @@ type RequireLoginProps = {
   signInPath: string
   signInMessage: string
   termsPath?: string // partners portal required accepted terms after sign-in
+  children?: React.ReactNode
 } & XOR<{ requireForRoutes?: string[] }, { skipForRoutes: string[] }>
 
 /**

--- a/sites/partners/__tests__/pages/users/index.test.tsx
+++ b/sites/partners/__tests__/pages/users/index.test.tsx
@@ -92,6 +92,9 @@ describe("users", () => {
       }),
       rest.get("http://localhost/api/adapter/user/csv", (_req, res, ctx) => {
         return res(ctx.json(""))
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
       })
     )
     const { findByText, getByText } = render(
@@ -129,6 +132,9 @@ describe("users", () => {
       }),
       rest.get("http://localhost/api/adapter/user/csv", (_req, res, ctx) => {
         return res(ctx.status(500), ctx.json(""))
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
       })
     )
     const { findByText } = render(

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@bloom-housing/backend-core": "^7.13.0",
     "@bloom-housing/shared-helpers": "^7.7.0",
-    "@bloom-housing/ui-components": "^12.0.0",
+    "@bloom-housing/ui-components": "^12.0.2",
     "@mapbox/mapbox-sdk": "^0.13.0",
     "ag-grid-community": "^26.0.0",
     "ag-grid-react": "^26.0.0",
@@ -46,7 +46,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^6.15.5",
-    "swr": "^1.0.1",
+"swr": "^2.1.2",
     "tailwindcss": "2.2.10",
     "tough-cookie": "4.1.2"
   },
@@ -62,7 +62,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/mapbox__mapbox-sdk": "^0.13.2",
     "@types/node": "^12.12.67",
-    "@types/react": "^16.9.52",
+    "@types/react": "^18.0.33",
     "aria-query": "5.1.3",
     "babel-loader": "^9.1.2",
     "concurrently": "^5.3.0",

--- a/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsMultiselectQuestions.tsx
@@ -48,7 +48,7 @@ const DetailsMultiselectQuestions = ({
                     if (extra.type === InputType.text)
                       return (
                         <ViewItem key={extra.key} label={t("t.name")}>
-                          {extra.value}
+                          <>{extra.value}</>
                         </ViewItem>
                       )
 

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@bloom-housing/backend-core": "^7.13.0",
     "@bloom-housing/shared-helpers": "^7.7.0",
-    "@bloom-housing/ui-components": "^12.0.0",
+    "@bloom-housing/ui-components": "^12.0.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.1",
     "@fortawesome/free-regular-svg-icons": "^6.1.1",
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
@@ -62,7 +62,7 @@
     "@testing-library/react": "14.0.0",
     "@types/markdown-to-jsx": "^6.11.2",
     "@types/node": "^12.12.67",
-    "@types/react": "^16.9.52",
+    "@types/react": "^18.0.33",
     "concurrently": "^5.3.0",
     "cypress": "^12.8.1",
     "js-levenshtein": "^1.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,10 +1438,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@^12.0.0":
-  version "12.0.0"
-  resolved "https://registry.npmjs.org/@bloom-housing/ui-components/-/ui-components-12.0.0.tgz"
-  integrity sha512-asPLVpLEBRKg5xoCBc3WQ4xdKuwJF317VlcV4CeKcPVVpW00wZLYQSzK4elMAaqBPI8FHfVw2J72F0KiXGg8UA==
+"@bloom-housing/ui-components@^12.0.2":
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-12.0.2.tgz#a60fbd4c317d793f7755c7b416493fab493e4f29"
+  integrity sha512-oHFEpwrT1qOcUp8QgqHWSmKrncMZF+7peNV3nOLCGnP1F2nevVTILgoSGBMLvUk8Ek9a4+joON7faUtrPjHjEQ==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"
@@ -1451,6 +1451,7 @@
     "@types/jwt-decode" "^2.2.1"
     "@types/mdx" "^2.0.1"
     "@types/node-polyglot" "^2.4.1"
+    "@types/react" "^18.0.32"
     "@types/react-beautiful-dnd" "^13.1.1"
     "@types/react-dom" "^16.9.5"
     "@types/react-text-mask" "^5.4.6"
@@ -4282,21 +4283,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "16.9.46"
-  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.46.tgz"
-  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
+"@types/react@*", "@types/react@^18.0.32", "@types/react@^18.0.33":
+  version "18.0.33"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.33.tgz#a1575160cb4376787c2f5fe0312302f824baa61e"
+  integrity sha512-sHxzVxeanvQyQ1lr8NSHaj0kDzcNiGpILEVt69g9S31/7PfMvNCKLKcsHw4lYKjs3cGNJjXSP4mYzX43QlnjNA==
   dependencies:
     "@types/prop-types" "*"
+    "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/react@^16.9.52":
-  version "16.9.52"
-  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.52.tgz"
-  integrity sha512-EHRjmnxiNivwhGdMh9sz1Yw9AUxTSZFxKqdBWAAzyZx3sufWwx6ogqHYh/WB1m/I4ZpjkoZLExF5QTy2ekVi/Q==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^3.0.2"
+"@types/scheduler@*":
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
+  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/serve-static@*":
   version "1.13.5"
@@ -16178,12 +16177,12 @@ swr@^0.5.5:
   dependencies:
     dequal "2.0.2"
 
-swr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/swr/-/swr-1.0.1.tgz"
-  integrity sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==
+swr@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.1.2.tgz#15841cf5bbb8b20f24e2408193f616a41b6734a0"
+  integrity sha512-ocfaD2rnYZKqTDplCEX2bH5Z1++n2JSej9oYi7hVfXXWYm+0RP+H6fVrogWB0mtMclv1guk9kEnAzNLygOy9Hw==
   dependencies:
-    dequal "2.0.2"
+    use-sync-external-store "^1.2.0"
 
 symbol-observable@4.0.0:
   version "4.0.0"
@@ -17135,6 +17134,11 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Pulls in the latest ui-component changes. Functionally there is nothing different in ui-components, it just now accurately updates the `@types/react` to 18. Because of this we also needed to update the types in core. The small changes are mostly around how the types for 18 are more strict on what can be a child and that "children" has to now be explicitly listed in the prop types
