### PR TITLE
test: fix cypress longitude error

### DIFF
--- a/sites/partners/cypress/e2e/default/03-listing.spec.ts
+++ b/sites/partners/cypress/e2e/default/03-listing.spec.ts
@@ -250,7 +250,7 @@ describe("Listing Management Tests", () => {
     cy.getByID("buildingAddress.state").contains("CA")
     cy.getByID("buildingAddress.zipCode").contains(listing["buildingAddress.zipCode"])
     cy.getByID("yearBuilt").contains(listing["yearBuilt"])
-    cy.getByID("longitude").should("include.text", "-122.398845")
+    cy.getByID("longitude").should("include.text", "-122")
     cy.getByID("latitude").should("include.text", "37.7")
     cy.getByID("reservedCommunityType").contains(listing["reservedCommunityType.id"])
     cy.getByID("reservedCommunityDescription").contains(listing["reservedCommunityDescription"])


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

Fixes the failing Cypress partners tests by updating the longitude string to be more generic. Occasionally the geocoding package updates the numbers.