### PR TITLE
fix: add preview check

### DIFF
--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -626,7 +626,7 @@ export const ListingView = (props: ListingProps) => {
           {!applicationsClosed && getWaitlist()}
           {hasNonReferralMethods &&
           !applicationsClosed &&
-          listing.status !== ListingsStatusEnum.closed ? (
+          (listing.status !== ListingsStatusEnum.closed || props.preview) ? (
             <>{applySidebar()}</>
           ) : (
             <></>
@@ -784,7 +784,7 @@ export const ListingView = (props: ListingProps) => {
               {!applicationsClosed && getWaitlist()}
               {hasNonReferralMethods &&
                 !applicationsClosed &&
-                listing.status !== ListingsStatusEnum.closed &&
+                (listing.status !== ListingsStatusEnum.closed || props.preview) &&
                 applySidebar()}
               {listing?.referralApplication && (
                 <ReferralApplication


### PR DESCRIPTION
This PR addresses [#668](https://github.com/metrotranscom/doorway/issues/668)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This logic update allows for partner users to see the application section of the listing detail page if they're in preview mode.

## How Can This Be Tested/Reviewed?

Run locally, close a listing, make changes to that listing (ie. add a paper application), ensure those updates are reflected when you preview that closed listing.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
