### PR TITLE
fix: add default value for map layer

### DIFF
--- a/backend/core/src/migration/1705637577495-add-feature-collection.ts
+++ b/backend/core/src/migration/1705637577495-add-feature-collection.ts
@@ -4,7 +4,9 @@ export class addFeatureCollection1705637577495 implements MigrationInterface {
   name = "addFeatureCollection1705637577495"
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "map_layers" ADD "feature_collection" jsonb NOT NULL`)
+    await queryRunner.query(
+      `ALTER TABLE "map_layers" ADD "feature_collection" jsonb NOT NULL default '{}'::jsonb`
+    )
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/sites/partners/__tests__/pages/settings/index.test.tsx
+++ b/sites/partners/__tests__/pages/settings/index.test.tsx
@@ -16,6 +16,17 @@ beforeAll(() => {
   mockNextRouter()
 })
 
+beforeEach(() => {
+  server.use(
+    rest.get("http://localhost/api/adapter/mapLayers", (_req, res, ctx) => {
+      return res(ctx.json({}))
+    }),
+    rest.get("http://localhost:3100/mapLayers", (_req, res, ctx) => {
+      return res(ctx.json({}))
+    })
+  )
+})
+
 afterEach(() => server.resetHandlers())
 
 afterAll(() => server.close())


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3814 

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Due to this new field being a non-null column the bloom-backend-main deployment fails as there are already dummy data in the table. This fix adds a default value to the featureCollection column so that the migration can successfully run. It will not be an issue in the production deployment as there is no map-layer data in the database yet

## How Can This Be Tested/Reviewed?

A reseed of the data did not catch this because that does a cleanse of the database before applying all migrations and then adding the seeded data. So in order to test this like how production would be the following must be done:

- Locally pull down the code one commit before the most recent commit (HEAD should be at `aa8e3a647`).
- Run a reseed. This should add the map-layer table to the database without the featureCollection column along with data in the table
- Pull down this PR and run `yarn db:migration:run` in the `backend/core` directory

This should now have the existing data in the map_layer table have `{}` as the value in the feature_collection column

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
