### PR TITLE
fix: radio preferences don't show description and geocoding fields

### DIFF
--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -1,12 +1,6 @@
 import * as React from "react"
 import { UseFormMethods } from "react-hook-form"
-import {
-  ExpandableContent,
-  Field,
-  FieldGroup,
-  resolveObject,
-  t,
-} from "@bloom-housing/ui-components"
+import { ExpandableContent, Field, resolveObject, t } from "@bloom-housing/ui-components"
 import { stateKeys } from "../utilities/formKeys"
 import {
   ApplicationMultiselectQuestion,
@@ -167,6 +161,7 @@ const getCheckboxField = (
       name={optionFieldName}
       type={"checkbox"}
       label={option.text}
+      labelClassName="font-semibold"
       register={register}
       inputProps={{
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -120,7 +120,9 @@ const getRadioField = (
   register: UseFormMethods["register"],
   setValue: UseFormMethods["setValue"],
   allOptions: string[],
-  optionFieldName: string
+  optionFieldName: string,
+  getValues: UseFormMethods["getValues"],
+  trigger?: UseFormMethods["trigger"]
 ) => {
   return (
     <>
@@ -133,11 +135,21 @@ const getRadioField = (
         inputProps={{
           value: !!option.text,
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+            if (e.target.checked && trigger) {
+              void trigger()
+            }
             uncheckOptions(allOptions, setValue)
             setValue(optionFieldName, e.target.value)
           },
         }}
         dataTestId={"app-question-option"}
+        validation={{
+          validate: {
+            somethingIsChecked: (value) => {
+              return !!value || !!allOptions.find((option) => getValues(option))
+            },
+          },
+        }}
       />
     </>
   )
@@ -340,10 +352,20 @@ export const getRadioOption = (
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [x: string]: any
   },
-  errors?: UseFormMethods["errors"]
+  getValues: UseFormMethods["getValues"],
+  errors?: UseFormMethods["errors"],
+  trigger?: UseFormMethods["trigger"]
 ) => {
   const optionFieldName = fieldName(question.text, applicationSection, option.text)
-  const radioField = getRadioField(option, register, setValue, allOptions, optionFieldName)
+  const radioField = getRadioField(
+    option,
+    register,
+    setValue,
+    allOptions,
+    optionFieldName,
+    getValues,
+    trigger
+  )
 
   return multiselectOptionWrapper(
     radioField,

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -20,6 +20,7 @@ import {
 } from "../types/backend-swagger"
 import { AddressHolder } from "../utilities/constants"
 import { FormAddressAlternate } from "./address/FormAddressAlternate"
+import { ReactNode } from "react"
 
 // Removes periods, commas, and apostrophes
 export const cleanMultiselectString = (name: string | undefined) => {
@@ -120,39 +121,31 @@ export const getAllOptions = (
   return optionPaths
 }
 
-export const getRadioFields = (
-  options: MultiselectOption[],
+const getRadioField = (
+  option: MultiselectOption,
   register: UseFormMethods["register"],
-  question: MultiselectQuestion,
-  applicationSection: MultiselectQuestionsApplicationSectionEnum,
-  errors?: UseFormMethods["errors"]
+  setValue: UseFormMethods["setValue"],
+  allOptions: string[],
+  optionFieldName: string
 ) => {
   return (
-    <fieldset>
-      {applicationSection === MultiselectQuestionsApplicationSectionEnum.preferences && (
-        <legend className="text__caps-spaced mb-4">{question?.text}</legend>
-      )}
-      <FieldGroup
-        fieldGroupClassName="grid grid-cols-1"
-        fieldClassName="ml-0"
-        type={"radio"}
-        groupNote={t("t.pleaseSelectOne")}
-        name={fieldName(question?.text, applicationSection)}
-        error={errors && errors?.application?.programs?.[question?.text]}
-        errorMessage={errors && t("errors.selectAnOption")}
+    <>
+      <Field
+        type="radio"
+        id={option.text}
+        name={optionFieldName}
+        label={option.text}
         register={register}
-        validation={{ required: true }}
-        fields={options?.map((option) => {
-          return {
-            id: `${question?.text}-${option?.text}`,
-            label: option?.text,
-            value: option?.text,
-            description: option?.description,
-            dataTestId: "app-question-option",
-          }
-        })}
+        inputProps={{
+          value: !!option.text,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+            uncheckOptions(allOptions, setValue)
+            setValue(optionFieldName, e.target.value)
+          },
+        }}
+        dataTestId={"app-question-option"}
       />
-    </fieldset>
+    </>
   )
 }
 
@@ -209,39 +202,23 @@ const getCheckboxField = (
   )
 }
 
-// Get an individual question option checkbox field
-export const getCheckboxOption = (
+export const multiselectOptionWrapper = (
+  field: ReactNode,
   option: MultiselectOption,
   question: MultiselectQuestion,
   applicationSection: MultiselectQuestionsApplicationSectionEnum,
   register: UseFormMethods["register"],
-  setValue: UseFormMethods["setValue"],
-  getValues: UseFormMethods["getValues"],
-  allOptions: string[],
   watchFields: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [x: string]: any
   },
-  errors?: UseFormMethods["errors"],
-  trigger?: UseFormMethods["trigger"],
-  exclusiveKeys?: string[]
+  errors?: UseFormMethods["errors"]
 ) => {
   const optionFieldName = fieldName(question.text, applicationSection, option.text)
   return (
     <div className="mb-3" key={option.text}>
       <div className={`mb-3 field ${resolveObject(optionFieldName, errors) ? "error" : ""}`}>
-        {getCheckboxField(
-          option,
-          question,
-          applicationSection,
-          register,
-          setValue,
-          getValues,
-          allOptions,
-          optionFieldName,
-          trigger,
-          exclusiveKeys
-        )}
+        {field}
       </div>
       {option.description && (
         <div className="ml-8 -mt-3 mb-6">
@@ -314,47 +291,111 @@ export const getCheckboxOption = (
   )
 }
 
-export const mapRadiosToApi = (
-  data: { [name: string]: string },
-  question: MultiselectQuestion
-): ApplicationMultiselectQuestion => {
-  const [key, value] = Object.entries(data)[0]
-  const options: ApplicationMultiselectQuestionOption[] = []
+// Get an individual question option checkbox field
+export const getCheckboxOption = (
+  option: MultiselectOption,
+  question: MultiselectQuestion,
+  applicationSection: MultiselectQuestionsApplicationSectionEnum,
+  register: UseFormMethods["register"],
+  setValue: UseFormMethods["setValue"],
+  getValues: UseFormMethods["getValues"],
+  allOptions: string[],
+  watchFields: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [x: string]: any
+  },
+  errors?: UseFormMethods["errors"],
+  trigger?: UseFormMethods["trigger"],
+  exclusiveKeys?: string[]
+) => {
+  const optionFieldName = fieldName(question.text, applicationSection, option.text)
+  const checkboxField = getCheckboxField(
+    option,
+    question,
+    applicationSection,
+    register,
+    setValue,
+    getValues,
+    allOptions,
+    optionFieldName,
+    trigger,
+    exclusiveKeys
+  )
 
-  if (value) {
-    options.push({
-      key: value,
-      checked: true,
-      extraData: [],
-    })
-  }
-
-  question?.options?.forEach((option) => {
-    if (option.text !== value) {
-      options.push({
-        key: option.text,
-        checked: false,
-        extraData: [],
-      })
-    }
-  })
-
-  return {
-    multiselectQuestionId: question.id,
-    key,
-    claimed: Object.keys(data)?.length !== 0,
-    options,
-  }
+  return multiselectOptionWrapper(
+    checkboxField,
+    option,
+    question,
+    applicationSection,
+    register,
+    watchFields,
+    errors
+  )
 }
 
+// Get an individual question option radio field
+export const getRadioOption = (
+  option: MultiselectOption,
+  question: MultiselectQuestion,
+  applicationSection: MultiselectQuestionsApplicationSectionEnum,
+  register: UseFormMethods["register"],
+  setValue: UseFormMethods["setValue"],
+  allOptions: string[],
+  watchFields: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [x: string]: any
+  },
+  errors?: UseFormMethods["errors"]
+) => {
+  const optionFieldName = fieldName(question.text, applicationSection, option.text)
+  const radioField = getRadioField(option, register, setValue, allOptions, optionFieldName)
+
+  return multiselectOptionWrapper(
+    radioField,
+    option,
+    question,
+    applicationSection,
+    register,
+    watchFields,
+    errors
+  )
+}
+
+function cleanRadioObject(obj: Record<string, any>) {
+  // Remove nulls
+  let cleanedObj = Object.entries(obj).reduce((acc, [key, value]) => {
+    if (value !== null) {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+
+  // Convert "true" to true
+  cleanedObj = Object.entries(cleanedObj).reduce((acc, [key, value]) => {
+    if (
+      value === "true" &&
+      !(key.includes(AddressHolder.Name) || key.includes(AddressHolder.Relationship))
+    ) {
+      acc[key] = true
+    } else {
+      acc[key] = value
+    }
+    return acc
+  }, {})
+
+  return cleanedObj
+}
 export const mapCheckboxesToApi = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   formData: { [name: string]: any },
   question: MultiselectQuestion,
   applicationSection: MultiselectQuestionsApplicationSectionEnum
 ): ApplicationMultiselectQuestion => {
-  const data =
+  const rawData =
     formData["application"][applicationSection][cleanMultiselectString(question.text) || ""]
+
+  const data = cleanRadioObject(rawData) // removes nulls and converts "true" to true for radio fields
+
   const claimed = !!Object.keys(data).filter((key) => data[key] === true).length
 
   const addressFields = Object.keys(data).filter((option) => Object.keys(data[option]))
@@ -451,48 +492,49 @@ export const mapApiToMultiselectForm = (
      *    }
      * }
      */
-    if (appQuestion.inputType === "checkbox") {
-      options = question.options.reduce((acc, curr) => {
-        const claimed = curr.checked
-        const cleanKey = cleanMultiselectString(curr.key) || ""
-        if (appQuestion.inputType === "checkbox") {
-          acc[cleanKey] = claimed
-          if (curr.extraData?.length) {
-            acc[`${cleanKey}-address`] = curr.extraData[0].value
-
-            const addressHolderName = curr.extraData?.find(
-              (field) => field.key === AddressHolder.Name
-            )
-            if (addressHolderName) {
-              acc[`${cleanKey}-${AddressHolder.Name}`] = addressHolderName.value
-            }
-
-            const addressHolderRelationship = curr.extraData?.find(
-              (field) => field.key === AddressHolder.Relationship
-            )
-            if (addressHolderRelationship) {
-              acc[`${cleanKey}-${AddressHolder.Relationship}`] = addressHolderRelationship.value
-            }
-            if (curr?.mapPinPosition) {
-              acc[`${cleanKey}-mapPinPosition`] = curr.mapPinPosition
-            }
-          }
-        }
-
-        return acc
-      }, {})
-
-      questionsFormData["application"][applicationSection][question.key] = options
-    }
 
     /**
      * Radio fields expect the following format
-     * QuestionName: OptionName
+     * QuestionName: {
+     *    OptionName1: "true"
+     *    OptionName1-address: {
+     *      street: "",
+     *      city: "",
+     *      ...
+     *    }
+     * }
      */
-    if (appQuestion.inputType === "radio") {
-      const selectedRadio = question.options.filter((option) => !!option.checked)[0]
-      questionsFormData["application"][applicationSection][question?.key] = selectedRadio?.key
-    }
+    options = question.options.reduce((acc, curr) => {
+      const claimed = curr.checked
+      const cleanKey = cleanMultiselectString(curr.key) || ""
+      if (appQuestion.inputType === "checkbox") {
+        acc[cleanKey] = claimed
+      } else {
+        acc[cleanKey] = claimed.toString()
+      }
+      if (curr.extraData?.length) {
+        acc[`${cleanKey}-address`] = curr.extraData[0].value
+
+        const addressHolderName = curr.extraData?.find((field) => field.key === AddressHolder.Name)
+        if (addressHolderName) {
+          acc[`${cleanKey}-${AddressHolder.Name}`] = addressHolderName.value
+        }
+
+        const addressHolderRelationship = curr.extraData?.find(
+          (field) => field.key === AddressHolder.Relationship
+        )
+        if (addressHolderRelationship) {
+          acc[`${cleanKey}-${AddressHolder.Relationship}`] = addressHolderRelationship.value
+        }
+        if (curr?.mapPinPosition) {
+          acc[`${cleanKey}-mapPinPosition`] = curr.mapPinPosition
+        }
+      }
+
+      return acc
+    }, {})
+
+    questionsFormData["application"][applicationSection][question.key] = options
   })
 
   return { ...questionsFormData }

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -1,13 +1,14 @@
-import React, { useEffect, useMemo, useState } from "react"
-import { Field, t, FieldGroup, resolveObject } from "@bloom-housing/ui-components"
+import React, { ReactNode, useEffect, useMemo, useState } from "react"
+import { Field, t, resolveObject } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
-import { useFormContext } from "react-hook-form"
+import { useFormContext, UseFormMethods } from "react-hook-form"
 import {
   stateKeys,
   getInputType,
   fieldName,
   AddressHolder,
   cleanMultiselectString,
+  getAllOptions,
 } from "@bloom-housing/shared-helpers"
 import {
   ListingMultiselectQuestion,
@@ -28,6 +29,13 @@ type FormMultiselectQuestionsProps = {
   sectionTitle: string
 }
 
+// Set the value as false for a set of option field names
+const uncheckOptions = (options: string[], setValue: (key: string, value: boolean) => void) => {
+  options?.forEach((option) => {
+    setValue(option, false)
+  })
+}
+
 const FormMultiselectQuestions = ({
   applicationSection,
   questions,
@@ -39,6 +47,7 @@ const FormMultiselectQuestions = ({
   const {
     register,
     watch,
+    setValue,
     formState: { errors },
   } = formMethods
 
@@ -77,7 +86,11 @@ const FormMultiselectQuestions = ({
 
   const watchQuestions = watch(allOptionFieldNames)
 
-  const getCheckboxOption = (option: MultiselectOption, question: MultiselectQuestion) => {
+  const multiselectOptionWrapper = (
+    field: ReactNode,
+    option: MultiselectOption,
+    question: MultiselectQuestion
+  ) => {
     const optionFieldName = fieldName(
       question.text,
       applicationSection,
@@ -85,13 +98,7 @@ const FormMultiselectQuestions = ({
     )
     return (
       <React.Fragment key={option.text}>
-        <Field
-          id={`${question?.text}-${option.text}`}
-          name={optionFieldName}
-          type={"checkbox"}
-          label={option.text}
-          register={register}
-        />
+        {field}
 
         {watchQuestions[optionFieldName] && option?.collectName && (
           <Field
@@ -146,27 +153,54 @@ const FormMultiselectQuestions = ({
     )
   }
 
-  const getRadioFields = (options: MultiselectOption[], question: MultiselectQuestion) => {
-    return (
-      <fieldset>
-        <FieldGroup
-          fieldGroupClassName="grid grid-cols-1"
-          fieldClassName="ml-0"
-          type={"radio"}
-          name={fieldName(question.text, applicationSection)}
-          register={register}
-          dataTestId={"app-question-option"}
-          fields={options?.map((option) => {
-            return {
-              id: `${question?.text}-${option.text}`,
-              label: option?.text,
-              value: option?.text,
-              description: option?.description,
-            }
-          })}
-        />
-      </fieldset>
+  const getCheckboxOption = (option: MultiselectOption, question: MultiselectQuestion) => {
+    const optionFieldName = fieldName(
+      question.text,
+      applicationSection,
+      cleanMultiselectString(option.text)
     )
+
+    const checkboxField = (
+      <Field
+        id={`${question?.text}-${option.text}`}
+        name={optionFieldName}
+        labelClassName="font-semibold"
+        type={"checkbox"}
+        label={option.text}
+        register={register}
+      />
+    )
+    return multiselectOptionWrapper(checkboxField, option, question)
+  }
+
+  const getRadioOption = (
+    option: MultiselectOption,
+    question: MultiselectQuestion,
+    setValue: UseFormMethods["setValue"]
+  ) => {
+    const optionFieldName = fieldName(
+      question.text,
+      applicationSection,
+      cleanMultiselectString(option.text)
+    )
+
+    const radioField = (
+      <Field
+        id={`${question?.text}-${option.text}`}
+        name={optionFieldName}
+        type={"radio"}
+        label={option.text}
+        register={register}
+        inputProps={{
+          value: !!option.text,
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+            uncheckOptions(getAllOptions(question, applicationSection), setValue)
+            setValue(optionFieldName, e.target.value)
+          },
+        }}
+      />
+    )
+    return multiselectOptionWrapper(radioField, option, question)
   }
 
   return (
@@ -179,29 +213,37 @@ const FormMultiselectQuestions = ({
             const inputType = getInputType(question.options as unknown as MultiselectOption[])
             return (
               <FieldValue label={question.text}>
-                {inputType === "checkbox" ? (
-                  <fieldset className={"mt-4"}>
-                    {question?.options
-                      ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
-                      .map((option) => {
-                        return getCheckboxOption(option, question)
-                      })}
-                    {question?.optOutText &&
-                      getCheckboxOption(
-                        {
-                          text: question.optOutText,
-                          description: null,
-                          links: [],
-                          collectAddress: false,
-                          exclusive: true,
-                          ordinal: question.options.length,
-                        },
-                        question
-                      )}
-                  </fieldset>
-                ) : (
-                  getRadioFields(question?.options, question)
-                )}
+                <fieldset className={"mt-4"}>
+                  {inputType === "checkbox" ? (
+                    <>
+                      {question?.options
+                        ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
+                        .map((option) => {
+                          return getCheckboxOption(option, question)
+                        })}
+                      {question?.optOutText &&
+                        getCheckboxOption(
+                          {
+                            text: question.optOutText,
+                            description: null,
+                            links: [],
+                            collectAddress: false,
+                            exclusive: true,
+                            ordinal: question.options.length,
+                          },
+                          question
+                        )}
+                    </>
+                  ) : (
+                    <>
+                      {question?.options
+                        ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
+                        .map((option) => {
+                          return getRadioOption(option, question, setValue)
+                        })}
+                    </>
+                  )}
+                </fieldset>
               </FieldValue>
             )
           })}

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -241,6 +241,19 @@ const FormMultiselectQuestions = ({
                         .map((option) => {
                           return getRadioOption(option, question, setValue)
                         })}
+                      {question?.optOutText &&
+                        getRadioOption(
+                          {
+                            text: question.optOutText,
+                            description: null,
+                            links: [],
+                            collectAddress: false,
+                            exclusive: true,
+                            ordinal: question.options.length,
+                          },
+                          question,
+                          setValue
+                        )}
                     </>
                   )}
                 </fieldset>

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -4,8 +4,6 @@ import {
   adaFeatureKeys,
   mapApiToMultiselectForm,
   mapCheckboxesToApi,
-  mapRadiosToApi,
-  getInputType,
 } from "@bloom-housing/shared-helpers"
 import { FormTypes, ApplicationTypes, Address } from "../../lib/applications/FormTypes"
 
@@ -14,7 +12,6 @@ import utc from "dayjs/plugin/utc"
 dayjs.extend(utc)
 import customParseFormat from "dayjs/plugin/customParseFormat"
 import {
-  MultiselectOption,
   HouseholdMember,
   ApplicationSubmissionTypeEnum,
   MultiselectQuestion,
@@ -141,29 +138,11 @@ export const mapFormToApi = ({
   })()
 
   const preferencesData = preferences.map((pref: MultiselectQuestion) => {
-    const inputType = getInputType(pref.options as unknown as MultiselectOption[])
-    if (inputType === "checkbox") {
-      return mapCheckboxesToApi(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences)
-    }
-    if (inputType === "radio") {
-      return mapRadiosToApi(
-        { [pref.text]: data.application.preferences[pref.text] as string },
-        pref
-      )
-    }
+    return mapCheckboxesToApi(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences)
   })
 
   const programsData = programs.map((program: MultiselectQuestion) => {
-    const inputType = getInputType(program.options as unknown as MultiselectOption[])
-    if (inputType === "checkbox") {
-      return mapCheckboxesToApi(data, program, MultiselectQuestionsApplicationSectionEnum.programs)
-    }
-    if (inputType === "radio") {
-      return mapRadiosToApi(
-        { [program.text]: data.application.programs[program.text] as string },
-        program
-      )
-    }
+    return mapCheckboxesToApi(data, program, MultiselectQuestionsApplicationSectionEnum.programs)
   })
 
   // additional phone

--- a/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
+++ b/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
@@ -9,11 +9,10 @@ import {
   getExclusiveKeys,
   getInputType,
   getPageQuestion,
-  getRadioFields,
+  getRadioOption,
   listingSectionQuestions,
   mapApiToMultiselectForm,
   mapCheckboxesToApi,
-  mapRadiosToApi,
   OnClientSide,
   PageView,
   pushGtmEvent,
@@ -53,6 +52,8 @@ const ApplicationMultiselectQuestionStep = ({
   const { profile } = useContext(AuthContext)
   const { conductor, application, listing } = useFormConductor(applicationStep)
 
+  console.log(conductor)
+
   const questions = listingSectionQuestions(listing, applicationSection)
   const [page, setPage] = useState(conductor.navigatedThroughBack ? questions.length : 1)
   const [applicationQuestions, setApplicationQuestions] = useState(application[applicationSection])
@@ -90,10 +91,7 @@ const ApplicationMultiselectQuestionStep = ({
 
   const onSubmit = (data) => {
     if (verifyAddressStep === 0) {
-      body.current =
-        questionSetInputType === "checkbox"
-          ? mapCheckboxesToApi(data, question, applicationSection)
-          : mapRadiosToApi(data.application[applicationSection], question)
+      body.current = mapCheckboxesToApi(data, question, applicationSection)
     }
 
     // Verify address on preferences
@@ -177,6 +175,19 @@ const ApplicationMultiselectQuestionStep = ({
     )
   }
 
+  const radioOption = (option: MultiselectOption) => {
+    return getRadioOption(
+      option,
+      question,
+      applicationSection,
+      register,
+      setValue,
+      allOptionNames,
+      watchQuestions,
+      errors
+    )
+  }
+
   const allOptions = question?.options ? [...question.options] : []
   if (question?.optOutText) {
     allOptions.push({
@@ -243,41 +254,49 @@ const ApplicationMultiselectQuestionStep = ({
 
           <div style={{ display: verifyAddress ? "none" : "block" }} key={question?.id}>
             <CardSection>
-              {questionSetInputType === "checkbox" ? (
-                <fieldset>
-                  <legend className="text__caps-spaced mb-4 sr-only">{question?.text}</legend>
-                  {applicationSection ===
-                    MultiselectQuestionsApplicationSectionEnum.preferences && (
-                    <div className="mb-6">
-                      <p className="text__caps-spaced m-0">{question?.text}</p>
-                      {question?.description && (
-                        <p className="field-note mt-3">{question?.description}</p>
-                      )}
-                      {question.links.map((link) => (
-                        <a
-                          key={link.url}
-                          className="block text-base mt-3 text-blue-500 underline"
-                          href={link.url}
-                          target={"_blank"}
-                          rel="noreferrer noopener"
-                        >
-                          {link.title}
-                        </a>
-                      ))}
-                    </div>
-                  )}
-                  <p className="field-note mb-3">
-                    {t("application.household.preferredUnit.optionsLabel")}
-                  </p>
-                  {allOptions
-                    ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
-                    .map((option) => {
-                      return checkboxOption(option)
-                    })}
-                </fieldset>
-              ) : (
-                getRadioFields(allOptions, register, question, applicationSection, errors)
-              )}
+              <fieldset>
+                <legend className="text__caps-spaced mb-4 sr-only">{question?.text}</legend>
+                {applicationSection === MultiselectQuestionsApplicationSectionEnum.preferences && (
+                  <div className="mb-6">
+                    <p className="text__caps-spaced m-0">{question?.text}</p>
+                    {question?.description && (
+                      <p className="field-note mt-3">{question?.description}</p>
+                    )}
+                    {question.links.map((link) => (
+                      <a
+                        key={link.url}
+                        className="block text-base mt-3 text-blue-500 underline"
+                        href={link.url}
+                        target={"_blank"}
+                        rel="noreferrer noopener"
+                      >
+                        {link.title}
+                      </a>
+                    ))}
+                  </div>
+                )}
+                {questionSetInputType === "checkbox" ? (
+                  <>
+                    <p className="field-note mb-3">
+                      {t("application.household.preferredUnit.optionsLabel")}
+                    </p>
+                    {allOptions
+                      ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
+                      .map((option) => {
+                        return checkboxOption(option)
+                      })}
+                  </>
+                ) : (
+                  <>
+                    <p className="field-note mb-3">{t("t.pleaseSelectOne")}</p>
+                    {allOptions
+                      ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
+                      .map((option) => {
+                        return radioOption(option)
+                      })}
+                  </>
+                )}
+              </fieldset>
             </CardSection>
           </div>
           {verifyAddress && (

--- a/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
+++ b/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
@@ -52,8 +52,6 @@ const ApplicationMultiselectQuestionStep = ({
   const { profile } = useContext(AuthContext)
   const { conductor, application, listing } = useFormConductor(applicationStep)
 
-  console.log(conductor)
-
   const questions = listingSectionQuestions(listing, applicationSection)
   const [page, setPage] = useState(conductor.navigatedThroughBack ? questions.length : 1)
   const [applicationQuestions, setApplicationQuestions] = useState(application[applicationSection])

--- a/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
+++ b/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
@@ -184,7 +184,9 @@ const ApplicationMultiselectQuestionStep = ({
       setValue,
       allOptionNames,
       watchQuestions,
-      errors
+      getValues,
+      errors,
+      trigger
     )
   }
 


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #3835 and #3830

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

It aligns radio fields behaviour to checkboxes (for multiselect options), so it adds description, and geocoding fields (address, address holder name / relationship).
This component is reused both for programs and preferences, so even that is preferences change it might affect programs (but it shouldn't).

## How Can This Be Tested/Reviewed?

On partners portal set all preferences options to exclusive (for selected preference). Also test with `Can applicants opt out?` set to `yes` for preference. That will work both for digital app and paper app.
- make sure user can't submit empty radio preference for digital app.
- make sure programs, and checkboxes work as before.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [x] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
