### PR TITLE
fix: geocoding verification fix

### DIFF
--- a/backend/core/test/applications/applications.e2e-spec.ts
+++ b/backend/core/test/applications/applications.e2e-spec.ts
@@ -362,7 +362,7 @@ describe("Applications", () => {
     expect(Array.isArray(res.body.items)).toBe(true)
     expect(res.body.items.length).toBe(1)
     expect(res.body.items[0].id === createRes.body.id)
-    expect(res.body.items[0]).toMatchObject(createRes.body)
+    expect(res.body.items[0]).toMatchObject({ ...createRes.body, updatedAt: expect.anything() })
   })
 
   it(`should not allow an admin to search for users application using a search query param of less than 3 characters`, async () => {
@@ -402,7 +402,7 @@ describe("Applications", () => {
     expect(Array.isArray(res.body.items)).toBe(true)
     expect(res.body.items.length).toBe(1)
     expect(res.body.items[0].id === createRes.body.id)
-    expect(res.body.items[0]).toMatchObject(createRes.body)
+    expect(res.body.items[0]).toMatchObject({ ...createRes.body, updatedAt: expect.anything() })
   })
 
   it(`should allow an admin to search for users application using email as textquery`, async () => {
@@ -425,7 +425,7 @@ describe("Applications", () => {
     expect(Array.isArray(res.body.items)).toBe(true)
     expect(res.body.items.length).toBe(1)
     expect(res.body.items[0].id === createRes.body.id)
-    expect(res.body.items[0]).toMatchObject(createRes.body)
+    expect(res.body.items[0]).toMatchObject({ ...createRes.body, updatedAt: expect.anything() })
   })
 
   // because we changed this to be done async to the request this is causing some problems with the tests
@@ -568,7 +568,7 @@ describe("Applications", () => {
       const { createRes, firstName } = responses[index]
 
       expect(item.id === createRes.body.id)
-      expect(item).toMatchObject(createRes.body)
+      expect(item).toMatchObject({ ...createRes.body, updatedAt: expect.anything() })
       expect(item.applicant).toMatchObject(createRes.body.applicant)
       expect(item.applicant.firstName === firstName)
     }


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3814 

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

While testing the e2e functionality of geocoding a bug was found when a listing has both a radius and map-layer preference tied to it. This is because the preferences were getting overwritten during the map-layer check if they were already updated on the radius check.

In order to solve this a small refactor was done to make sure the updated preferences are getting passed to each consecutive check.

## How Can This Be Tested/Reviewed?

- Create a preference that collects address and validates against a radius
- Create a preference that collects address and validates against a map layer
- On an open listing attach both of the above preferences to it
- Go to the public site and apply to the listing making sure to add address for both of the preferences

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
