### PR TITLE
fix: add error message for incorrect listing approval

### DIFF
--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -28,6 +28,7 @@ type ListingFormActionsProps = {
   showRequestChangesModal?: () => void
   showSubmitForApprovalModal?: () => void
   submitFormWithStatus?: (confirm?: boolean, status?: ListingsStatusEnum) => void
+  setErrorAlert?: (alertMessage: string) => void
 }
 
 const ListingFormActions = ({
@@ -37,6 +38,7 @@ const ListingFormActions = ({
   showRequestChangesModal,
   showSubmitForApprovalModal,
   submitFormWithStatus,
+  setErrorAlert,
 }: ListingFormActionsProps) => {
   const listing = useContext(ListingContext)
   const { profile, listingsService } = useContext(AuthContext)
@@ -270,10 +272,16 @@ const ListingFormActions = ({
                   await router.push(`/`)
                 }
               } catch (err) {
+                // if it is a bad request (is missing fields or incorrect data) then display an error banner
+                if (err.response?.status === 400) {
+                  setErrorAlert(
+                    "There are errors in this listing that must be resolved before publishing. To see the errors, please try to approve this listing from the edit view."
+                  )
+                }
                 addToast(
                   err.response?.data?.message === "email failed"
-                    ? "errors.alert.listingsApprovalEmailError"
-                    : "errors.somethingWentWrong",
+                    ? t("errors.alert.listingsApprovalEmailError")
+                    : t("errors.somethingWentWrong"),
                   { variant: "warn" }
                 )
               }

--- a/sites/partners/src/pages/listings/[id]/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/index.tsx
@@ -42,7 +42,7 @@ interface ListingProps {
 
 export default function ListingDetail(props: ListingProps) {
   const { listing } = props
-  const [errorAlert, setErrorAlert] = useState(false)
+  const [errorAlert, setErrorAlert] = useState<string>(null)
   const [unitDrawer, setUnitDrawer] = useState<UnitDrawer>(null)
 
   if (!listing) return null
@@ -80,11 +80,11 @@ export default function ListingDetail(props: ListingProps) {
                 {errorAlert && (
                   <AlertBox
                     className="mb-5"
-                    onClose={() => setErrorAlert(false)}
+                    onClose={() => setErrorAlert(null)}
                     closeable
                     type="alert"
                   >
-                    {t("authentication.signIn.errorGenericMessage")}
+                    {errorAlert || t("authentication.signIn.errorGenericMessage")}
                   </AlertBox>
                 )}
 
@@ -111,7 +111,10 @@ export default function ListingDetail(props: ListingProps) {
                   </div>
 
                   <div className="w-full md:w-3/12 md:pl-6">
-                    <ListingFormActions type={ListingFormActionsType.details} />
+                    <ListingFormActions
+                      type={ListingFormActionsType.details}
+                      setErrorAlert={setErrorAlert}
+                    />
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
This PR addresses [#639](https://github.com/metrotranscom/doorway/issues/639)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When submitting a listing for approval not every field needs to be filled out. This can cause a side effect of when an admin approves the listing they then have to resolve the missing fields. The issue is made even worse if the admin chooses to approve from the details view rather than the edit view as only a generic error message happens (which also was broken). As a remediation this PR adds an additional error banner on the listing details view when this error happens so that the user knows the next step that needs to happen 

## How Can This Be Tested/Reviewed?

- As a partner user submit a listing that is missing at least one required field.
- Log in as an admin and click the "Approve & Publish" button for that listing (note: not on the edit view, but on the page that shows when first going to a listing in partners)
- New error message should show


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [N/A] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
