### PR TITLE
fix: pagination and deletion fix

### DIFF
--- a/backend_new/src/services/listing.service.ts
+++ b/backend_new/src/services/listing.service.ts
@@ -185,7 +185,7 @@ export class ListingService implements OnModuleInit {
     // revert back to the first page
     let page = params.page;
     if (count && params.limit && params.limit !== 'all' && params.page > 1) {
-      if (count / params.limit < params.page) {
+      if (Math.ceil(count / params.limit) < params.page) {
         page = 1;
       }
     }

--- a/backend_new/src/services/listing.service.ts
+++ b/backend_new/src/services/listing.service.ts
@@ -181,8 +181,17 @@ export class ListingService implements OnModuleInit {
       where: whereClause,
     });
 
+    // if passed in page and limit would result in no results because there aren't that many listings
+    // revert back to the first page
+    let page = params.page;
+    if (count && params.limit && params.limit !== 'all' && params.page > 1) {
+      if (count / params.limit < params.page) {
+        page = 1;
+      }
+    }
+
     const listingsRaw = await this.prisma.listings.findMany({
-      skip: calculateSkip(params.limit, params.page),
+      skip: calculateSkip(params.limit, page),
       take: calculateTake(params.limit),
       orderBy: buildOrderByForListings(params.orderBy, params.orderDir),
       include: views[params.view ?? 'full'],

--- a/backend_new/src/services/listing.service.ts
+++ b/backend_new/src/services/listing.service.ts
@@ -945,6 +945,11 @@ export class ListingService implements OnModuleInit {
           listingId: dto.id,
         },
       }),
+      this.prisma.listingMultiselectQuestions.deleteMany({
+        where: {
+          listingId: dto.id,
+        },
+      }),
       this.prisma.listings.update({
         data: {
           ...dto,
@@ -1010,22 +1015,10 @@ export class ListingService implements OnModuleInit {
             : undefined,
           listingMultiselectQuestions: dto.listingMultiselectQuestions
             ? {
-                upsert: dto.listingMultiselectQuestions.map(
+                create: dto.listingMultiselectQuestions.map(
                   (multiselectQuestion) => ({
-                    where: {
-                      listingId_multiselectQuestionId: {
-                        listingId: dto.id,
-                        multiselectQuestionId: multiselectQuestion.id,
-                      },
-                    },
-                    update: {
-                      ordinal: multiselectQuestion.ordinal,
-                      multiselectQuestionId: multiselectQuestion.id,
-                    },
-                    create: {
-                      ordinal: multiselectQuestion.ordinal,
-                      multiselectQuestionId: multiselectQuestion.id,
-                    },
+                    ordinal: multiselectQuestion.ordinal,
+                    multiselectQuestionId: multiselectQuestion.id,
                   }),
                 ),
               }

--- a/backend_new/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/backend_new/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -683,9 +683,12 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
 
     it('should succeed for delete endpoint', async () => {
       await unitAccessibilityPriorityTypeFactoryAll(prisma);
-      const unitTypeA = await unitAccessibilityPriorityTypeFactorySingle(
-        prisma,
-      );
+      const unitTypeA =
+        await await prisma.unitAccessibilityPriorityTypes.create({
+          data: {
+            name: 'unit type A',
+          },
+        });
 
       await request(app.getHttpServer())
         .delete(`/unitAccessibilityPriorityTypes`)
@@ -744,10 +747,12 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
     });
 
     it('should succeed for delete endpoint', async () => {
-      const unitTypeA = await unitTypeFactorySingle(
-        prisma,
-        UnitTypeEnum.fiveBdrm,
-      );
+      const unitTypeA = await prisma.unitTypes.create({
+        data: {
+          name: UnitTypeEnum.studio,
+          numBedrooms: 23,
+        },
+      });
 
       await request(app.getHttpServer())
         .delete(`/unitTypes`)

--- a/backend_new/test/unit/services/listing.service.spec.ts
+++ b/backend_new/test/unit/services/listing.service.spec.ts
@@ -2353,22 +2353,10 @@ describe('Testing listing service', () => {
           ],
         },
         listingMultiselectQuestions: {
-          upsert: [
+          create: [
             {
-              where: {
-                listingId_multiselectQuestionId: {
-                  listingId: expect.anything(),
-                  multiselectQuestionId: expect.anything(),
-                },
-              },
-              create: {
-                multiselectQuestionId: expect.anything(),
-                ordinal: 0,
-              },
-              update: {
-                multiselectQuestionId: expect.anything(),
-                ordinal: 0,
-              },
+              multiselectQuestionId: expect.anything(),
+              ordinal: 0,
             },
           ],
         },

--- a/backend_new/test/unit/services/listing.service.spec.ts
+++ b/backend_new/test/unit/services/listing.service.spec.ts
@@ -633,6 +633,65 @@ describe('Testing listing service', () => {
     });
   });
 
+  it('should return first page if params are more than count', async () => {
+    prisma.listings.findMany = jest.fn().mockResolvedValue(mockListingSet(10));
+
+    prisma.listings.count = jest.fn().mockResolvedValue(20);
+
+    const params: ListingsQueryParams = {
+      view: ListingViews.base,
+      page: 2,
+      limit: 30,
+      orderBy: [ListingOrderByKeys.name],
+      orderDir: [OrderByEnum.ASC],
+    };
+
+    await service.list(params);
+
+    expect(prisma.listings.findMany).toHaveBeenCalledWith({
+      skip: 0,
+      take: 30,
+      orderBy: [
+        {
+          name: 'asc',
+        },
+      ],
+      where: {
+        AND: [],
+      },
+      include: {
+        jurisdictions: true,
+        listingsBuildingAddress: true,
+        reservedCommunityTypes: true,
+        listingImages: {
+          include: {
+            assets: true,
+          },
+        },
+        listingMultiselectQuestions: {
+          include: {
+            multiselectQuestions: true,
+          },
+        },
+        listingFeatures: true,
+        listingUtilities: true,
+        units: {
+          include: {
+            unitTypes: true,
+            unitAmiChartOverrides: true,
+            amiChart: true,
+          },
+        },
+      },
+    });
+
+    expect(prisma.listings.count).toHaveBeenCalledWith({
+      where: {
+        AND: [],
+      },
+    });
+  });
+
   it('should build where clause when only params sent', async () => {
     const params: ListingFilterParams[] = [
       {

--- a/backend_new/test/unit/services/user.service.spec.ts
+++ b/backend_new/test/unit/services/user.service.spec.ts
@@ -144,7 +144,7 @@ describe('Testing user service', () => {
       const date = new Date();
       const mockedValue = mockUserSet(3, date);
       prisma.userAccounts.findMany = jest.fn().mockResolvedValue(mockedValue);
-      prisma.userAccounts.count = jest.fn().mockResolvedValue(3);
+      prisma.userAccounts.count = jest.fn().mockResolvedValue(6);
 
       expect(
         await service.list(
@@ -166,8 +166,8 @@ describe('Testing user service', () => {
           currentPage: 2,
           itemCount: 3,
           itemsPerPage: 5,
-          totalItems: 3,
-          totalPages: 1,
+          totalItems: 6,
+          totalPages: 2,
         },
       });
 
@@ -215,6 +215,46 @@ describe('Testing user service', () => {
               ],
             },
           ],
+        },
+      });
+    });
+
+    it('should return first page if params are more than count', async () => {
+      const date = new Date();
+      const mockedValue = mockUserSet(3, date);
+      prisma.userAccounts.findMany = jest.fn().mockResolvedValue(mockedValue);
+      prisma.userAccounts.count = jest.fn().mockResolvedValue(3);
+
+      expect(
+        await service.list(
+          {
+            page: 2,
+            limit: 5,
+          },
+          null,
+        ),
+      ).toEqual({
+        items: mockedValue,
+        meta: {
+          currentPage: 2,
+          itemCount: 3,
+          itemsPerPage: 5,
+          totalItems: 3,
+          totalPages: 1,
+        },
+      });
+
+      expect(prisma.userAccounts.findMany).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: true,
+          listings: true,
+          userRoles: true,
+        },
+        orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+        skip: 0,
+        take: 5,
+        where: {
+          AND: [],
         },
       });
     });


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This addresses an issue found during the bug bash. On the listings page in partners if you go to page two of the table and then change the per page to a number higher than the total listing count no listings are returned. This fixes it by resetting to the first page if that scenario hits the backend.

The same thing has been implemented for the users table

Also another issue was found on deletion of multiselect questions on a listing. When you deleted a preference on the listing edit page it wasn't actually disconnecting it from the listing in the DB. This change makes it so all are deleted before recreated in the listingmultiselectquestion table

## How Can This Be Tested/Reviewed?

Pagination:
- Make sure you have more than 8 listings and go to the listings page in partners.
- Click "next" button on the table
- Change the "show" count to a number greater than the total listing count
- Page should get reset to page 1 and listings should appear

Multiselect question deletion:
- Go to a listing in partners that has at least one multiselect question (preferably at least 2)
- Delete one of the attached preferences and click save
- Listing should no longer have the referenced preference on the page


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
