### PR TITLE
fix: account for multiselect type mismatch (#686)

### DIFF
--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -244,6 +244,13 @@ const ListingFormActions = ({
                   id: listing.id,
                   body: {
                     ...(listing as unknown as ListingUpdate),
+                    // account for type mismatch between ListingMultiSelectQuestionType and IdDto
+                    listingMultiselectQuestions: listing.listingMultiselectQuestions?.map(
+                      (multiselectQuestions) => ({
+                        ordinal: multiselectQuestions.ordinal,
+                        id: multiselectQuestions.multiselectQuestions?.id,
+                      })
+                    ),
                     status: ListingsStatusEnum.active,
                   },
                 })


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

**This is a carry-over from HBA to address support issue**
This PR addresses #3996

- [ ] This change addresses the issue in full
- [x] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This fix resolves the error below which was blocking users from clicking the "Approve and Publish" button from the detail (not edit) view. This is caused by a type mismatch. The frontend listing data had the ListingMultiSelectQuestionType shape but the update function in the listing.service was expecting an idDto for listing multiselect question data. After talking with @YazeedLoonat, it was decided to do the work on the frontend to format the data since other formatting work is already done there instead of on the backend. 
<img width="544" alt="Screenshot 2024-04-03 at 4 56 57 PM" src="https://github.com/housingbayarea/bloom/assets/53269332/62fc92b1-7f6a-4c03-bf39-940db166b912">

**Note**: Since the technical notes in the attached ticket present a more thorough investigation around consistent submitting of listing updates, I decided this one off fix was okay for now.

## How Can This Be Tested/Reviewed?

This can be tested locally by opening a partners user window and a separate admin user window. Find a listing that has all its required fields filled out correctly (note that some seeded public listings have data that fails validation, i.e. fake phone number) and submit it for review by the partners user. Then on the admin session, click "Approve and Publish" and the listing should successfully publish.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [ ] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [ ] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
