### PR TITLE
fix: only email language if user has set language

### DIFF
--- a/backend/core/src/email/email.service.ts
+++ b/backend/core/src/email/email.service.ts
@@ -218,7 +218,7 @@ export class EmailService {
       genericTranslations: Translation | null,
       jurisdictionalDefaultTranslations: Translation | null
 
-    if (language != Language.en) {
+    if (language && language !== Language.en) {
       if (jurisdiction) {
         jurisdictionalTranslations = await this.translationService.getTranslationByLanguageAndJurisdictionOrDefaultEn(
           language,


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Forget password emails for SJ users are coming in Spanish if the user has no language set. This is because when we do the DB query and language is null it returns the first row from the translation table that is of the correct jurisdiction. In this case it happened to be Spanish. This PR fixes that by only doing the custom translation fetch if the "language" value exists (is not null) 

## How Can This Be Tested/Reviewed?

The easiest way to test this is to grab the production data and copy it to your locally running database and then do the following steps.

1. Log into partners as an admin user
2. Create a new jurisdictional admin user that has the jurisdiction of San Jose
3. Log out and confirm your new account (click on email link, accept terms and set password)
4. logout and click "forgot password" link on the login screen
5. You should receive an email from SJ:HousingBayArea.org with the correct english translations

Note, you might want to test the above steps locally without the changes as well to make sure that you were getting the Spanish email 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
