### PR TITLE
fix: restores getStaticProps functionality

### DIFF
--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -165,20 +165,24 @@ export async function fetchClosedListings(req: any) {
 let jurisdiction: Jurisdiction | null = null
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function fetchJurisdictionByName(req: any) {
+export async function fetchJurisdictionByName(req?: any) {
   try {
     if (jurisdiction) {
       return jurisdiction
     }
 
     const jurisdictionName = process.env.jurisdictionName
+
+    const headers = {
+      passkey: process.env.API_PASS_KEY,
+    }
+    if (req) {
+      headers["x-forwarded-for"] = req.headers["x-forwarded-for"] ?? req.socket.remoteAddress
+    }
     const jurisdictionRes = await axios.get(
       `${process.env.backendApiBase}/jurisdictions/byName/${jurisdictionName}`,
       {
-        headers: {
-          passkey: process.env.API_PASS_KEY,
-          "x-forwarded-for": req.headers["x-forwarded-for"] ?? req.socket.remoteAddress,
-        },
+        headers,
       }
     )
     jurisdiction = jurisdictionRes?.data

--- a/sites/public/src/pages/index.tsx
+++ b/sites/public/src/pages/index.tsx
@@ -115,8 +115,8 @@ export default function Home(props: IndexProps) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function getStaticProps(context: { req: any }) {
-  const jurisdiction = await fetchJurisdictionByName(context.req)
+export async function getStaticProps() {
+  const jurisdiction = await fetchJurisdictionByName()
 
   return {
     props: { jurisdiction },


### PR DESCRIPTION
This fixes an issue where during the getStaticProps call we were asking for the request but getStaticProps does not have access to the request as its a static generator


this fix should keep the public's listings list page working, the public listing detail page working, and shouldn't throw an error in the public site during build/initially when the public site has `yarn dev` ran