### PR TITLE
fix: change how user is retreived from req

### DIFF
--- a/backend_new/package.json
+++ b/backend_new/package.json
@@ -52,7 +52,7 @@
     "@nestjs/cli": "^8.0.0",
     "@nestjs/schematics": "^8.0.0",
     "@nestjs/testing": "^8.0.0",
-    "@types/express": "^4.17.13",
+    "@types/express": "^4.17.17",
     "@types/jest": "^29.5.3",
     "@types/node": "^18.7.14",
     "@types/supertest": "^2.0.11",

--- a/backend_new/src/controllers/user.controller.ts
+++ b/backend_new/src/controllers/user.controller.ts
@@ -45,7 +45,7 @@ export class UserController {
 
   @Get()
   profile(@Request() req: ExpressRequest): User {
-    return mapTo(User, req.user);
+    return mapTo(User, req['user']);
   }
 
   @Get('/list')
@@ -60,7 +60,7 @@ export class UserController {
     @Request() req: ExpressRequest,
     @Query() queryParams: UserQueryParams,
   ): Promise<PaginatedUserDto> {
-    return await this.userService.list(queryParams, mapTo(User, req.user));
+    return await this.userService.list(queryParams, mapTo(User, req['user']));
   }
 
   @Get(`:id`)

--- a/backend_new/yarn.lock
+++ b/backend_new/yarn.lock
@@ -1266,7 +1266,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^4.17.13":
+"@types/express@^4.17.17":
   version "4.17.17"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.17.tgz#01d5437f6ef9cfa8668e616e13c2f2ac9a491ae4"
   integrity sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==


### PR DESCRIPTION
When attempting to deploy the new backend to Heroku there was a typing error. This PR solves that by getting the user from the request in a more safe pattern. I don't know why this works locally, I think VSCode thinks it can infer from the incorrect package what the type is.

This is proven to work with the deployment to bloom-prisma backend. https://dashboard.heroku.com/apps/bloom-prisma/activity/builds/e1039a2f-1ff9-4151-a5d6-18c977372092