### PR TITLE
fix: amiPercentage being unset on unit edit

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -510,6 +510,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                   onChange: () => {
                     if (amiChartID && !loading && amiChartsOptions) {
                       void fetchAmiChart()
+                      setIsAmiPercentageDirty(true)
                     }
                   },
                 }}

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -37,11 +37,10 @@ type UnitFormProps = {
 const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormProps) => {
   const { amiChartsService } = useContext(AuthContext)
 
-  const [options, setOptions] = useState({
-    amiCharts: [],
-    unitPriorities: [],
-    unitTypes: [],
-  })
+  const [amiChartsOptions, setAmiChartsOptions] = useState([])
+  const [unitPrioritiesOptions, setUnitPrioritiesOptions] = useState([])
+  const [unitTypesOptions, setUnitTypesOptions] = useState([])
+  const [isAmiPercentageDirty, setIsAmiPercentageDirty] = useState(false)
   const [loading, setLoading] = useState(true)
   const [currentAmiChart, setCurrentAmiChart] = useState(null)
   const [amiChartPercentageOptions, setAmiChartPercentageOptions] = useState([])
@@ -181,11 +180,25 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
   }
 
   useEffect(() => {
-    if (amiPercentage && !loading && options) {
+    if (
+      amiPercentage &&
+      !loading &&
+      amiChartsOptions &&
+      unitPrioritiesOptions &&
+      unitTypesOptions &&
+      isAmiPercentageDirty
+    ) {
       resetAmiTableValues()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [amiPercentage])
+  }, [amiPercentage, amiChartPercentageOptions, isAmiPercentageDirty])
+
+  useEffect(() => {
+    if (defaultUnit && !amiPercentage) {
+      setValue("amiPercentage", defaultUnit.amiPercentage)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [amiChartPercentageOptions])
 
   type FormSubmitAction = "saveNew" | "saveExit" | "save"
 
@@ -312,47 +325,16 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
     },
   ]
 
+  // sets the unit type to be the value from default
+  // after the unitType options are set
   useEffect(() => {
-    if (amiCharts.length === 0 || options.amiCharts.length) return
-    setOptions({
-      ...options,
-      amiCharts: arrayToFormOptions<AmiChart>(amiCharts, "name", "id"),
-    })
-  }, [amiCharts, options])
-
-  useEffect(() => {
-    if (unitPriorities.length === 0 || options.unitPriorities.length) return
-    setOptions({
-      ...options,
-      unitPriorities: arrayToFormOptions<UnitAccessibilityPriorityType>(
-        unitPriorities,
-        "name",
-        "id"
-      ),
-    })
-  }, [options, unitPriorities])
-
-  useEffect(() => {
-    if (unitTypes.length === 0 || options.unitTypes.length) return
-    setOptions({
-      ...options,
-      unitTypes: arrayToFormOptions<UnitType>(unitTypes, "name", "id", "listings.unit.typeOptions"),
-    })
-  }, [options, unitTypes])
-
-  useEffect(() => {
-    if (defaultUnit) {
-      setValue("amiChart.id", defaultUnit.amiChart?.id)
-      setValue("priorityType.id", defaultUnit.priorityType?.id)
-    }
-  }, [defaultUnit, setValue])
-
-  useEffect(() => {
-    if (defaultUnit && options.unitTypes) {
+    if (defaultUnit && unitTypesOptions) {
       setValue("unitType.id", defaultUnit.unitType?.id)
     }
-  }, [defaultUnit, options, setValue])
+  }, [defaultUnit, unitTypesOptions, setValue])
 
+  // when rent type is updated we set the rent/income data to defaultUnit data for that value
+  // e.g. rent is fixed and swithced to percentage, then switched back we readd the old fixed data
   useEffect(() => {
     if (defaultUnit) {
       if (rentType === "fixed") {
@@ -364,6 +346,28 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rentType])
+
+  // sets the options for the ami charts
+  useEffect(() => {
+    if (amiCharts.length === 0 || amiChartsOptions.length) return
+    setAmiChartsOptions(arrayToFormOptions<AmiChart>(amiCharts, "name", "id"))
+  }, [amiCharts, amiChartsOptions])
+
+  // sets the options for the unit priorities
+  useEffect(() => {
+    if (unitPriorities.length === 0 || unitPrioritiesOptions.length) return
+    setUnitPrioritiesOptions(
+      arrayToFormOptions<UnitAccessibilityPriorityType>(unitPriorities, "name", "id")
+    )
+  }, [unitPrioritiesOptions, unitPriorities, defaultUnit, setValue])
+
+  // sets the options for the unit types
+  useEffect(() => {
+    if (unitTypes.length === 0 || unitTypesOptions.length) return
+    setUnitTypesOptions(
+      arrayToFormOptions<UnitType>(unitTypes, "name", "id", "listings.unit.typeOptions")
+    )
+  }, [unitTypesOptions, unitTypes])
 
   return (
     <Form onSubmit={() => false}>
@@ -392,7 +396,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                 labelClassName="sr-only"
                 register={register}
                 controlClassName="control"
-                options={options.unitTypes}
+                options={unitTypesOptions}
                 error={fieldHasError(errors?.unitType)}
                 errorMessage={t("errors.requiredFieldError")}
                 validation={{ required: true }}
@@ -501,10 +505,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                 labelClassName="sr-only"
                 register={register}
                 controlClassName="control"
-                options={options.amiCharts}
+                options={amiChartsOptions}
                 inputProps={{
                   onChange: () => {
-                    if (amiChartID && !loading && options) {
+                    if (amiChartID && !loading && amiChartsOptions) {
                       void fetchAmiChart()
                     }
                   },
@@ -522,6 +526,11 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                 register={register}
                 controlClassName="control"
                 options={amiChartPercentageOptions}
+                inputProps={{
+                  onChange: () => {
+                    setIsAmiPercentageDirty(true)
+                  },
+                }}
               />
             </FieldValue>
           </GridCell>
@@ -613,7 +622,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                 labelClassName="sr-only"
                 register={register}
                 controlClassName="control"
-                options={options.unitPriorities}
+                options={unitPrioritiesOptions}
               />
             </FieldValue>
           </GridCell>


### PR DESCRIPTION
## Issue Overview

This PR addresses [#issue](https://github.com/bloom-housing/bloom/issues/3628)

- [x] This change addresses the issue in full

## Description
this fixes an issue where editing a listing's unit meant the ami percentage value as reset

## How Can This Be Tested/Reviewed?
Create or edit a listing
add a unit and select an ami percentage that is NOT the first value in the select. 

for example if ami percentage options are 20, 40, 60, 80, 100 select something larger than 20 (so you can verify the fix is in place)

Then change one of the maximum annual income set values (it can be anything, but the more memorable the better)

so your values should look something like:  
![image](https://github.com/bloom-housing/bloom/assets/10088764/fa1d5097-eb03-4b21-b773-311cb9c2ac4f)


save the unit then go in and edit. The values you set should be there

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [x] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
