### PR TITLE
fix: now removes criteria file if a url is input

### DIFF
--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -134,6 +134,18 @@ export class ListingsService {
       await this.afsService.scheduleAfsProcessing()
     }
 
+    if (listingDto.buildingSelectionCriteria) {
+      listing.buildingSelectionCriteriaFile = null
+      await this.listingRepository.update(
+        { id: listing.id },
+        {
+          buildingSelectionCriteriaFile: null,
+        }
+      )
+    } else if (listingDto.buildingSelectionCriteriaFile) {
+      listing.buildingSelectionCriteria = null
+    }
+
     Object.assign(listing, {
       ...listingDto,
       publishedAt:

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -49,6 +49,7 @@ const LotteryResults = () => {
 
   const saveURL = (url) => {
     setValue("buildingSelectionCriteria", url)
+    deletePDF()
   }
   const deleteURL = () => {
     setValue("buildingSelectionCriteria", "")
@@ -58,6 +59,7 @@ const LotteryResults = () => {
       fileId: cloudinaryData.id,
       label: "cloudinaryPDF",
     })
+    deleteURL()
   }
   const deletePDF = () => {
     setValue("buildingSelectionCriteriaFile", { fileId: "", label: "" })


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses [#issue](https://github.com/bloom-housing/bloom/issues/3418)

- [x] This change addresses the issue in full

## Description
There is an issue where if a listing already has a building selection criteria of a pdf upload (or really any upload) then attempting to switch it to a url will store both with the upload taking precedence 



## How Can This Be Tested/Reviewed?
Go in to edit or create a listing
upload a file for the building selection criteria
this should save correcty
go back in to edit the listing and switch the building selection criteria to be a url
this should save correctly now too

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
