### PR TITLE
fix: null check on option links

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -220,7 +220,7 @@ const SelectAndOrder = ({
           {option.collectAddress && (
             <div
               className={`${
-                isNotLastItem && (option.description || option.links.length > 0) ? "-mt-4" : "mt-0"
+                isNotLastItem && (option.description || option.links?.length > 0) ? "-mt-4" : "mt-0"
               }`}
             >
               ({t("listings.providesAdditionalFields.info")})


### PR DESCRIPTION
When a preference collects address but doesn't have a description or any links a null pointer exception happens when clicking the "preview" button when selecting a preference on a listing.

To test:
Assuming there is a preference that has at least one option that "collects address" and doesn't have a description or any links.
- In edit mode of a listing click "add preference".
- On the above mentioned preference click "preview"
- The preview should properly show