### PR TITLE
fix: spacing on preference pages

### DIFF
--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -221,8 +221,8 @@ export const getCheckboxOption = (
 ) => {
   const optionFieldName = fieldName(question.text, applicationSection, option.text)
   return (
-    <div className={`mb-5 ${option.ordinal !== 1 ? "border-t pt-5" : ""}`} key={option.text}>
-      <div className={`mb-5 field ${resolveObject(optionFieldName, errors) ? "error" : ""}`}>
+    <div className={`mb-3 ${option.ordinal !== 1 ? "pt-3" : ""}`} key={option.text}>
+      <div className={`mb-3 field ${resolveObject(optionFieldName, errors) ? "error" : ""}`}>
         {getCheckboxField(
           option,
           question,
@@ -237,7 +237,7 @@ export const getCheckboxOption = (
         )}
       </div>
       {option.description && (
-        <div className="ml-8 -mt-5 mb-5">
+        <div className="ml-8 -mt-3 mb-3">
           <ExpandableContent strings={{ readMore: t("t.readMore"), readLess: t("t.readLess") }}>
             <p className="field-note mb-2">
               {option.description}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3833

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This issue seem like some weird tailwind config issue, where on our remote envs for example class `.pt-5` is not generated. Strangely locally it works fine. But to not overcomplicate that i decided to align it to [this design](https://www.figma.com/file/Ne8jOyPpCBvlAhyaRlXgTq/Geocoding?type=design&node-id=1627-5899&mode=design&t=KhELQj7swCtDCkoM-4) (which btw seem like a thing that i should do anyway).
As that tailwind config is in UIC and it uses some old library for rtl, so not sure if it's easely upgradable (similar issues were solved by bumping tailwind). And testing it will be  problematic as it's only remote thing. I can see `pt-5` class was only used here anyways (not sure if other classes also are missing).

## How Can This Be Tested/Reviewed?

fill application to programs / preferences step. Now it won't have divider, and spacing will be slightly smaller, but consistent. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
