### PR TITLE
fix: allow removal of mailing address

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -982,6 +982,19 @@ export class ListingService implements OnModuleInit {
           },
         });
       } else {
+        // in order to delete the old address we first need to disconnect it from the listing
+        await this.prisma.listings.update({
+          data: {
+            [field]: {
+              disconnect: {
+                id: existingListing[field].id,
+              },
+            },
+          },
+          where: {
+            id: existingListing.id,
+          },
+        });
         await this.prisma.address.delete({
           where: {
             id: existingListing[field].id,

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -628,6 +628,7 @@ describe('Listing Controller Tests', () => {
       });
 
       const val = await constructFullListingData(listing.id, jurisdictionA.id);
+      val.listingsApplicationMailingAddress = undefined;
 
       const res = await request(app.getHttpServer())
         .put(`/listings/${listing.id}`)

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationAddress.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationAddress.tsx
@@ -373,7 +373,7 @@ const ApplicationAddress = ({ listing }: ApplicationAddressProps) => {
                       )
                     }
                     inputProps={{
-                      onChange: () => clearErrors("applicationMailingAddress"),
+                      onChange: () => clearErrors("listingsApplicationMailingAddress"),
                     }}
                   />
                 </Grid.Cell>

--- a/sites/partners/src/lib/listings/AdditionalMetadataFormatter.ts
+++ b/sites/partners/src/lib/listings/AdditionalMetadataFormatter.ts
@@ -49,9 +49,9 @@ export default class AdditionalMetadataFormatter extends Formatter {
 
     cleanAddress("leasingAgentAddress")
     cleanAddress("buildingAddress")
-    cleanAddress("applicationMailingAddress")
-    cleanAddress("applicationPickUpAddress")
-    cleanAddress("applicationDropOffAddress")
+    cleanAddress("listingsApplicationMailingAddress")
+    cleanAddress("listingsApplicationPickUpAddress")
+    cleanAddress("listingsApplicationDropOffAddress")
 
     this.data.customMapPin = this.metadata.customMapPositionChosen
     this.data.yearBuilt = this.data.yearBuilt ? Number(this.data.yearBuilt) : null

--- a/sites/partners/src/lib/listings/BooleansFormatter.ts
+++ b/sites/partners/src/lib/listings/BooleansFormatter.ts
@@ -23,19 +23,19 @@ export default class BooleansFormatter extends Formatter {
         addressTypes[this.data.whereApplicationsMailedIn] !== addressTypes.anotherAddress,
       trueCase: () => addressTypes[this.data.whereApplicationsMailedIn],
     })
-    this.processBoolean("applicationDropOffAddress", {
+    this.processBoolean("listingsApplicationDropOffAddress", {
       when:
         this.data.canApplicationsBeDroppedOff === YesNoEnum.yes &&
         this.data.whereApplicationsDroppedOff === addressTypes.anotherAddress,
       trueCase: () => this.data.listingsApplicationDropOffAddress,
     })
-    this.processBoolean("applicationPickUpAddress", {
+    this.processBoolean("listingsApplicationPickUpAddress", {
       when:
         this.data.canPaperApplicationsBePickedUp === YesNoEnum.yes &&
         this.data.whereApplicationsPickedUp === addressTypes.anotherAddress,
       trueCase: () => this.data.listingsApplicationPickUpAddress,
     })
-    this.processBoolean("applicationMailingAddress", {
+    this.processBoolean("listingsApplicationMailingAddress", {
       when:
         this.data.canApplicationsBeMailedIn === YesNoEnum.yes &&
         this.data.whereApplicationsMailedIn === addressTypes.anotherAddress,


### PR DESCRIPTION
This PR addresses [#638](https://github.com/metrotranscom/doorway/issues/638)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When updating a listing and removing the mailing, pickup, or drop-off address the existing address was still sticking around. This is happening due to the Prisma change over. Specifically because the field names of those were updated in Prisma and the new change was missed in one place in the partner site. This also exposed an issue with how we were deleting addresses, the address needs to be disconnected from the listing before it can be deleted from the listing table.

## How Can This Be Tested/Reviewed?

The following steps can be tested:

1. Add "another" mailing address, pick-up address, and drop-off address
![image](https://github.com/bloom-housing/bloom/assets/42942267/8430555d-b25b-4a67-9539-71f348496ed4)
2. Save the listing.

Both of these use cases should be tested for all three fields:
1. Select "at the leasing agent address" and then re-save the listing
![image](https://github.com/bloom-housing/bloom/assets/42942267/ffe59286-23da-45a6-a0c9-3c68f460e7d9)
2. Remove the address option altogether by selecting "No" on the above question and then re-save the listing
![image](https://github.com/bloom-housing/bloom/assets/42942267/b15c5bdf-19b6-4f84-acbf-efd2ba1af24f)

When reloading the listing the original saved listing from step one should be removed

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
