### PR TITLE
fix: use consistent ports in cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,6 @@ executors:
           JURISDICTION_NAME: Bloomington
     environment:
       PORT: "3100"
-      PORT_NEW: "3101"
       EMAIL_API_KEY: "SG.SOME-LONG-SECRET-KEY"
       APP_SECRET: "CI-LONG-SECRET-KEY"
       # DB URL for migration and seeds:

--- a/backend_new/src/main.ts
+++ b/backend_new/src/main.ts
@@ -25,8 +25,6 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
   const configService: ConfigService = app.get(ConfigService);
-  await app.listen(
-    configService.get<number>('PORT_NEW') || configService.get<number>('PORT'),
-  );
+  await app.listen(configService.get<number>('PORT'));
 }
 bootstrap();

--- a/sites/public/next.config.js
+++ b/sites/public/next.config.js
@@ -16,7 +16,6 @@ if (process.env.NODE_ENV !== "production") {
 }
 // Set up app-wide constants
 let BACKEND_API_BASE = "http://localhost:3100"
-let BACKEND_API_BASE_NEW = process.env.BACKEND_API_BASE_NEW
 if (process.env.INCOMING_HOOK_BODY && process.env.INCOMING_HOOK_BODY.startsWith("http")) {
   // This is a value that can get set via a Netlify webhook for branch deploys
   BACKEND_API_BASE = decodeURIComponent(process.env.INCOMING_HOOK_BODY)
@@ -41,8 +40,7 @@ module.exports = withBundleAnalyzer(
   withTM({
     env: {
       backendApiBase: BACKEND_API_BASE,
-      backendApiBaseNew: process.env.BACKEND_API_BASE_NEW,
-      listingServiceUrl: BACKEND_API_BASE_NEW + LISTINGS_QUERY,
+      listingServiceUrl: BACKEND_API_BASE + LISTINGS_QUERY,
       listingPhotoSize: process.env.LISTING_PHOTO_SIZE || "1302",
       mapBoxToken: MAPBOX_TOKEN,
       housingCounselorServiceUrl: HOUSING_COUNSELOR_SERVICE_URL,

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -24,7 +24,7 @@
     "dev:server-wait": "wait-on \"http-get://localhost:${PORT:-3100}/listings\"  --httpTimeout 60000 --tcpTimeout 1500 -v --interval 15000 && yarn dev",
     "dev:server-wait-new": "wait-on \"http-get://localhost:3101/listings\" && yarn dev",
     "dev:server-wait-cypress": "wait-on \"http-get://localhost:${PORT:-3100}/listings\" --httpTimeout 60000 --tcpTimeout 1500 -v --interval 15000 && yarn build && yarn start",
-    "dev:all-cypress": "concurrently \"yarn dev:new-backend\" \"yarn dev:server-wait-new\"",
+    "dev:all-cypress": "concurrently \"yarn dev:new-backend\" \"yarn dev:server-wait\"",
     "dev:all": "concurrently \"yarn dev:listings\" \"yarn dev:server-wait\""
   },
   "dependencies": {

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -153,7 +153,7 @@ export async function fetchJurisdictionByName() {
 
     const jurisdictionName = process.env.jurisdictionName
     const jurisdictionRes = await axios.get(
-      `${process.env.backendApiBaseNew}/jurisdictions/byName/${jurisdictionName}`
+      `${process.env.backendApiBase}/jurisdictions/byName/${jurisdictionName}`
     )
     jurisdiction = jurisdictionRes?.data
   } catch (error) {

--- a/sites/public/src/pages/listing/[id].tsx
+++ b/sites/public/src/pages/listing/[id].tsx
@@ -13,7 +13,7 @@ export async function getServerSideProps(context: { params: Record<string, strin
   let response
 
   try {
-    response = await axios.get(`${process.env.backendApiBaseNew}/listings/${context.params.id}`)
+    response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`)
   } catch (e) {
     return { notFound: true }
   }

--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -123,7 +123,7 @@ export async function getServerSideProps(context: {
   let response
 
   try {
-    response = await axios.get(`${process.env.backendApiBaseNew}/listings/${context.params.id}`, {
+    response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`, {
       headers: { language: context.locale },
     })
   } catch (e) {


### PR DESCRIPTION
# Pull Request Template

## Description

The public cypress tests are flaky because when starting up the app we were not correctly waiting for the backend to startup. Along with this having a separate port for the new backend was causing more headaches than it was solving. This cleans up those.

## How Can This Be Tested/Reviewed?

Nothing should change for your local. Cypress tests should now pass in CI

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
