### PR TITLE
fix: allow jurisdictional admin for map layers

### DIFF
--- a/backend/core/src/map-layers/map-layers.controller.ts
+++ b/backend/core/src/map-layers/map-layers.controller.ts
@@ -3,17 +3,17 @@ import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger"
 import { MapLayersService } from "./map-layers.service"
 import { ResourceType } from "../auth/decorators/resource-type.decorator"
 import { OptionalAuthGuard } from "../auth/guards/optional-auth.guard"
-import { AuthzGuard } from "../auth/guards/authz.guard"
 import { defaultValidationPipeOptions } from "../shared/default-validation-pipe-options"
 import { mapTo } from "../shared/mapTo"
 import { MapLayerDto } from "./dto/map-layer.dto"
 import { MapLayersQueryParams } from "./dto/map-layers-query-params"
+import { AdminOrJurisdictionalAdminGuard } from "../auth/guards/admin-or-jurisidictional-admin.guard"
 
 @Controller("/mapLayers")
 @ApiTags("mapLayers")
 @ApiBearerAuth()
 @ResourceType("mapLayer")
-@UseGuards(OptionalAuthGuard, AuthzGuard)
+@UseGuards(OptionalAuthGuard, AdminOrJurisdictionalAdminGuard)
 @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
 export class MapLayersController {
   constructor(private readonly mapLayerService: MapLayersService) {}


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3852 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

The jurisdictional admins are getting an unauthorized exception when loading the settings page because on page load a call to the map-layers endpoint is being done. We have a check on the front-end that catches any 403 exceptions and re-routes them to the unauthorized page. Since jurisdictional admins can access the settings page we should also allow the map layer endpoint to have j-admins to hit it.

Note:
- No tests are being added in this PR to catch this since we don't have a great setup for permission level testing. This functionality is also getting pulled over to the new backend here https://github.com/bloom-housing/bloom/pull/3844 and I will add an additional test to make sure this is covered there.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

Sign into the partner site as a jurisdictional admin and go to the settings page. You should no longer get rerouted to the unauthorized page. 

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
