### PR TITLE
fix: application multiselect questions

### DIFF
--- a/backend_new/src/dtos/applications/application-multiselect-question.dto.ts
+++ b/backend_new/src/dtos/applications/application-multiselect-question.dto.ts
@@ -3,13 +3,22 @@ import { Expose, Type } from 'class-transformer';
 import {
   ArrayMaxSize,
   IsBoolean,
+  IsDefined,
   IsString,
+  IsUUID,
   ValidateNested,
 } from 'class-validator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 import { ApplicationMultiselectQuestionOption } from './application-multiselect-question-option.dto';
 
 export class ApplicationMultiselectQuestion {
+  @Expose()
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  multiselectQuestionId: string;
+
   @Expose()
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @ApiProperty()

--- a/backend_new/test/integration/application.e2e-spec.ts
+++ b/backend_new/test/integration/application.e2e-spec.ts
@@ -6,6 +6,7 @@ import {
   ApplicationSubmissionTypeEnum,
   IncomePeriodEnum,
   LanguagesEnum,
+  MultiselectQuestionsApplicationSectionEnum,
   UnitTypeEnum,
   YesNoEnum,
 } from '@prisma/client';
@@ -31,6 +32,7 @@ import { AddressCreate } from '../../src/dtos/addresses/address-create.dto';
 import { ApplicationUpdate } from '../../src/dtos/applications/application-update.dto';
 import { translationFactory } from '../../prisma/seed-helpers/translation-factory';
 import { EmailService } from '../../src/services/email.service';
+import { multiselectQuestionFactory } from '../../prisma/seed-helpers/multiselect-question-factory';
 
 describe('Application Controller Tests', () => {
   let app: INestApplication;
@@ -45,6 +47,28 @@ describe('Application Controller Tests', () => {
     testEmailService,
     'applicationConfirmation',
   );
+
+  const createMultiselectQuestion = async (
+    jurisdictionId: string,
+    listingId: string,
+    section: MultiselectQuestionsApplicationSectionEnum,
+  ) => {
+    const res = await prisma.multiselectQuestions.create({
+      data: multiselectQuestionFactory(jurisdictionId, {
+        numberOfOptions: 2,
+        multiselectQuestion: {
+          applicationSection: section,
+          listings: {
+            create: {
+              listingId: listingId,
+            },
+          },
+        },
+      }),
+    });
+
+    return res.id;
+  };
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -256,12 +280,24 @@ describe('Application Controller Tests', () => {
       data: listing1,
     });
 
+    const multiselectQuestionProgram = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.programs,
+    );
+    const multiselectQuestionPreference = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.preferences,
+    );
+
     const submissionDate = new Date();
     const exampleAddress = addressFactory() as AddressCreate;
     const dto: ApplicationCreate = {
       contactPreferences: ['example contact preference'],
       preferences: [
         {
+          multiselectQuestionId: multiselectQuestionPreference,
           key: 'example key',
           claimed: true,
           options: [
@@ -363,6 +399,7 @@ describe('Application Controller Tests', () => {
       reviewStatus: ApplicationReviewStatusEnum.valid,
       programs: [
         {
+          multiselectQuestionId: multiselectQuestionProgram,
           key: 'example key',
           claimed: true,
           options: [
@@ -400,12 +437,24 @@ describe('Application Controller Tests', () => {
       data: listing1,
     });
 
+    const multiselectQuestionProgram = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.programs,
+    );
+    const multiselectQuestionPreference = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.preferences,
+    );
+
     const submissionDate = new Date();
     const exampleAddress = addressFactory() as AddressCreate;
     const dto: ApplicationCreate = {
       contactPreferences: ['example contact preference'],
       preferences: [
         {
+          multiselectQuestionId: multiselectQuestionPreference,
           key: 'example key',
           claimed: true,
           options: [
@@ -507,6 +556,7 @@ describe('Application Controller Tests', () => {
       reviewStatus: ApplicationReviewStatusEnum.valid,
       programs: [
         {
+          multiselectQuestionId: multiselectQuestionProgram,
           key: 'example key',
           claimed: true,
           options: [
@@ -543,6 +593,17 @@ describe('Application Controller Tests', () => {
       data: listing1,
     });
 
+    const multiselectQuestionProgram = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.programs,
+    );
+    const multiselectQuestionPreference = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.preferences,
+    );
+
     const applicationA = await prisma.applications.create({
       data: applicationFactory({ unitTypeId: unitTypeA.id }),
       include: {
@@ -557,6 +618,7 @@ describe('Application Controller Tests', () => {
       contactPreferences: ['example contact preference'],
       preferences: [
         {
+          multiselectQuestionId: multiselectQuestionPreference,
           key: 'example key',
           claimed: true,
           options: [
@@ -658,6 +720,7 @@ describe('Application Controller Tests', () => {
       reviewStatus: ApplicationReviewStatusEnum.valid,
       programs: [
         {
+          multiselectQuestionId: multiselectQuestionProgram,
           key: 'example key',
           claimed: true,
           options: [
@@ -697,6 +760,17 @@ describe('Application Controller Tests', () => {
       data: listing1,
     });
 
+    const multiselectQuestionProgram = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.programs,
+    );
+    const multiselectQuestionPreference = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.preferences,
+    );
+
     const submissionDate = new Date();
     const exampleAddress = addressFactory() as AddressCreate;
     const dto: ApplicationUpdate = {
@@ -704,6 +778,7 @@ describe('Application Controller Tests', () => {
       contactPreferences: ['example contact preference'],
       preferences: [
         {
+          multiselectQuestionId: multiselectQuestionPreference,
           key: 'example key',
           claimed: true,
           options: [
@@ -805,6 +880,7 @@ describe('Application Controller Tests', () => {
       reviewStatus: ApplicationReviewStatusEnum.valid,
       programs: [
         {
+          multiselectQuestionId: multiselectQuestionProgram,
           key: 'example key',
           claimed: true,
           options: [
@@ -844,12 +920,24 @@ describe('Application Controller Tests', () => {
       data: listing1,
     });
 
+    const multiselectQuestionProgram = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.programs,
+    );
+    const multiselectQuestionPreference = await createMultiselectQuestion(
+      jurisdiction.id,
+      listing1Created.id,
+      MultiselectQuestionsApplicationSectionEnum.preferences,
+    );
+
     const submissionDate = new Date();
     const exampleAddress = addressFactory() as AddressCreate;
     const dto: ApplicationCreate = {
       contactPreferences: ['example contact preference'],
       preferences: [
         {
+          multiselectQuestionId: multiselectQuestionPreference,
           key: 'example key',
           claimed: true,
           options: [
@@ -951,6 +1039,7 @@ describe('Application Controller Tests', () => {
       reviewStatus: ApplicationReviewStatusEnum.valid,
       programs: [
         {
+          multiselectQuestionId: multiselectQuestionProgram,
           key: 'example key',
           claimed: true,
           options: [

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -3809,6 +3809,9 @@ export interface ApplicationMultiselectQuestionOption {
 
 export interface ApplicationMultiselectQuestion {
   /**  */
+  multiselectQuestionId: string
+
+  /**  */
   key: string
 
   /**  */

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -302,6 +302,7 @@ export const mapRadiosToApi = (
   })
 
   return {
+    multiselectQuestionId: question.id,
     key,
     claimed: Object.keys(data)?.length !== 0,
     options,
@@ -334,6 +335,7 @@ export const mapCheckboxesToApi = (
     })
 
   return {
+    multiselectQuestionId: question.id,
     key: question.text ?? "",
     claimed,
     options: questionOptions,


### PR DESCRIPTION
## Issue Overview

This PR adds the multiselectQuestionId to `ApplicationMultiselectQuestion`, so that we can gain efficiency in tying application responses with preferences and programs to the multiselect question. The end result should be that when users submit an application, their preference and program responses will be saved with the multiselectQuestionId.

