### PR TITLE
fix: redirect and alert language

### DIFF
--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -608,6 +608,7 @@
   "listings.applicationPerApplicantAgeDescription": "per applicant age 18 and over",
   "listings.applications": "Applications",
   "listings.applicationsClosed": "Applications Closed",
+  "listings.applicationsClosedRedirect": "This listing is no longer accepting applications.",
   "listings.apply.applicationWillBeAvailableOn": "Application will be available for download and pick up on %{openDate}",
   "listings.apply.applyOnline": "Apply Online",
   "listings.apply.downloadApplication": "Download Application",

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -39,6 +39,7 @@ import {
   EventType,
   StandardTableData,
   ExpandableSection,
+  SiteAlert,
 } from "@bloom-housing/ui-components"
 import {
   cloudinaryPdfFromId,
@@ -504,6 +505,7 @@ export const ListingView = (props: ListingProps) => {
   return (
     <article className="flex flex-wrap relative max-w-5xl m-auto">
       <header className="image-card--leader">
+        <SiteAlert type="alert" dismissable />
         <ImageCard
           images={imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize)).map(
             (imageUrl: string) => {

--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -15,6 +15,7 @@ import {
   t,
   Heading,
   AppearanceSizeType,
+  setSiteAlertMessage,
 } from "@bloom-housing/ui-components"
 import {
   imageUrlFromListing,
@@ -77,6 +78,13 @@ const ApplicationChooseLanguage = () => {
       setListing(context.listing)
     }
   }, [router, conductor, context, listingId])
+
+  useEffect(() => {
+    if (listing?.status === "closed") {
+      setSiteAlertMessage(t("listings.applicationsClosedRedirect"), "alert")
+      void router.push(`/listing/${listing?.id}`)
+    }
+  }, [listing, router])
 
   const currentPageSection = 1
 


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3463 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This fix redirects a user who lands at the beginning of an application for a listing that is closed. Couple notes:

1. Did my best on the language with the intention of it being clear while avoiding the repetition of "Applications Closed" seen on the right. Also curious how translations should be handled here? @sarahlazarich @eajensenwa 
<img width="912" alt="Screenshot 2023-05-24 at 12 21 06 AM" src="https://github.com/bloom-housing/bloom/assets/53269332/21cd632c-0eb4-4534-b31d-b2047a3b84b4">
2. I recognize that this only covers the case of when a user hits the first step of an application for a closed listing directly as opposed to setting up the redirect for landing on any page. My thought is that, in the case of this quick fix, I shouldn't build in coverage for users skipping parts of our application since that seems like its own conversation/bug that isn't dependent on whether the listing is closed or not.

## How Can This Be Tested/Reviewed?

This can be tested by pulling it down locally, setting a listing to closed, and then hitting this url:

http://localhost:3000/applications/start/choose-language?listingId=**listingIdThatYouJustClosed**

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
