### PR TITLE
fix: use correct statuses for deciding to purge

### DIFF
--- a/backend/core/src/listings/cache-purge.service.ts
+++ b/backend/core/src/listings/cache-purge.service.ts
@@ -1,8 +1,6 @@
 import { HttpService } from "@nestjs/axios"
 import { firstValueFrom } from "rxjs"
 import { Listing } from "./entities/listing.entity"
-import { ListingCreateDto } from "./dto/listing-create.dto"
-import { ListingUpdateDto } from "./dto/listing-update.dto"
 import { ListingStatus } from "./types/listing-status-enum"
 import { Injectable } from "@nestjs/common"
 
@@ -18,8 +16,8 @@ export class CachePurgeService {
    * like all lists and only the edited listing, then we can do that here (with a corresponding update to nginx config)
    */
   public async cachePurgeForSingleListing(
-    currentListing: Listing,
-    incomingChanges: ListingCreateDto | ListingUpdateDto,
+    previousStatus: ListingStatus,
+    newStatus: ListingStatus,
     saveReponse: Listing
   ) {
     if (process.env.PROXY_URL) {
@@ -30,10 +28,7 @@ export class CachePurgeService {
           url: `/listings/${saveReponse.id}*`,
         })
       ).catch((e) => console.log(`purge listing ${saveReponse.id} error = `, e))
-      if (
-        incomingChanges.status !== ListingStatus.pending ||
-        currentListing.status === ListingStatus.active
-      ) {
+      if (newStatus !== ListingStatus.pending || previousStatus === ListingStatus.active) {
         await this.cachePurgeListings()
       }
     }

--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -144,6 +144,8 @@ export class ListingsService {
       listing.buildingSelectionCriteria = null
     }
 
+    const previousStatus = listing.status
+    const newStatus = listingDto.status
     Object.assign(listing, {
       ...listingDto,
       publishedAt:
@@ -157,7 +159,7 @@ export class ListingsService {
     })
 
     const saveResponse = await this.listingRepository.save(listing)
-    await this.cachePurgeService.cachePurgeForSingleListing(listing, listingDto, saveResponse)
+    await this.cachePurgeService.cachePurgeForSingleListing(previousStatus, newStatus, saveResponse)
     return saveResponse
   }
 


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3565 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

The change a month ago to fix the proxy cache purge is only working for one of the use cases. This is because the statuses used to determine if a cache purge should happen is incorrect. The "listing" value is updated right before the cache service is called so when checking the old status it is no longer accurate. To solve this a new variable is stored to keep track of the statuses 

## How Can This Be Tested/Reviewed?

1. Use the instructions in the backend proxy readme to startup the proxy locally https://github.com/bloom-housing/bloom/blob/main/backend/proxy/README.md.
2. Make sure the `PROXY_URL` is set in the .env for the backend and `BACKEND_PROXY_BASE` is set in the .env for the public site. sample `PROXY_URL=http://localhost:9000` and `BACKEND_PROXY_BASE=http://localhost:9000`
3. Start up the app and go the partner site. Choose a listing that is "open"
4. Click "unpublish"
5. Notice that two purge calls are done in the logs of the proxy and that the listing is no longer in the listings for the public site

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
