### PR TITLE
fix: add correct command to run on heroku

### DIFF
--- a/backend_new/Procfile
+++ b/backend_new/Procfile
@@ -1,1 +1,1 @@
-web: yarn start
+web: yarn start:prod

--- a/backend_new/Procfile
+++ b/backend_new/Procfile
@@ -1,0 +1,1 @@
+web: yarn start

--- a/backend_new/package.json
+++ b/backend_new/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest --config ./test/jest.config.js",
     "test:watch": "jest --watch",

--- a/backend_new/tsconfig.json
+++ b/backend_new/tsconfig.json
@@ -17,5 +17,6 @@
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false
-  }
+  },
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
These are the required changes in order to get the prisma backend to work in Heroku.

- Add Procfile so that the correct start command is done (by default it tries to do npm start)
- The start:prod command was point to the wrong directory.

Also of note, Heroku had to add this buildpack https://github.com/timanovsky/subdir-heroku-buildpack and add the PROJECT_PATH env variable
