### PR TITLE
FIX: Case Insensitive Name Matching for Applicants

### DIFF
--- a/api/src/services/application-flagged-set.service.ts
+++ b/api/src/services/application-flagged-set.service.ts
@@ -649,8 +649,8 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
       return `${listingId}-email-${application.applicant.emailAddress}`;
     } else {
       return (
-        `${listingId}-nameAndDOB-${application.applicant.firstName}-${application.applicant.lastName}-${application.applicant.birthMonth}-` +
-        `${application.applicant.birthDay}-${application.applicant.birthYear}`
+        `${listingId}-nameAndDOB-${application.applicant.firstName.toLowerCase()}-${application.applicant.lastName.toLowerCase()}` +
+        `-${application.applicant.birthMonth}-${application.applicant.birthDay}-${application.applicant.birthYear}`
       );
     }
   }
@@ -748,6 +748,7 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
                         some: {
                           firstName: {
                             in: firstNames,
+                            mode: 'insensitive',
                           },
                         },
                       },
@@ -756,6 +757,7 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
                       applicant: {
                         firstName: {
                           in: firstNames,
+                          mode: 'insensitive',
                         },
                       },
                     },
@@ -768,6 +770,7 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
                         some: {
                           lastName: {
                             in: lastNames,
+                            mode: 'insensitive',
                           },
                         },
                       },
@@ -776,6 +779,7 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
                       applicant: {
                         lastName: {
                           in: lastNames,
+                          mode: 'insensitive',
                         },
                       },
                     },

--- a/api/test/unit/services/application-flagged-set.service.spec.ts
+++ b/api/test/unit/services/application-flagged-set.service.spec.ts
@@ -83,6 +83,7 @@ describe('Testing application flagged set service', () => {
                       'household first name 1',
                       'household first name 2',
                     ],
+                    mode: 'insensitive',
                   },
                 },
               },
@@ -95,6 +96,7 @@ describe('Testing application flagged set service', () => {
                     'household first name 1',
                     'household first name 2',
                   ],
+                  mode: 'insensitive',
                 },
               },
             },
@@ -111,6 +113,7 @@ describe('Testing application flagged set service', () => {
                       'household last name 1',
                       'household last name 2',
                     ],
+                    mode: 'insensitive',
                   },
                 },
               },
@@ -123,6 +126,7 @@ describe('Testing application flagged set service', () => {
                     'household last name 1',
                     'household last name 2',
                   ],
+                  mode: 'insensitive',
                 },
               },
             },
@@ -346,6 +350,24 @@ describe('Testing application flagged set service', () => {
           applicant: {
             firstName: 'first name',
             lastName: 'last name',
+            birthMonth: 5,
+            birthDay: 6,
+            birthYear: 2000,
+          },
+        } as unknown as Application,
+        RuleEnum.nameAndDOB,
+        'example id',
+      ),
+    ).toEqual('example id-nameAndDOB-first name-last name-5-6-2000');
+  });
+
+  it('should build rule key in lowercase when rule is nameAndDOB', async () => {
+    expect(
+      await service.buildRuleKey(
+        {
+          applicant: {
+            firstName: 'FIRST Name',
+            lastName: 'lAsT nAMe',
             birthMonth: 5,
             birthDay: 6,
             birthYear: 2000,
@@ -700,7 +722,7 @@ describe('Testing application flagged set service', () => {
         id: 'example id 1',
       },
       {
-        id: 'example id 2',
+        id: 'Example id 2',
       },
     ]);
 
@@ -714,7 +736,7 @@ describe('Testing application flagged set service', () => {
         id: 'example id 1',
       },
       {
-        id: 'example id 2',
+        id: 'Example id 2',
       },
     ]);
 
@@ -964,7 +986,7 @@ describe('Testing application flagged set service', () => {
         id: 'example id 1',
       },
       {
-        id: 'example id 2',
+        id: 'Example id 2',
       },
     ]);
 
@@ -979,7 +1001,7 @@ describe('Testing application flagged set service', () => {
         id: 'example id 1',
       },
       {
-        id: 'example id 2',
+        id: 'Example id 2',
       },
     ]);
 


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #issue

- [ ] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description
Currently, our db query tries to match string with case sensitive defaulted for strings. Thus when there are duplicate applications with the same first/last name, they can slip through the flagging process.

These changes switch our db query to case insensitive as well as keep our ruleKey lowercase.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.
Create applications for the same listing, either through the partner site or public site, with the same name and birthdate. Make sure some of the names have mixed casing, for example: `Eric`, `eric`, `eRiC`, etc.
Using the backend api, call `applicationFlagSet/process` or edit the listing the applications are on to trigger it.
Wait until complete, navigate to the listing's application page, click on `Pending Reviews`, confirm all duplicates are present.

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.
Ran all backend and partner tests. Added e2e and unit test cases to the backend.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have added QA notes to the issue with applicable URLs
- [ ] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
