### PR TITLE
feat: ami chart import script runner

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -16,6 +16,7 @@ import { OptionalAuthGuard } from '../guards/optional.guard';
 import { AdminOrJurisdictionalAdminGuard } from '../guards/admin-or-jurisdiction-admin.guard';
 import { DataTransferDTO } from '../dtos/script-runner/data-transfer.dto';
 import { BulkApplicationResendDTO } from '../dtos/script-runner/bulk-application-resend.dto';
+import { AmiChartImportDTO } from '../dtos/script-runner/ami-chart-import.dto';
 
 @Controller('scriptRunner')
 @ApiTags('scriptRunner')
@@ -62,5 +63,16 @@ export class ScirptRunnerController {
       req,
       bulkApplicationResendDTO,
     );
+  }
+
+  @Put('amiChartImport')
+  @ApiOperation({
+    summary:
+      'A script that takes in a standardized string and outputs the input for the ami chart create endpoint',
+    operationId: 'amiChartImport',
+  })
+  @ApiOkResponse({ type: String })
+  amiChartImport(@Body() amiChartImportDTO: AmiChartImportDTO): string {
+    return this.scriptRunnerService.amiChartImport(amiChartImportDTO);
   }
 }

--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -71,8 +71,14 @@ export class ScirptRunnerController {
       'A script that takes in a standardized string and outputs the input for the ami chart create endpoint',
     operationId: 'amiChartImport',
   })
-  @ApiOkResponse({ type: String })
-  amiChartImport(@Body() amiChartImportDTO: AmiChartImportDTO): string {
-    return this.scriptRunnerService.amiChartImport(amiChartImportDTO);
+  @ApiOkResponse({ type: SuccessDTO })
+  async amiChartImport(
+    @Body() amiChartImportDTO: AmiChartImportDTO,
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.amiChartImport(
+      req,
+      amiChartImportDTO,
+    );
   }
 }

--- a/api/src/dtos/script-runner/ami-chart-import.dto.ts
+++ b/api/src/dtos/script-runner/ami-chart-import.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsDefined, IsString } from 'class-validator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class AmiChartImportDTO {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  values: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  name: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  jurisdictionId: string;
+}

--- a/api/src/modules/script-runner.module.ts
+++ b/api/src/modules/script-runner.module.ts
@@ -4,9 +4,10 @@ import { ScriptRunnerService } from '../services/script-runner.service';
 import { PrismaModule } from './prisma.module';
 import { PermissionModule } from './permission.module';
 import { EmailModule } from './email.module';
+import { AmiChartModule } from './ami-chart.module';
 
 @Module({
-  imports: [PrismaModule, PermissionModule, EmailModule],
+  imports: [PrismaModule, PermissionModule, EmailModule, AmiChartModule],
   controllers: [ScirptRunnerController],
   providers: [ScriptRunnerService],
   exports: [ScriptRunnerService],

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -140,10 +140,10 @@ export class ScriptRunnerService {
 
   /**
    *
-   * @param amiChartImportDTO this is a string it takes a very specific formatted like:
+   * @param amiChartImportDTO this is a string in a very specific format like:
    * percentOfAmiValue_1 householdSize_1_income_value householdSize_2_income_value \n percentOfAmiValue_2 householdSize_1_income_value householdSize_2_income_value
-   * @returns a stringified version of AmiChartCreate DTO
-   * @description transfers data from foreign data into the database this api normally connects to. From this you can use it
+   * @returns successDTO
+   * @description takes the incoming AMI Chart string and stores it as a new AMI Chart in the database
    */
   async amiChartImport(
     req: ExpressRequest,

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -192,6 +192,149 @@ describe('Testing script runner service', () => {
     );
   });
 
+  it('should build ami chart import object', () => {
+    const name = 'example name';
+    const jurisdictionId = 'example jurisdictionId';
+    const valueItem =
+      '15 18400 21000 23650 26250 28350 30450 32550 34650\n30 39150 44750 50350 55900 60400 64850 69350 73800\n50 65250 74600 83900 93200 100700 108150 115600 123050';
+    const res = service.amiChartImport({
+      values: valueItem,
+      name,
+      jurisdictionId,
+    });
+
+    expect(res).toEqual(
+      JSON.stringify({
+        items: [
+          {
+            percentOfAmi: 15,
+            householdSize: 1,
+            income: 18400,
+          },
+          {
+            percentOfAmi: 15,
+            householdSize: 2,
+            income: 21000,
+          },
+          {
+            percentOfAmi: 15,
+            householdSize: 3,
+            income: 23650,
+          },
+          {
+            percentOfAmi: 15,
+            householdSize: 4,
+            income: 26250,
+          },
+          {
+            percentOfAmi: 15,
+            householdSize: 5,
+            income: 28350,
+          },
+          {
+            percentOfAmi: 15,
+            householdSize: 6,
+            income: 30450,
+          },
+          {
+            percentOfAmi: 15,
+            householdSize: 7,
+            income: 32550,
+          },
+          {
+            percentOfAmi: 15,
+            householdSize: 8,
+            income: 34650,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 1,
+            income: 39150,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 2,
+            income: 44750,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 3,
+            income: 50350,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 4,
+            income: 55900,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 5,
+            income: 60400,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 6,
+            income: 64850,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 7,
+            income: 69350,
+          },
+          {
+            percentOfAmi: 30,
+            householdSize: 8,
+            income: 73800,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 1,
+            income: 65250,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 2,
+            income: 74600,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 3,
+            income: 83900,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 4,
+            income: 93200,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 5,
+            income: 100700,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 6,
+            income: 108150,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 7,
+            income: 115600,
+          },
+          {
+            percentOfAmi: 50,
+            householdSize: 8,
+            income: 123050,
+          },
+        ],
+        name,
+        jurisdictions: {
+          id: jurisdictionId,
+        },
+      }),
+    );
+  });
+
   // | ---------- HELPER TESTS BELOW ---------- | //
   it('should mark script run as started if no script run present in db', async () => {
     prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2062,6 +2062,28 @@ export class ScriptRunnerService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * A script that takes in a standardized string and outputs the input for the ami chart create endpoint
+   */
+  amiChartImport(
+    params: {
+      /** requestBody */
+      body?: AmiChartImportDTO
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/amiChartImport"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export interface SuccessDTO {
@@ -5251,6 +5273,17 @@ export interface DataTransferDTO {
 export interface BulkApplicationResendDTO {
   /**  */
   listingId: string
+}
+
+export interface AmiChartImportDTO {
+  /**  */
+  values: string
+
+  /**  */
+  name: string
+
+  /**  */
+  jurisdictionId: string
 }
 
 export enum ListingViews {


### PR DESCRIPTION
This PR addresses https://github.com/bloom-housing/bloom/issues/4041

- [x] Addresses the issue in full

## Description
Creates a new script runner endpoint that takes in the standardized string and creates the new ami chart

## How Can This Be Tested/Reviewed?
a unit test was added, but you can test via localhost:3100/api login, and then leverage the new script runner endpoint

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
