### PR TITLE
fix: do a cache purge on listings cron job

### DIFF
--- a/backend/core/src/listings/cache-purge.service.ts
+++ b/backend/core/src/listings/cache-purge.service.ts
@@ -1,0 +1,53 @@
+import { HttpService } from "@nestjs/axios"
+import { firstValueFrom } from "rxjs"
+import { Listing } from "./entities/listing.entity"
+import { ListingCreateDto } from "./dto/listing-create.dto"
+import { ListingUpdateDto } from "./dto/listing-update.dto"
+import { ListingStatus } from "./types/listing-status-enum"
+import { Injectable } from "@nestjs/common"
+
+@Injectable()
+export class CachePurgeService {
+  constructor(private readonly httpService: HttpService) {}
+
+  /**
+   * Send purge request to Nginx.
+   * Wrapped in try catch, because it's possible that content may not be cached in between edits,
+   * and will return a 404, which is expected.
+   * listings* purges all /listings locations (with args, details), so if we decide to clear on certain locations,
+   * like all lists and only the edited listing, then we can do that here (with a corresponding update to nginx config)
+   */
+  public async cachePurgeForSingleListing(
+    currentListing: Listing,
+    incomingChanges: ListingCreateDto | ListingUpdateDto,
+    saveReponse: Listing
+  ) {
+    if (process.env.PROXY_URL) {
+      await firstValueFrom(
+        this.httpService.request({
+          baseURL: process.env.PROXY_URL,
+          method: "PURGE",
+          url: `/listings/${saveReponse.id}*`,
+        })
+      ).catch((e) => console.log(`purge listing ${saveReponse.id} error = `, e))
+      if (
+        incomingChanges.status !== ListingStatus.pending ||
+        currentListing.status === ListingStatus.active
+      ) {
+        await this.cachePurgeListings()
+      }
+    }
+  }
+
+  public async cachePurgeListings() {
+    if (process.env.PROXY_URL) {
+      await firstValueFrom(
+        this.httpService.request({
+          baseURL: process.env.PROXY_URL,
+          method: "PURGE",
+          url: "/listings?*",
+        })
+      ).catch((e) => console.log("purge all listings error = ", e))
+    }
+  }
+}

--- a/backend/core/src/listings/listings.module.ts
+++ b/backend/core/src/listings/listings.module.ts
@@ -17,6 +17,7 @@ import { ApplicationFlaggedSetsModule } from "../application-flagged-sets/applic
 import { ListingsCronService } from "./listings-cron.service"
 import { ListingsCsvExporterService } from "./listings-csv-exporter.service"
 import { CsvBuilder } from "../../src/applications/services/csv-builder.service"
+import { CachePurgeService } from "./cache-purge.service"
 
 @Module({
   imports: [
@@ -35,7 +36,14 @@ import { CsvBuilder } from "../../src/applications/services/csv-builder.service"
     ApplicationFlaggedSetsModule,
     HttpModule,
   ],
-  providers: [ListingsService, ListingsCronService, Logger, CsvBuilder, ListingsCsvExporterService],
+  providers: [
+    ListingsService,
+    ListingsCronService,
+    Logger,
+    CsvBuilder,
+    ListingsCsvExporterService,
+    CachePurgeService,
+  ],
   exports: [ListingsService],
   controllers: [ListingsController],
 })

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -1,5 +1,4 @@
 import { Inject, Injectable, NotFoundException, Scope, UnauthorizedException } from "@nestjs/common"
-import { HttpService } from "@nestjs/axios"
 import { InjectRepository } from "@nestjs/typeorm"
 import { Pagination } from "nestjs-typeorm-paginate"
 import { Brackets, In, Repository } from "typeorm"
@@ -20,7 +19,7 @@ import { REQUEST } from "@nestjs/core"
 import { User } from "../auth/entities/user.entity"
 import { ApplicationFlaggedSetsService } from "../application-flagged-sets/application-flagged-sets.service"
 import { ListingsQueryBuilder } from "./db/listing-query-builder"
-import { firstValueFrom } from "rxjs"
+import { CachePurgeService } from "./cache-purge.service"
 
 @Injectable({ scope: Scope.REQUEST })
 export class ListingsService {
@@ -32,7 +31,7 @@ export class ListingsService {
     @InjectRepository(User) private readonly userRepository: Repository<User>,
     @Inject(REQUEST) private req: ExpressRequest,
     private readonly afsService: ApplicationFlaggedSetsService,
-    private readonly httpService: HttpService
+    private readonly cachePurgeService: CachePurgeService
   ) {}
 
   private getFullyJoinedQueryBuilder() {
@@ -158,7 +157,7 @@ export class ListingsService {
     })
 
     const saveResponse = await this.listingRepository.save(listing)
-    await this.cachePurge(listing, listingDto, saveResponse)
+    await this.cachePurgeService.cachePurgeForSingleListing(listing, listingDto, saveResponse)
     return saveResponse
   }
 
@@ -329,40 +328,5 @@ export class ListingsService {
     result.units = unitData.units
 
     return result
-  }
-
-  /**
-   * Send purge request to Nginx.
-   * Wrapped in try catch, because it's possible that content may not be cached in between edits,
-   * and will return a 404, which is expected.
-   * listings* purges all /listings locations (with args, details), so if we decide to clear on certain locations,
-   * like all lists and only the edited listing, then we can do that here (with a corresponding update to nginx config)
-   */
-  private async cachePurge(
-    currentListing: Listing,
-    incomingChanges: ListingCreateDto | ListingUpdateDto,
-    saveReponse: Listing
-  ) {
-    if (process.env.PROXY_URL) {
-      await firstValueFrom(
-        this.httpService.request({
-          baseURL: process.env.PROXY_URL,
-          method: "PURGE",
-          url: `/listings/${saveReponse.id}*`,
-        })
-      ).catch((e) => console.log(`purge listing ${saveReponse.id} error = `, e))
-      if (
-        incomingChanges.status !== ListingStatus.pending ||
-        currentListing.status === ListingStatus.active
-      ) {
-        await firstValueFrom(
-          this.httpService.request({
-            baseURL: process.env.PROXY_URL,
-            method: "PURGE",
-            url: "/listings?*",
-          })
-        ).catch((e) => console.log("purge all listings error = ", e))
-      }
-    }
   }
 }

--- a/backend/core/src/listings/tests/listings.service.spec.ts
+++ b/backend/core/src/listings/tests/listings.service.spec.ts
@@ -16,6 +16,7 @@ import { Listing } from "../entities/listing.entity"
 import { User } from "../../auth/entities/user.entity"
 import { UserService } from "../../auth/services/user.service"
 import { HttpService } from "@nestjs/axios"
+import { CachePurgeService } from "../cache-purge.service"
 
 /* eslint-disable @typescript-eslint/unbound-method */
 
@@ -137,6 +138,7 @@ describe("ListingsService", () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ListingsService,
+        CachePurgeService,
         {
           provide: ApplicationFlaggedSetsService,
           useValue: { scheduleAfsProcessing: jest.fn() },


### PR DESCRIPTION
## Issue Overview

This PR addresses #3499 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

The proxy cache is only getting purged when a listing is updated. There is another case where a listing is scheduled to get closed via the listings cron job. In this job we check on all open listings that have an application due date in the past. Once those are updated in the DB with the new status we need to also purge the listings endpoint in the proxy (the endpoint used on the listings search page). This is now being done after the save to the DB.

Notes:
- Since cron jobs cannot use any service that has request scope I made a new cache-purge service that both the listings service and the listings cron service uses.

## How Can This Be Tested/Reviewed?

In order to test this locally you will need to have the proxy running locally (instructions here: https://github.com/bloom-housing/bloom/blob/main/backend/proxy/README.md).

Also make sure the PROXY_URL env variable is added to both public and backend/core

With the proxy running locally update a listing to have an application due date in the near future. Wait for the cron job to run (it will output `WARN changeOverdueListingsStatusCron job running` and list at least 1). The purge call should show up in the proxy logs and on refresh of the listings page the listing that was closed should no longer be in the list.

The cron job triggers every hour (counting from the time the app is started) so to speed up the testing you can change the Interval in ListingsCronService to a shorter time period

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs - will do when merged
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
