### PR TITLE
feat: add MA application check for signed-in user

### DIFF
--- a/shared-helpers/src/auth/UseRequireLoggedInUser.ts
+++ b/shared-helpers/src/auth/UseRequireLoggedInUser.ts
@@ -6,11 +6,11 @@ import { NavigationContext } from "@bloom-housing/ui-components"
  * Require a logged in user. Waits on initial load, then initiates a redirect to `redirectPath` if user is not
  * logged in.
  */
-function useRequireLoggedInUser(redirectPath: string, disable?: boolean) {
+function useRequireLoggedInUser(redirectPath: string) {
   const { profile, initialStateLoaded } = useContext(AuthContext)
   const { router } = useContext(NavigationContext)
 
-  if (!disable && initialStateLoaded && !profile) {
+  if (initialStateLoaded && !profile) {
     void router.push(redirectPath)
   }
   return profile

--- a/shared-helpers/src/auth/UseRequireLoggedInUser.ts
+++ b/shared-helpers/src/auth/UseRequireLoggedInUser.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react"
 import { AuthContext } from "./AuthContext"
-import { NavigationContext } from "@bloom-housing/ui-components"
+import { useRouter } from "next/router"
 
 /**
  * Require a logged in user. Waits on initial load, then initiates a redirect to `redirectPath` if user is not
@@ -8,9 +8,9 @@ import { NavigationContext } from "@bloom-housing/ui-components"
  */
 function useRequireLoggedInUser(redirectPath: string) {
   const { profile, initialStateLoaded } = useContext(AuthContext)
-  const { router } = useContext(NavigationContext)
+  const router = useRouter()
 
-  if (initialStateLoaded && !profile) {
+  if (process.env.showMandatedAccounts && initialStateLoaded && !profile) {
     void router.push(redirectPath)
   }
   return profile

--- a/shared-helpers/src/auth/UseRequireLoggedInUser.ts
+++ b/shared-helpers/src/auth/UseRequireLoggedInUser.ts
@@ -6,11 +6,11 @@ import { NavigationContext } from "@bloom-housing/ui-components"
  * Require a logged in user. Waits on initial load, then initiates a redirect to `redirectPath` if user is not
  * logged in.
  */
-function useRequireLoggedInUser(redirectPath: string) {
+function useRequireLoggedInUser(redirectPath: string, disable?: boolean) {
   const { profile, initialStateLoaded } = useContext(AuthContext)
   const { router } = useContext(NavigationContext)
 
-  if (initialStateLoaded && !profile) {
+  if (!disable && initialStateLoaded && !profile) {
     void router.push(redirectPath)
   }
   return profile

--- a/shared-helpers/src/auth/UseRequireLoggedInUser.ts
+++ b/shared-helpers/src/auth/UseRequireLoggedInUser.ts
@@ -6,11 +6,11 @@ import { NavigationContext } from "@bloom-housing/ui-components"
  * Require a logged in user. Waits on initial load, then initiates a redirect to `redirectPath` if user is not
  * logged in.
  */
-function useRequireLoggedInUser(redirectPath: string) {
+function useRequireLoggedInUser(redirectPath: string, disable?: boolean) {
   const { profile, initialStateLoaded } = useContext(AuthContext)
   const { router } = useContext(NavigationContext)
 
-  if (process.env.showMandatedAccounts && initialStateLoaded && !profile) {
+  if (!disable && initialStateLoaded && !profile) {
     void router.push(redirectPath)
   }
   return profile

--- a/shared-helpers/src/auth/UseRequireLoggedInUser.ts
+++ b/shared-helpers/src/auth/UseRequireLoggedInUser.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react"
 import { AuthContext } from "./AuthContext"
-import { useRouter } from "next/router"
+import { NavigationContext } from "@bloom-housing/ui-components"
 
 /**
  * Require a logged in user. Waits on initial load, then initiates a redirect to `redirectPath` if user is not
@@ -8,7 +8,7 @@ import { useRouter } from "next/router"
  */
 function useRequireLoggedInUser(redirectPath: string) {
   const { profile, initialStateLoaded } = useContext(AuthContext)
-  const router = useRouter()
+  const { router } = useContext(NavigationContext)
 
   if (process.env.showMandatedAccounts && initialStateLoaded && !profile) {
     void router.push(redirectPath)

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -33,7 +33,7 @@ export const useRedirectToPrevPage = (defaultPath = "/") => {
 }
 
 export const useFormConductor = (stepName: string) => {
-  useRequireLoggedInUser("/sign-in", !process.env.showMandatedAccounts)
+  useRequireLoggedInUser("/", !process.env.showMandatedAccounts)
   const context = useContext(AppSubmissionContext)
   const conductor = context.conductor
 

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -33,7 +33,7 @@ export const useRedirectToPrevPage = (defaultPath = "/") => {
 }
 
 export const useFormConductor = (stepName: string) => {
-  useRequireLoggedInUser("/sign-in", true)
+  useRequireLoggedInUser("/sign-in", !process.env.showMandatedAccounts)
   const context = useContext(AppSubmissionContext)
   const conductor = context.conductor
 

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -15,6 +15,7 @@ import {
 import { ParsedUrlQuery } from "querystring"
 import { AppSubmissionContext } from "./applications/AppSubmissionContext"
 import { getListingApplicationStatus } from "./helpers"
+import { useRequireLoggedInUser } from "@bloom-housing/shared-helpers"
 
 export const useRedirectToPrevPage = (defaultPath = "/") => {
   const router = useRouter()
@@ -32,6 +33,7 @@ export const useRedirectToPrevPage = (defaultPath = "/") => {
 }
 
 export const useFormConductor = (stepName: string) => {
+  useRequireLoggedInUser("/sign-in")
   const context = useContext(AppSubmissionContext)
   const conductor = context.conductor
 

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -33,7 +33,7 @@ export const useRedirectToPrevPage = (defaultPath = "/") => {
 }
 
 export const useFormConductor = (stepName: string) => {
-  useRequireLoggedInUser("/", !process.env.showMandatedAccounts)
+  useRequireLoggedInUser("/")
   const context = useContext(AppSubmissionContext)
   const conductor = context.conductor
 

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -33,7 +33,7 @@ export const useRedirectToPrevPage = (defaultPath = "/") => {
 }
 
 export const useFormConductor = (stepName: string) => {
-  useRequireLoggedInUser("/sign-in")
+  useRequireLoggedInUser("/sign-in", true)
   const context = useContext(AppSubmissionContext)
   const conductor = context.conductor
 

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -33,7 +33,7 @@ export const useRedirectToPrevPage = (defaultPath = "/") => {
 }
 
 export const useFormConductor = (stepName: string) => {
-  useRequireLoggedInUser("/")
+  useRequireLoggedInUser("/", !process.env.showMandatedAccounts)
   const context = useContext(AppSubmissionContext)
   const conductor = context.conductor
 

--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -55,6 +55,10 @@ const ApplicationChooseLanguage = () => {
   }, [profile])
 
   useEffect(() => {
+    if (process.env.showMandatedAccounts && initialStateLoaded && !profile) {
+      void conductor.routeTo("/sign-in")
+      return
+    }
     conductor.reset()
     if (!router.isReady && !listingId) return
     if (router.isReady && !listingId) {
@@ -62,7 +66,6 @@ const ApplicationChooseLanguage = () => {
         ? undefined
         : void router.push("/")
     }
-
     if (!context.listing || context.listing.id !== listingId) {
       void loadListing(listingId, setListing, conductor, context, "en")
     } else {

--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -55,16 +55,12 @@ const ApplicationChooseLanguage = () => {
   }, [profile])
 
   useEffect(() => {
-    if (process.env.showMandatedAccounts && initialStateLoaded && !profile) {
-      void conductor.routeTo("/sign-in")
-      return
-    }
     conductor.reset()
     if (!router.isReady && !listingId) return
-    if (router.isReady && !listingId) {
-      return process.env.showMandatedAccounts && initialStateLoaded && profile
-        ? undefined
-        : void router.push("/")
+    if (router.isReady) {
+      if (!listingId || (process.env.showMandatedAccounts && initialStateLoaded && !profile)) {
+        void router.push("/")
+      }
     }
     if (!context.listing || context.listing.id !== listingId) {
       void loadListing(listingId, setListing, conductor, context, "en")


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3769.

- [X] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

As part of the Mandated Accounts MVP, this PR redirects users to the sign-in page if they access an application page while not signed in. This prevents the case where signed-out users are directed to a page in the middle of an application.

## How Can This Be Tested/Reviewed?

To review this PR:

1. Ensure that you are not signed in. 
2. Check that when you access a page in the middle of an application (see [urls](https://github.com/bloom-housing/bloom/blob/9f35e7e1a995c63dd6bbf23a23ca8ece049b3843/sites/public/src/lib/applications/ApplicationConductor.ts#L41)), you are redirected to the `/sign-in` page. For example, `http://localhost:3000/applications/start/what-to-expect` or `http://localhost:3000/applications/review/summary`.

Note: This ticket does not include redirection for the case where a signed-in user access the middle of an application, as it applies specifically to signed-out users. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
