### PR TITLE
fix: only send listing approval email once

### DIFF
--- a/backend/core/src/listings/listings.service.ts
+++ b/backend/core/src/listings/listings.service.ts
@@ -316,7 +316,10 @@ export class ListingsService {
     const nonApprovingRoles = [UserRoleEnum.partner]
     if (!params.approvingRoles.includes(UserRoleEnum.jurisdictionAdmin))
       nonApprovingRoles.push(UserRoleEnum.jurisdictionAdmin)
-    if (params.status === ListingStatus.pendingReview) {
+    if (
+      params.status === ListingStatus.pendingReview &&
+      params.previousStatus !== ListingStatus.pendingReview
+    ) {
       const userInfo = await this.getUserEmailInfo(
         params.approvingRoles,
         params.listingInfo.id,
@@ -330,7 +333,10 @@ export class ListingsService {
       )
     }
     // admin updates status to changes requested when approval requires partner changes
-    else if (params.status === ListingStatus.changesRequested) {
+    else if (
+      params.status === ListingStatus.changesRequested &&
+      params.previousStatus !== ListingStatus.changesRequested
+    ) {
       const userInfo = await this.getUserEmailInfo(
         nonApprovingRoles,
         params.listingInfo.id,


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3722 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

When a listing is edited after it has been requested for approval another request for approval email was getting sent. This has been happening many times for the same listing in HBA since the admin/jurisdictional admin make edits and don't publish right away. This change checks the previous status for both pendingReview and changesRequested so that only an email is sent the first time is goes to that status

## How Can This Be Tested/Reviewed?

1. Make sure you have two users set that can receive emails - An admin and a partner.
2. While signed in as the partner submit a listing for approval. Admin user should receive an email
3. While signed in as the admin make a change to the same listing with "save and exit" rather than "publish". No email should be sent.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
