### PR TITLE
fix: looser isUserSiteMatch

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -31,7 +31,7 @@ TWILIO_ACCOUNT_SID=
 # account auth token for twilio
 TWILIO_AUTH_TOKEN=
 # url for the partner front end
-PARTNERS_PORTAL_URL=http://localhost:3001/
+PARTNERS_PORTAL_URL=http://localhost:3001
 # sendgrid email api key
 EMAIL_API_KEY=SG.ExampleApiKey
 # controls the repetition of the afs cron job

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -407,8 +407,7 @@ export class UserService {
       storedUser.userRoles?.isPartner;
     const isUserSiteMatch =
       (isPartnerPortalUser && dto.appUrl === process.env.PARTNERS_PORTAL_URL) ||
-      (!isPartnerPortalUser &&
-        dto.appUrl === storedUser.jurisdictions?.[0]?.publicUrl);
+      (!isPartnerPortalUser && dto.appUrl !== process.env.PARTNERS_PORTAL_URL);
     // user on wrong site, return neutral message and don't send email
     if (!isUserSiteMatch) return { success: true };
 


### PR DESCRIPTION
# Pull Request Template

## Issue Overview

This PR addresses #4089 

- [x] This change addresses the issue in full
- [ ] This change addresses only certain aspects of the issue
- [ ] This change is a dependency for another issue
- [ ] This change has a dependency from another issue

## Description

This PR incorporates some points that @mcgarrye came up in discussing the previous [PR](https://github.com/bloom-housing/bloom/pull/4090) addressing this issue. Specifically in HBA, an alameda public user is able to log in to the san jose site and see applications from alameda in the san jose portal. Matching fully on the public url from the users jurisdiction would mean the forgot password experience is incorporating security that users aren't experiencing on the sign in page itself leading to a confusing experience. This issue is captured here #4119 

As a result of this, this PR just checks that a public user is not using the partners portal. **Additionally, this PR updates the env and env template to just include http://localhost:3001 to actually match the window.location.origin checks along with our staging and production sites who's urls do not include this trailing slash.**

## How Can This Be Tested/Reviewed?

**Update your env to match the template**

This can be tested by making a public user and partner user and with each account following the forgot password flow on the public and partners account. The flow should work as expected on the matching site but should not send an email for the mismatch.



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have added QA notes to the issue with applicable URLs
- [x] I have performed a self-review of my own code
- [x] I have reviewed the changes in a desktop view
- [ ] I have reviewed the changes in a mobile view
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have assigned reviewers
- [ ] I have run `yarn generate:client` and/or created a migration if I made backend changes that require them
- [x] My commit message(s) is/are polished, and any breaking changes are indicated in the message and are well-described
- [ ] Commits made across packages purposefully have the same commit message/version change, else are separated into different commits

## Reviewer Notes:

Steps to review a PR:

- Read and understand the issue, and ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Also review the acceptance criteria on the Netlify deploy preview (noting that these do not yet include any backend changes made in the PR)
- Either explicitly ask a clarifying question, request changes, or approve the PR if there are small remaining changes but the PR is otherwise good to go

## On Merge:

If you have one commit and message, squash. If you need each message to be applied, rebase and merge.
