### PR TITLE
fix: provides additional fields info text overflows

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -183,6 +183,7 @@ const SelectAndOrder = ({
   ) => {
     const getInfoSection = (option, index) => {
       const isNotLastItem = index < item.options.length - 1
+      console.log(option)
       return (
         <div key={index} className={isNotLastItem ? "mb-5" : "mb-1"}>
           <div className={"font-semibold mb-1 text-gray-800"}>
@@ -214,7 +215,7 @@ const SelectAndOrder = ({
           {option.collectAddress && (
             <div
               className={`${
-                isNotLastItem && (option.description || option.links) ? "-mt-4" : "mt-0"
+                isNotLastItem && (option.description || option.links.length > 0) ? "-mt-4" : "mt-0"
               }`}
             >
               ({t("listings.providesAdditionalFields.info")})

--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -183,7 +183,6 @@ const SelectAndOrder = ({
   ) => {
     const getInfoSection = (option, index) => {
       const isNotLastItem = index < item.options.length - 1
-      console.log(option)
       return (
         <div key={index} className={isNotLastItem ? "mb-5" : "mb-1"}>
           <div className={"font-semibold mb-1 text-gray-800"}>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -212,7 +212,11 @@ const SelectAndOrder = ({
             </div>
           )}
           {option.collectAddress && (
-            <div className={`${isNotLastItem ? "-mt-4" : "mt-0"}`}>
+            <div
+              className={`${
+                isNotLastItem && (option.description || option.links) ? "-mt-4" : "mt-0"
+              }`}
+            >
               ({t("listings.providesAdditionalFields.info")})
             </div>
           )}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3690

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

It is issue that was reported after merge of #3690.
in partners in edit listing page Housing Preferences -> edit preferences -> select preferences -> preview, there was the case where `(This preference provides additional details that will be included in the exported data)` overflowed with above text (for example here https://partners.bloom.exygy.dev/listings/14b211fa-e9a4-4541-a6d6-b5416ade1d55/edit -> Test radius geocoding preference).
It happen when no description and links present in option.


## How Can This Be Tested/Reviewed?

for different options variants (like with description, with links etc) check if that behaviour still exist.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
