### PR TITLE
fix: duplicate review alignment

### DIFF
--- a/sites/partners/src/pages/application/[id]/review.tsx
+++ b/sites/partners/src/pages/application/[id]/review.tsx
@@ -203,13 +203,14 @@ const Flag = () => {
               <section className={"w-full"}>
                 <Button
                   variant="primary"
+                  className="w-full"
                   onClick={() => setSaveModalOpen(true)}
                   id={"save-set-button"}
                 >
                   {t("t.save")}
                 </Button>
                 {data?.updatedAt && (
-                  <div className="border-t text-xs flex items-center justify-center md:mt-0 mt-4 pt-4">
+                  <div className="border-t text-xs flex items-center justify-center mt-4 pt-4">
                     {t("t.lastUpdated")}: {dayjs(data?.updatedAt).format("MMMM DD, YYYY")}
                   </div>
                 )}


### PR DESCRIPTION
This PR addresses https://github.com/bloom-housing/Bloom-Doorway/issues/51

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The Save button was misaligned and flush with a bottom border on the duplicate applications review. This fixes the alignment and spacing.

## How Can This Be Tested/Reviewed?

https://deploy-preview-4129--partners-bloom-dev.netlify.app/application/52ee25ee-41f2-4495-961d-86e7de85c43f/review

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
