### PR TITLE
fix: get correct time period for submitted

### DIFF
--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -96,7 +96,7 @@ export const mapFormToApi = ({
 
     const dateString = dayjs(
       `${submissionMonth}/${submissionDay}/${submissionYear} ${hours}:${minutes}:${seconds} ${period}`,
-      "MM/DD/YYYY hh:mm:ss A"
+      "MM/DD/YYYY hh:mm:ss a"
     ).format(TIME_24H_FORMAT)
 
     const formattedDate = dayjs(dateString, TIME_24H_FORMAT).utc(true).toDate()
@@ -290,7 +290,7 @@ export const mapApiToForm = (applicationData: ApplicationUpdate, listing: Listin
     const hours = submissionDate.format("hh")
     const minutes = submissionDate.format("mm")
     const seconds = submissionDate.format("ss")
-    const period = submissionDate.format("A").toLowerCase() as TimeFieldPeriod
+    const period = submissionDate.format("a").toLowerCase() as TimeFieldPeriod
 
     return {
       hours,


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3513

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

No matter what you select on the "Time Submitted" field on the paper application for AM/PM it always selects AM on submission. This is due to a mismatch in the mapping of formatting when converting it to a 24 hour string. A capital "A" is for AM/PM whereas a lower case "a" is for am/pm. We need it to be lowercase because that is what we get back from the timeField.

## How Can This Be Tested/Reviewed?

Go to a listing and create a manual application submission in partners. Select "PM" when selecting the "Time Submitted". On save it should now display pm on this page along with the applications table. 

You should be able to also edit the application and it should properly save the new time.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
