### PR TITLE
Fix: Update Jurisdictional Admin E2E Tests and Correct Jurisdictional Admin Delete User

### DIFF
--- a/api/src/enums/user/view-enum.ts
+++ b/api/src/enums/user/view-enum.ts
@@ -1,0 +1,4 @@
+export enum UserViews {
+  jurisdictions = 'jurisdictions',
+  full = 'full',
+}

--- a/api/src/enums/user/view-enum.ts
+++ b/api/src/enums/user/view-enum.ts
@@ -1,4 +1,4 @@
 export enum UserViews {
-  jurisdictions = 'jurisdictions',
+  base = 'base',
   full = 'full',
 }

--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -9,6 +9,7 @@ import { sign, verify } from 'jsonwebtoken';
 import { Prisma } from '@prisma/client';
 import { UpdatePassword } from '../dtos/auth/update-password.dto';
 import { MfaType } from '../enums/mfa/mfa-type-enum';
+import { UserViews } from '../enums/user/view-enum';
 import { isPasswordValid, passwordToHash } from '../utilities/password-helpers';
 import { RequestMfaCodeResponse } from '../dtos/mfa/request-mfa-code-response.dto';
 import { RequestMfaCode } from '../dtos/mfa/request-mfa-code.dto';
@@ -186,7 +187,7 @@ export class AuthService {
   async requestMfaCode(dto: RequestMfaCode): Promise<RequestMfaCodeResponse> {
     const user = await this.userService.findUserOrError(
       { email: dto.email },
-      true,
+      UserViews.full,
     );
 
     if (!user.mfaEnabled) {
@@ -291,10 +292,7 @@ export class AuthService {
   async confirmUser(dto: Confirm, res?: Response): Promise<SuccessDTO> {
     const token = verify(dto.token, process.env.APP_SECRET) as IdAndEmail;
 
-    let user = await this.userService.findUserOrError(
-      { userId: token.id },
-      false,
-    );
+    let user = await this.userService.findUserOrError({ userId: token.id });
 
     if (user.confirmationToken !== dto.token) {
       throw new BadRequestException(

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -48,22 +48,16 @@ import { generateSingleUseCode } from '../utilities/generate-single-use-code';
   it handles all the backend's business logic for reading/writing/deleting user data
 */
 
-const view: Prisma.UserAccountsInclude = {
-  listings: true,
-  jurisdictions: true,
-  userRoles: true,
-};
-
 const views: Partial<Record<UserViews, Prisma.UserAccountsInclude>> = {
-  jurisdictions: {
+  base: {
     jurisdictions: true,
+    userRoles: true,
   },
 };
 
 views.full = {
-  ...views.jurisdictions,
+  ...views.base,
   listings: true,
-  userRoles: true,
 };
 
 type findByOptions = {
@@ -312,7 +306,7 @@ export class UserService {
   async delete(userId: string, requestingUser: User): Promise<SuccessDTO> {
     const targetUser = await this.findUserOrError(
       { userId: userId },
-      UserViews.jurisdictions,
+      UserViews.base,
     );
 
     this.authorizeAction(

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -819,20 +819,20 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         .expect(200);
     });
 
-    it('should error as forbidden for retrieve endpoint', async () => {
+    it('should succeed for retrieve endpoint', async () => {
       const userA = await prisma.userAccounts.create({
-        data: await userFactory(),
+        data: await userFactory({ jurisdictionIds: [jurisId] }),
       });
 
       await request(app.getHttpServer())
         .get(`/user/${userA.id}`)
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
-    it('should error as forbidden for update endpoint', async () => {
+    it('should succeed for update endpoint', async () => {
       const userA = await prisma.userAccounts.create({
-        data: await userFactory(),
+        data: await userFactory({ jurisdictionIds: [jurisId] }),
       });
 
       await request(app.getHttpServer())
@@ -841,14 +841,15 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
           id: userA.id,
           firstName: 'New User First Name',
           lastName: 'New User Last Name',
+          jurisdictions: [{ id: jurisId } as IdDTO],
         } as UserUpdate)
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
-    it('should error as forbidden for delete endpoint', async () => {
+    it('should succeed for delete endpoint', async () => {
       const userA = await prisma.userAccounts.create({
-        data: await userFactory(),
+        data: await userFactory({ jurisdictionIds: [jurisId] }),
       });
 
       await request(app.getHttpServer())
@@ -857,7 +858,7 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
           id: userA.id,
         } as IdDTO)
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
     it('should succeed for public resend confirmation endpoint', async () => {
@@ -950,7 +951,10 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
 
       await request(app.getHttpServer())
         .post(`/user/invite`)
-        .send(buildUserInviteMock(juris, 'partnerUser+jurisCorrect@email.com'))
+        .send(
+          // builds an invite for an admin
+          buildUserInviteMock(jurisId, 'partnerUser+jurisCorrect@email.com'),
+        )
         .set('Cookie', cookies)
         .expect(403);
     });

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -17,6 +17,7 @@ import { User } from '../../../src/dtos/users/user.dto';
 import { PermissionService } from '../../../src/services/permission.service';
 import { permissionActions } from '../../../src/enums/permissions/permission-actions-enum';
 import { OrderByEnum } from '../../../src/enums/shared/order-by-enum';
+import { UserViews } from '../../../src/enums/user/view-enum';
 
 describe('Testing user service', () => {
   let service: UserService;
@@ -370,7 +371,7 @@ describe('Testing user service', () => {
       prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
         id,
       });
-      const res = await service.findUserOrError({ userId: id }, true);
+      const res = await service.findUserOrError({ userId: id }, UserViews.full);
       expect(res).toEqual({ id });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
@@ -384,12 +385,35 @@ describe('Testing user service', () => {
       });
     });
 
+    it('should find user by id and include only jurisdictions joins', async () => {
+      const id = randomUUID();
+      prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
+        id,
+      });
+      const res = await service.findUserOrError(
+        { userId: id },
+        UserViews.jurisdictions,
+      );
+      expect(res).toEqual({ id });
+      expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: true,
+        },
+        where: {
+          id,
+        },
+      });
+    });
+
     it('should find user by email and include joins', async () => {
       const email = 'example@email.com';
       prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
         email,
       });
-      const res = await service.findUserOrError({ email: email }, true);
+      const res = await service.findUserOrError(
+        { email: email },
+        UserViews.full,
+      );
       expect(res).toEqual({ email });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
@@ -408,7 +432,7 @@ describe('Testing user service', () => {
       prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
         id,
       });
-      const res = await service.findUserOrError({ userId: id }, false);
+      const res = await service.findUserOrError({ userId: id });
       expect(res).toEqual({ id });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         where: {
@@ -422,7 +446,7 @@ describe('Testing user service', () => {
       prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
         email,
       });
-      const res = await service.findUserOrError({ email: email }, false);
+      const res = await service.findUserOrError({ email: email });
       expect(res).toEqual({ email });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         where: {
@@ -435,7 +459,7 @@ describe('Testing user service', () => {
       const email = 'example@email.com';
       prisma.userAccounts.findUnique = jest.fn().mockResolvedValue(null);
       await expect(
-        async () => await service.findUserOrError({ email: email }, false),
+        async () => await service.findUserOrError({ email: email }),
       ).rejects.toThrowError(
         'user email: example@email.com was requested but not found',
       );
@@ -859,6 +883,9 @@ describe('Testing user service', () => {
         where: {
           id,
         },
+        include: {
+          jurisdictions: true,
+        },
       });
       expect(prisma.userAccounts.delete).toHaveBeenCalledWith({
         where: {
@@ -901,6 +928,9 @@ describe('Testing user service', () => {
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         where: {
           id,
+        },
+        include: {
+          jurisdictions: true,
         },
       });
 

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -390,14 +390,12 @@ describe('Testing user service', () => {
       prisma.userAccounts.findUnique = jest.fn().mockResolvedValue({
         id,
       });
-      const res = await service.findUserOrError(
-        { userId: id },
-        UserViews.jurisdictions,
-      );
+      const res = await service.findUserOrError({ userId: id }, UserViews.base);
       expect(res).toEqual({ id });
       expect(prisma.userAccounts.findUnique).toHaveBeenCalledWith({
         include: {
           jurisdictions: true,
+          userRoles: true,
         },
         where: {
           id,
@@ -885,6 +883,7 @@ describe('Testing user service', () => {
         },
         include: {
           jurisdictions: true,
+          userRoles: true,
         },
       });
       expect(prisma.userAccounts.delete).toHaveBeenCalledWith({
@@ -931,6 +930,7 @@ describe('Testing user service', () => {
         },
         include: {
           jurisdictions: true,
+          userRoles: true,
         },
       });
 


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses [#issue](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4024)

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

Part 1: Jurisdictional Admin E2E Permission Tests were falsely passing because they we not correctly creating the test user and did not match the actual permissions juris admins have. To correct this, correctly called the user factory and updated the tests to match the expected permissions.

Part 2: In doing so, discovered that when a jurisdictional admin attempts to delete a user (from their jurisdiction or not) and error is thrown due to a missing field on the target user and then the target user is deleted anyway.
We now load the jurisdictions onto the target user and compare them properly with the jurisdictions the jurisdictional admin has access to before deleting.
In doing this, switched the UserService to use views.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review.

Login to the partner site as a jurisdictional admin. Navigate to the Users page. Select a user for deletion. Make sure it deletes without an error.
To go further, logged in as a jurisdictional admin, call the delete user api with a user in a different jurisdiction. Should return a 403 Forbidden error, not a 500.
To go EVEN further! Test all user endpoints because of the user views introduction.

Describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration.

All api, partner and public tests were run and passed locally. Added/updated tests in api unit and e2e test suites.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
