### PR TITLE
fix: Searching on the applications table causes the page to crash

### DIFF
--- a/backend/core/src/applications/services/applications.service.ts
+++ b/backend/core/src/applications/services/applications.service.ts
@@ -268,7 +268,7 @@ export class ApplicationsService {
       orderBy: (qb, { orderBy, order }) => qb.orderBy(orderBy, order, "NULLS LAST"),
       search: (qb, { search }) =>
         qb.andWhere(
-          `to_tsvector('english', REGEXP_REPLACE(concat_ws(' ', applicant, alternateContact.emailAddress), '[_]|[-]', '/', 'g')) @@ to_tsquery(CONCAT(CAST(REGEXP_REPLACE(:search, '[_]|[-]', '/', 'g') as text), ':*'))`,
+          `to_tsvector('english', REGEXP_REPLACE(concat_ws(' ', applicant, alternateContact.emailAddress), '[_]|[-]', '/', 'g')) @@ to_tsquery('simple', websearch_to_tsquery('simple', :search)::text || ':*')`,
           {
             search,
           }


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3377 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

For search we use `to_tsquery` function that requires specific "input" format. In other words passing there signs like ` `(space) `(`, `)`, `!` etc. will make it crash. There is another function that is more suitable for our case `websearch_to_tsquery` it will accept simple unformatted text, but it doesn't support "partial matching" `:*`. That's why i used both functions  `websearch_to_tsquery` to produce valid input and `to_tsquery` to provide partial matching.

## How Can This Be Tested/Reviewed?

go to application tab of any listing in partners site.
Check if filtering table will crash page.
Test if special signs are passing.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
