### PR TITLE
fix: switch to HTML text inputs with numeric validation

### DIFF
--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
@@ -84,6 +84,9 @@ const FormHouseholdIncome = () => {
               placeholder={t("t.enterAmount")}
               register={register}
               disabled={incomePeriodValue !== IncomePeriodEnum.perMonth}
+              validation={{ pattern: /^[0-9]+$/ }}
+              error={fieldHasError(errors?.incomeMonth)}
+              errorMessage={t("errors.numberError")}
             />
           </Grid.Cell>
 

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
@@ -7,12 +7,13 @@ import {
   YesNoEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
+import { fieldHasError } from "../../../../lib/helpers"
 
 const FormHouseholdIncome = () => {
   const formMethods = useFormContext()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, setValue, watch } = formMethods
+  const { errors, register, setValue, trigger, watch } = formMethods
 
   const incomePeriodValue: string = watch("application.incomePeriod")
 
@@ -62,19 +63,22 @@ const FormHouseholdIncome = () => {
           <Grid.Cell>
             <Field
               id="incomeYear"
-              type="number"
+              type="text"
               name="incomeYear"
               label={t("application.details.annualIncome")}
               placeholder={t("t.enterAmount")}
               register={register}
               disabled={incomePeriodValue !== IncomePeriodEnum.perYear}
+              validation={{ pattern: /^[0-9]+$/ }}
+              error={fieldHasError(errors?.incomeYear)}
+              errorMessage={t("errors.numberError")}
             />
           </Grid.Cell>
 
           <Grid.Cell>
             <Field
               id="incomeMonth"
-              type="number"
+              type="text"
               name="incomeMonth"
               label={t("application.details.monthlyIncome")}
               placeholder={t("t.enterAmount")}

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
@@ -69,7 +69,7 @@ const FormHouseholdIncome = () => {
               placeholder={t("t.enterAmount")}
               register={register}
               disabled={incomePeriodValue !== IncomePeriodEnum.perYear}
-              validation={{ pattern: /^[0-9]+$/ }}
+              validation={{ pattern: /^[0-9.]+$/ }}
               error={fieldHasError(errors?.incomeYear)}
               errorMessage={t("errors.numberError")}
             />
@@ -84,7 +84,7 @@ const FormHouseholdIncome = () => {
               placeholder={t("t.enterAmount")}
               register={register}
               disabled={incomePeriodValue !== IncomePeriodEnum.perMonth}
-              validation={{ pattern: /^[0-9]+$/ }}
+              validation={{ pattern: /^[0-9.]+$/ }}
               error={fieldHasError(errors?.incomeMonth)}
               errorMessage={t("errors.numberError")}
             />

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdIncome.tsx
@@ -13,7 +13,7 @@ const FormHouseholdIncome = () => {
   const formMethods = useFormContext()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { errors, register, setValue, trigger, watch } = formMethods
+  const { errors, register, getValues, setValue, trigger, watch } = formMethods
 
   const incomePeriodValue: string = watch("application.incomePeriod")
 
@@ -63,13 +63,14 @@ const FormHouseholdIncome = () => {
           <Grid.Cell>
             <Field
               id="incomeYear"
-              type="text"
+              type="currency"
+              getValues={getValues}
+              setValue={setValue}
               name="incomeYear"
               label={t("application.details.annualIncome")}
               placeholder={t("t.enterAmount")}
               register={register}
               disabled={incomePeriodValue !== IncomePeriodEnum.perYear}
-              validation={{ pattern: /^[0-9.]+$/ }}
               error={fieldHasError(errors?.incomeYear)}
               errorMessage={t("errors.numberError")}
             />
@@ -78,13 +79,14 @@ const FormHouseholdIncome = () => {
           <Grid.Cell>
             <Field
               id="incomeMonth"
-              type="text"
+              type="currency"
+              getValues={getValues}
+              setValue={setValue}
               name="incomeMonth"
               label={t("application.details.monthlyIncome")}
               placeholder={t("t.enterAmount")}
               register={register}
               disabled={incomePeriodValue !== IncomePeriodEnum.perMonth}
-              validation={{ pattern: /^[0-9.]+$/ }}
               error={fieldHasError(errors?.incomeMonth)}
               errorMessage={t("errors.numberError")}
             />

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -84,13 +84,15 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
           name={fieldName}
           label={t("t.minimumIncome")}
           register={register}
-          type="number"
+          type="currency"
+          getValues={getValues}
+          setValue={setValue}
           prepend="$"
           readerOnly
           className={errors[fieldName] ? "error" : ""}
           error={errors[fieldName]}
           errorMessage={t("errors.requiredFieldError")}
-          validation={{ required: !!amiChartID }}
+          validation={{ required: !!amiChartID, pattern: /^[0-9]+$/ }}
           inputProps={{
             onChange: () => {
               clearErrors(fieldName)
@@ -339,7 +341,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
   }, [defaultUnit, unitTypesOptions, setValue])
 
   // when rent type is updated we set the rent/income data to defaultUnit data for that value
-  // e.g. rent is fixed and swithced to percentage, then switched back we readd the old fixed data
+  // e.g. rent is fixed and switched to percentage, then switched back we readd the old fixed data
   useEffect(() => {
     if (defaultUnit) {
       if (rentType === "fixed") {
@@ -452,7 +454,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                       placeholder={t("listings.unit.squareFootage")}
                       register={register}
                       readerOnly
-                      type="number"
+                      type="text"
+                      validation={{ pattern: /^[0-9.]+$/ }}
+                      error={fieldHasError(errors?.sqFeet)}
+                      errorMessage={t("errors.numberError")}
                     />
                   </FieldValue>
 
@@ -589,8 +594,12 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                           label={t("t.monthlyMinimumIncome")}
                           placeholder="0.00"
                           register={register}
-                          type="number"
+                          type="currency"
+                          getValues={getValues}
+                          setValue={setValue}
                           prepend="$"
+                          error={fieldHasError(errors?.monthlyIncomeMin)}
+                          errorMessage={t("errors.numberError")}
                         />
                       </Grid.Cell>
 
@@ -601,8 +610,12 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                           label={t("listings.unit.monthlyRent")}
                           placeholder="0.00"
                           register={register}
-                          type="number"
+                          type="currency"
+                          getValues={getValues}
+                          setValue={setValue}
                           prepend="$"
+                          error={fieldHasError(errors?.monthlyRent)}
+                          errorMessage={t("errors.numberError")}
                         />
                       </Grid.Cell>
                     </>
@@ -615,7 +628,10 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
                         label={t("listings.unit.%incomeRent")}
                         placeholder={t("listings.unit.percentage")}
                         register={register}
-                        type="number"
+                        type="text"
+                        validation={{ pattern: /^[0-9.]+$/ }}
+                        error={fieldHasError(errors?.monthlyRentAsPercentOfIncome)}
+                        errorMessage={t("errors.numberError")}
                       />
                     </Grid.Cell>
                   )}

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -92,7 +92,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
           className={errors[fieldName] ? "error" : ""}
           error={errors[fieldName]}
           errorMessage={t("errors.requiredFieldError")}
-          validation={{ required: !!amiChartID, pattern: /^[0-9.]+$/ }}
+          validation={{ required: !!amiChartID }}
           inputProps={{
             onChange: () => {
               clearErrors(fieldName)

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -92,7 +92,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
           className={errors[fieldName] ? "error" : ""}
           error={errors[fieldName]}
           errorMessage={t("errors.requiredFieldError")}
-          validation={{ required: !!amiChartID, pattern: /^[0-9]+$/ }}
+          validation={{ required: !!amiChartID, pattern: /^[0-9.]+$/ }}
           inputProps={{
             onChange: () => {
               clearErrors(fieldName)

--- a/sites/partners/src/components/listings/PaperListingForm/sections/AdditionalFees.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/AdditionalFees.tsx
@@ -15,7 +15,7 @@ const AdditionalFees = (props: AdditionalFeesProps) => {
   const formMethods = useFormContext()
   const { profile } = useContext(AuthContext)
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, watch, errors, clearErrors } = formMethods
+  const { register, watch, errors, clearErrors, getValues, setValue } = formMethods
 
   const jurisdiction = watch("jurisdiction.id")
 
@@ -47,6 +47,8 @@ const AdditionalFees = (props: AdditionalFeesProps) => {
               id={"applicationFee"}
               register={register}
               type={"currency"}
+              getValues={getValues}
+              setValue={setValue}
               prepend={"$"}
               placeholder={"0.00"}
             />
@@ -58,6 +60,8 @@ const AdditionalFees = (props: AdditionalFeesProps) => {
               id={"depositMin"}
               register={register}
               type={"currency"}
+              getValues={getValues}
+              setValue={setValue}
               prepend={"$"}
               placeholder={"0.00"}
               error={fieldHasError(errors?.depositMin)}
@@ -74,6 +78,8 @@ const AdditionalFees = (props: AdditionalFeesProps) => {
               id={"depositMax"}
               register={register}
               type={"currency"}
+              getValues={getValues}
+              setValue={setValue}
               prepend={"$"}
               placeholder={"0.00"}
               error={fieldHasError(errors?.depositMax)}

--- a/sites/partners/src/components/settings/PreferenceDrawer.tsx
+++ b/sites/partners/src/components/settings/PreferenceDrawer.tsx
@@ -704,10 +704,10 @@ const PreferenceDrawer = ({
                           name="radiusSize"
                           label={t("settings.preferenceValidatingAddress.howManyMiles")}
                           register={register}
-                          validation={{ required: true, min: 0 }}
+                          validation={{ required: true, min: 0, pattern: /^[0-9.]+$/ }}
                           error={errors.radiusSize}
                           errorMessage={t("errors.requiredFieldError")}
-                          type="number"
+                          type="text"
                           readerOnly
                           defaultValue={optionData?.radiusSize ?? null}
                           dataTestId={"preference-option-radius-size"}


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/658

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

**Note:** [see comment below](https://github.com/bloom-housing/bloom/pull/4128#issuecomment-2197522427)

The working theory is the issue with numbers changing randomly in the unit editing is due to `input type="number"` weirdness around mouse/trackpad scrolling. This PR switches to `input type="text"` and uses React Hook Form validation to verify integer input.

## How Can This Be Tested/Reviewed?

Try editing units for a listing, income, or the miles radius on preferences.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
