### PR TITLE
fix: call submit directly from onClick

### DIFF
--- a/sites/public/src/components/account/ConfirmationModal.tsx
+++ b/sites/public/src/components/account/ConfirmationModal.tsx
@@ -21,11 +21,11 @@ const ConfirmationModal = (props: ConfirmationModalProps) => {
   // This is causing a linting issue with unbound-method, see open issue as of 10/21/2020:
   // https://github.com/react-hook-form/react-hook-form/issues/2887
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, handleSubmit, errors, watch } = useForm()
+  const { register, handleSubmit, errors, watch, getValues } = useForm()
   const email = useRef({})
   email.current = watch("email", "")
 
-  const onSubmit = async ({ email }) => {
+  const onSubmit = async (email) => {
     try {
       const listingId = router.query?.listingId as string
       await resendConfirmation(email, listingId)
@@ -37,6 +37,11 @@ const ConfirmationModal = (props: ConfirmationModalProps) => {
       setModalMessage(t(`authentication.createAccount.errors.${data.message}`))
     }
     window.scrollTo(0, 0)
+  }
+
+  const onFormSubmit = async () => {
+    const { email } = getValues()
+    await onSubmit(email)
   }
 
   useEffect(() => {
@@ -83,15 +88,7 @@ const ConfirmationModal = (props: ConfirmationModalProps) => {
         window.scrollTo(0, 0)
       }}
       actions={[
-        <Button
-          variant="primary"
-          onClick={() => {
-            document
-              .getElementById("resend-confirmation")
-              .dispatchEvent(new Event("submit", { cancelable: true }))
-          }}
-          size="sm"
-        >
+        <Button type="submit" variant="primary" onClick={() => onFormSubmit()} size="sm">
           {t("authentication.createAccount.resendTheEmail")}
         </Button>,
         <Button


### PR DESCRIPTION
# Pull Request Template

## Issue Overview
#3846 

This PR addresses #issue

- [ ] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Previously, this was using an event dispatch to trigger the form submit. Following the pattern from `ResendConfirmationModal`, I changed this to call the submit action onClick.

## How Can This Be Tested/Reviewed?
- Create an account
- When the first modal appears, also click the resend button
- You will receive two emails, click the confirmation link on the FIRST email
- This should trigger the timeout modal to appear
- When this appears, the useEffect will see if the token is valid, since it is not, it will throw a 400 which I believe is expected.
- If you enter your email, and hit resend, the request should succeed and you will receive a new confirmation email.

This commit fixes the existing bug, but I think there are a lot of opportunities for refactoring here. Lmk your thoughts and suggestions!


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
