### PR TITLE
fix: add the ability to disconnect community types

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -47,6 +47,7 @@ import { IdDTO } from '../dtos/shared/id.dto';
 import { startCronJob } from '../utilities/cron-job-starter';
 import { PermissionService } from './permission.service';
 import { permissionActions } from '../enums/permissions/permission-actions-enum';
+import { disconnect } from 'node:process';
 
 export type getListingsArgs = {
   skip: number;
@@ -1017,6 +1018,7 @@ export class ListingService implements OnModuleInit {
   */
   async update(dto: ListingUpdate, requestingUser: User): Promise<Listing> {
     const storedListing = await this.findOrThrow(dto.id, ListingViews.details);
+    console.log('RCD', dto.reservedCommunityTypes);
 
     await this.permissionService.canOrThrow(
       requestingUser,
@@ -1210,6 +1212,12 @@ export class ListingService implements OnModuleInit {
             ? {
                 connect: {
                   id: dto.reservedCommunityTypes.id,
+                },
+              }
+            : storedListing.reservedCommunityTypes
+            ? {
+                disconnect: {
+                  id: storedListing.reservedCommunityTypes.id,
                 },
               }
             : undefined,

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -47,7 +47,6 @@ import { IdDTO } from '../dtos/shared/id.dto';
 import { startCronJob } from '../utilities/cron-job-starter';
 import { PermissionService } from './permission.service';
 import { permissionActions } from '../enums/permissions/permission-actions-enum';
-import { disconnect } from 'node:process';
 
 export type getListingsArgs = {
   skip: number;
@@ -1018,7 +1017,6 @@ export class ListingService implements OnModuleInit {
   */
   async update(dto: ListingUpdate, requestingUser: User): Promise<Listing> {
     const storedListing = await this.findOrThrow(dto.id, ListingViews.details);
-    console.log('RCD', dto.reservedCommunityTypes);
 
     await this.permissionService.canOrThrow(
       requestingUser,

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -38,6 +38,7 @@ import { User } from '../../../src/dtos/users/user.dto';
 import { EmailService } from '../../../src/services/email.service';
 import { PermissionService } from '../../../src/services/permission.service';
 import { permissionActions } from '../../../src/enums/permissions/permission-actions-enum';
+import { disconnect } from 'process';
 
 /*
   generates a super simple mock listing for us to test logic with
@@ -425,96 +426,281 @@ describe('Testing listing service', () => {
     };
   };
 
-  it('should handle call to list() with no params sent', async () => {
-    prisma.listings.findMany = jest.fn().mockResolvedValue(mockListingSet(10));
+  describe('Test list endpoint', () => {
+    it('should handle call to list() with no params sent', async () => {
+      prisma.listings.findMany = jest
+        .fn()
+        .mockResolvedValue(mockListingSet(10));
 
-    prisma.listings.count = jest.fn().mockResolvedValue(10);
+      prisma.listings.count = jest.fn().mockResolvedValue(10);
 
-    const params: ListingsQueryParams = {};
+      const params: ListingsQueryParams = {};
 
-    await service.list(params);
+      await service.list(params);
 
-    expect(prisma.listings.findMany).toHaveBeenCalledWith({
-      skip: 0,
-      take: undefined,
-      orderBy: undefined,
-      where: {
-        AND: [],
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        requestedChangesUser: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
+      expect(prisma.listings.findMany).toHaveBeenCalledWith({
+        skip: 0,
+        take: undefined,
+        orderBy: undefined,
+        where: {
+          AND: [],
         },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
           },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        applicationMethods: {
-          include: {
-            paperApplications: {
-              include: {
-                assets: true,
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          listingsBuildingSelectionCriteriaFile: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingsResult: true,
+          listingsLeasingAgentAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationMailingAddress: true,
+          units: {
+            include: {
+              unitAmiChartOverrides: true,
+              unitTypes: true,
+              unitRentTypes: true,
+              unitAccessibilityPriorityTypes: true,
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
               },
             },
           },
         },
-        listingsBuildingSelectionCriteriaFile: true,
-        listingEvents: {
-          include: {
-            assets: true,
-          },
+      });
+
+      expect(prisma.listings.count).toHaveBeenCalledWith({
+        where: {
+          AND: [],
         },
-        listingsResult: true,
-        listingsLeasingAgentAddress: true,
-        listingsApplicationPickUpAddress: true,
-        listingsApplicationDropOffAddress: true,
-        listingsApplicationMailingAddress: true,
-        units: {
-          include: {
-            unitAmiChartOverrides: true,
-            unitTypes: true,
-            unitRentTypes: true,
-            unitAccessibilityPriorityTypes: true,
-            amiChart: {
-              include: {
-                jurisdictions: true,
-                unitGroupAmiLevels: true,
+      });
+    });
+
+    it('should handle call to list() with params sent', async () => {
+      prisma.listings.findMany = jest
+        .fn()
+        .mockResolvedValue(mockListingSet(10));
+
+      prisma.listings.count = jest.fn().mockResolvedValue(20);
+
+      const params: ListingsQueryParams = {
+        view: ListingViews.base,
+        page: 2,
+        limit: 10,
+        orderBy: [ListingOrderByKeys.name],
+        orderDir: [OrderByEnum.ASC],
+        search: 'simple search',
+        filter: [
+          {
+            [ListingFilterKeys.name]: 'Listing,name',
+            $comparison: Compare.IN,
+          },
+          {
+            [ListingFilterKeys.bedrooms]: 2,
+            $comparison: Compare['>='],
+          },
+        ],
+      };
+
+      await service.list(params);
+
+      expect(prisma.listings.findMany).toHaveBeenCalledWith({
+        skip: 10,
+        take: 10,
+        orderBy: [
+          {
+            name: 'asc',
+          },
+        ],
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  name: {
+                    in: ['listing', 'name'],
+                    mode: 'insensitive',
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
+                  units: {
+                    some: {
+                      numBedrooms: {
+                        gte: 2,
+                        mode: 'insensitive',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              name: {
+                contains: 'simple search',
+                mode: 'insensitive',
               },
+            },
+          ],
+        },
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          units: {
+            include: {
+              unitTypes: true,
+              unitAmiChartOverrides: true,
             },
           },
         },
-      },
+      });
+
+      expect(prisma.listings.count).toHaveBeenCalledWith({
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  name: {
+                    in: ['listing', 'name'],
+                    mode: 'insensitive',
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
+                  units: {
+                    some: {
+                      numBedrooms: {
+                        gte: 2,
+                        mode: 'insensitive',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              name: {
+                contains: 'simple search',
+                mode: 'insensitive',
+              },
+            },
+          ],
+        },
+      });
     });
 
-    expect(prisma.listings.count).toHaveBeenCalledWith({
-      where: {
-        AND: [],
-      },
+    it('should return first page if params are more than count', async () => {
+      prisma.listings.findMany = jest
+        .fn()
+        .mockResolvedValue(mockListingSet(10));
+
+      prisma.listings.count = jest.fn().mockResolvedValue(20);
+
+      const params: ListingsQueryParams = {
+        view: ListingViews.base,
+        page: 2,
+        limit: 30,
+        orderBy: [ListingOrderByKeys.name],
+        orderDir: [OrderByEnum.ASC],
+      };
+
+      await service.list(params);
+
+      expect(prisma.listings.findMany).toHaveBeenCalledWith({
+        skip: 0,
+        take: 30,
+        orderBy: [
+          {
+            name: 'asc',
+          },
+        ],
+        where: {
+          AND: [],
+        },
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          units: {
+            include: {
+              unitTypes: true,
+              unitAmiChartOverrides: true,
+            },
+          },
+        },
+      });
+
+      expect(prisma.listings.count).toHaveBeenCalledWith({
+        where: {
+          AND: [],
+        },
+      });
     });
-  });
 
-  it('should handle call to list() with params sent', async () => {
-    prisma.listings.findMany = jest.fn().mockResolvedValue(mockListingSet(10));
-
-    prisma.listings.count = jest.fn().mockResolvedValue(20);
-
-    const params: ListingsQueryParams = {
-      view: ListingViews.base,
-      page: 2,
-      limit: 10,
-      orderBy: [ListingOrderByKeys.name],
-      orderDir: [OrderByEnum.ASC],
-      search: 'simple search',
-      filter: [
+    it('should build where clause when only params sent', async () => {
+      const params: ListingFilterParams[] = [
         {
           [ListingFilterKeys.name]: 'Listing,name',
           $comparison: Compare.IN,
@@ -523,20 +709,9 @@ describe('Testing listing service', () => {
           [ListingFilterKeys.bedrooms]: 2,
           $comparison: Compare['>='],
         },
-      ],
-    };
+      ];
 
-    await service.list(params);
-
-    expect(prisma.listings.findMany).toHaveBeenCalledWith({
-      skip: 10,
-      take: 10,
-      orderBy: [
-        {
-          name: 'asc',
-        },
-      ],
-      where: {
+      expect(service.buildWhereClause(params)).toEqual({
         AND: [
           {
             OR: [
@@ -562,361 +737,25 @@ describe('Testing listing service', () => {
               },
             ],
           },
-          {
-            name: {
-              contains: 'simple search',
-              mode: 'insensitive',
-            },
-          },
         ],
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        units: {
-          include: {
-            unitTypes: true,
-            unitAmiChartOverrides: true,
-          },
-        },
-      },
+      });
     });
 
-    expect(prisma.listings.count).toHaveBeenCalledWith({
-      where: {
+    it('should build where clause when only search param sent', async () => {
+      expect(service.buildWhereClause(null, 'simple search')).toEqual({
         AND: [
           {
-            OR: [
-              {
-                name: {
-                  in: ['listing', 'name'],
-                  mode: 'insensitive',
-                },
-              },
-            ],
-          },
-          {
-            OR: [
-              {
-                units: {
-                  some: {
-                    numBedrooms: {
-                      gte: 2,
-                      mode: 'insensitive',
-                    },
-                  },
-                },
-              },
-            ],
-          },
-          {
             name: {
               contains: 'simple search',
               mode: 'insensitive',
             },
           },
         ],
-      },
-    });
-  });
-
-  it('should return first page if params are more than count', async () => {
-    prisma.listings.findMany = jest.fn().mockResolvedValue(mockListingSet(10));
-
-    prisma.listings.count = jest.fn().mockResolvedValue(20);
-
-    const params: ListingsQueryParams = {
-      view: ListingViews.base,
-      page: 2,
-      limit: 30,
-      orderBy: [ListingOrderByKeys.name],
-      orderDir: [OrderByEnum.ASC],
-    };
-
-    await service.list(params);
-
-    expect(prisma.listings.findMany).toHaveBeenCalledWith({
-      skip: 0,
-      take: 30,
-      orderBy: [
-        {
-          name: 'asc',
-        },
-      ],
-      where: {
-        AND: [],
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        units: {
-          include: {
-            unitTypes: true,
-            unitAmiChartOverrides: true,
-          },
-        },
-      },
+      });
     });
 
-    expect(prisma.listings.count).toHaveBeenCalledWith({
-      where: {
-        AND: [],
-      },
-    });
-  });
-
-  it('should build where clause when only params sent', async () => {
-    const params: ListingFilterParams[] = [
-      {
-        [ListingFilterKeys.name]: 'Listing,name',
-        $comparison: Compare.IN,
-      },
-      {
-        [ListingFilterKeys.bedrooms]: 2,
-        $comparison: Compare['>='],
-      },
-    ];
-
-    expect(service.buildWhereClause(params)).toEqual({
-      AND: [
-        {
-          OR: [
-            {
-              name: {
-                in: ['listing', 'name'],
-                mode: 'insensitive',
-              },
-            },
-          ],
-        },
-        {
-          OR: [
-            {
-              units: {
-                some: {
-                  numBedrooms: {
-                    gte: 2,
-                    mode: 'insensitive',
-                  },
-                },
-              },
-            },
-          ],
-        },
-      ],
-    });
-  });
-
-  it('should build where clause when only search param sent', async () => {
-    expect(service.buildWhereClause(null, 'simple search')).toEqual({
-      AND: [
-        {
-          name: {
-            contains: 'simple search',
-            mode: 'insensitive',
-          },
-        },
-      ],
-    });
-  });
-
-  it('should build where clause when params, and search param sent', async () => {
-    const params: ListingFilterParams[] = [
-      {
-        [ListingFilterKeys.name]: 'Listing,name',
-        $comparison: Compare.IN,
-      },
-      {
-        [ListingFilterKeys.bedrooms]: 2,
-        $comparison: Compare['>='],
-      },
-    ];
-
-    expect(service.buildWhereClause(params, 'simple search')).toEqual({
-      AND: [
-        {
-          OR: [
-            {
-              name: {
-                in: ['listing', 'name'],
-                mode: 'insensitive',
-              },
-            },
-          ],
-        },
-        {
-          OR: [
-            {
-              units: {
-                some: {
-                  numBedrooms: {
-                    gte: 2,
-                    mode: 'insensitive',
-                  },
-                },
-              },
-            },
-          ],
-        },
-        {
-          name: {
-            contains: 'simple search',
-            mode: 'insensitive',
-          },
-        },
-      ],
-    });
-  });
-
-  it('should return records from findOne() with base view', async () => {
-    prisma.listings.findUnique = jest.fn().mockResolvedValue(mockListing(0));
-
-    await service.findOne('listingId', LanguagesEnum.en, ListingViews.base);
-
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      where: {
-        id: 'listingId',
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        units: {
-          include: {
-            unitTypes: true,
-            unitAmiChartOverrides: true,
-          },
-        },
-      },
-    });
-  });
-
-  it('should handle no records returned when findOne() is called with details view', async () => {
-    prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
-
-    await expect(
-      async () =>
-        await service.findOne(
-          'a different listingId',
-          LanguagesEnum.en,
-          ListingViews.details,
-        ),
-    ).rejects.toThrowError();
-
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      where: {
-        id: 'a different listingId',
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        requestedChangesUser: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        applicationMethods: {
-          include: {
-            paperApplications: {
-              include: {
-                assets: true,
-              },
-            },
-          },
-        },
-        listingsBuildingSelectionCriteriaFile: true,
-        listingEvents: {
-          include: {
-            assets: true,
-          },
-        },
-        listingsResult: true,
-        listingsLeasingAgentAddress: true,
-        listingsApplicationPickUpAddress: true,
-        listingsApplicationDropOffAddress: true,
-        listingsApplicationMailingAddress: true,
-        units: {
-          include: {
-            unitAmiChartOverrides: true,
-            unitTypes: true,
-            unitRentTypes: true,
-            unitAccessibilityPriorityTypes: true,
-            amiChart: {
-              include: {
-                jurisdictions: true,
-                unitGroupAmiLevels: true,
-              },
-            },
-          },
-        },
-      },
-    });
-  });
-
-  it('should get records from list() with params and units', async () => {
-    const date = new Date();
-
-    prisma.listings.findMany = jest
-      .fn()
-      .mockResolvedValue([mockListing(9, { numberToMake: 9, date })]);
-
-    prisma.listings.count = jest.fn().mockResolvedValue(20);
-
-    const params: ListingsQueryParams = {
-      view: ListingViews.base,
-      page: 2,
-      limit: 10,
-      orderBy: [ListingOrderByKeys.name],
-      orderDir: [OrderByEnum.ASC],
-      search: 'simple search',
-      filter: [
+    it('should build where clause when params, and search param sent', async () => {
+      const params: ListingFilterParams[] = [
         {
           [ListingFilterKeys.name]: 'Listing,name',
           $comparison: Compare.IN,
@@ -925,149 +764,9 @@ describe('Testing listing service', () => {
           [ListingFilterKeys.bedrooms]: 2,
           $comparison: Compare['>='],
         },
-      ],
-    };
+      ];
 
-    const res = await service.list(params);
-
-    expect(res.items[0].name).toEqual(`listing ${10}`);
-    expect(res.items[0].units).toEqual(
-      mockListing(9, { numberToMake: 9, date }).units,
-    );
-    expect(res.items[0].unitsSummarized).toEqual({
-      byUnitTypeAndRent: [
-        {
-          areaRange: { min: 0, max: 7 },
-          minIncomeRange: { min: '$0', max: '$7' },
-          occupancyRange: { min: 0, max: 7 },
-          rentRange: { min: '$0', max: '$7' },
-          rentAsPercentIncomeRange: { min: 0, max: 0 },
-          floorRange: { min: 0, max: 7 },
-          unitTypes: {
-            id: 'unitType 0',
-            createdAt: date,
-            updatedAt: date,
-            name: 'SRO',
-            numBedrooms: 0,
-          },
-          totalAvailable: 2,
-        },
-        {
-          areaRange: { min: 1, max: 8 },
-          minIncomeRange: { min: '$1', max: '$8' },
-          occupancyRange: { min: 1, max: 8 },
-          rentRange: { min: '$1', max: '$8' },
-          rentAsPercentIncomeRange: { min: 1, max: 1 },
-          floorRange: { min: 1, max: 8 },
-          unitTypes: {
-            id: 'unitType 1',
-            createdAt: date,
-            updatedAt: date,
-            name: 'studio',
-            numBedrooms: 1,
-          },
-          totalAvailable: 2,
-        },
-        {
-          areaRange: { min: 2, max: 2 },
-          minIncomeRange: { min: '$2', max: '$2' },
-          occupancyRange: { min: 2, max: 2 },
-          rentRange: { min: '$2', max: '$2' },
-          rentAsPercentIncomeRange: { min: 2, max: 2 },
-          floorRange: { min: 2, max: 2 },
-          unitTypes: {
-            id: 'unitType 2',
-            createdAt: date,
-            updatedAt: date,
-            name: 'oneBdrm',
-            numBedrooms: 2,
-          },
-          totalAvailable: 1,
-        },
-        {
-          areaRange: { min: 3, max: 3 },
-          minIncomeRange: { min: '$3', max: '$3' },
-          occupancyRange: { min: 3, max: 3 },
-          rentRange: { min: '$3', max: '$3' },
-          rentAsPercentIncomeRange: { min: 3, max: 3 },
-          floorRange: { min: 3, max: 3 },
-          unitTypes: {
-            id: 'unitType 3',
-            createdAt: date,
-            updatedAt: date,
-            name: 'twoBdrm',
-            numBedrooms: 3,
-          },
-          totalAvailable: 1,
-        },
-        {
-          areaRange: { min: 4, max: 4 },
-          minIncomeRange: { min: '$4', max: '$4' },
-          occupancyRange: { min: 4, max: 4 },
-          rentRange: { min: '$4', max: '$4' },
-          rentAsPercentIncomeRange: { min: 4, max: 4 },
-          floorRange: { min: 4, max: 4 },
-          unitTypes: {
-            id: 'unitType 4',
-            createdAt: date,
-            updatedAt: date,
-            name: 'threeBdrm',
-            numBedrooms: 4,
-          },
-          totalAvailable: 1,
-        },
-        {
-          areaRange: { min: 5, max: 5 },
-          minIncomeRange: { min: '$5', max: '$5' },
-          occupancyRange: { min: 5, max: 5 },
-          rentRange: { min: '$5', max: '$5' },
-          rentAsPercentIncomeRange: { min: 5, max: 5 },
-          floorRange: { min: 5, max: 5 },
-          unitTypes: {
-            id: 'unitType 5',
-            createdAt: date,
-            updatedAt: date,
-            name: 'fourBdrm',
-            numBedrooms: 5,
-          },
-          totalAvailable: 1,
-        },
-        {
-          areaRange: { min: 6, max: 6 },
-          minIncomeRange: { min: '$6', max: '$6' },
-          occupancyRange: { min: 6, max: 6 },
-          rentRange: { min: '$6', max: '$6' },
-          rentAsPercentIncomeRange: { min: 6, max: 6 },
-          floorRange: { min: 6, max: 6 },
-          unitTypes: {
-            id: 'unitType 6',
-            createdAt: date,
-            updatedAt: date,
-            name: 'fiveBdrm',
-            numBedrooms: 6,
-          },
-          totalAvailable: 1,
-        },
-      ],
-    });
-
-    expect(res.meta).toEqual({
-      currentPage: 2,
-      itemCount: 1,
-      itemsPerPage: 10,
-      totalItems: 20,
-      totalPages: 2,
-    });
-
-    expect(prisma.listings.findMany).toHaveBeenCalledWith({
-      skip: 10,
-      take: 10,
-      orderBy: [
-        {
-          name: 'asc',
-        },
-      ],
-      where: {
+      expect(service.buildWhereClause(params, 'simple search')).toEqual({
         AND: [
           {
             OR: [
@@ -1100,122 +799,52 @@ describe('Testing listing service', () => {
             },
           },
         ],
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        units: {
-          include: {
-            unitTypes: true,
-            unitAmiChartOverrides: true,
-          },
-        },
-      },
+      });
     });
 
-    expect(prisma.listings.count).toHaveBeenCalledWith({
-      where: {
-        AND: [
+    it('should get records from list() with params and units', async () => {
+      const date = new Date();
+
+      prisma.listings.findMany = jest
+        .fn()
+        .mockResolvedValue([mockListing(9, { numberToMake: 9, date })]);
+
+      prisma.listings.count = jest.fn().mockResolvedValue(20);
+
+      const params: ListingsQueryParams = {
+        view: ListingViews.base,
+        page: 2,
+        limit: 10,
+        orderBy: [ListingOrderByKeys.name],
+        orderDir: [OrderByEnum.ASC],
+        search: 'simple search',
+        filter: [
           {
-            OR: [
-              {
-                name: {
-                  in: ['listing', 'name'],
-                  mode: 'insensitive',
-                },
-              },
-            ],
+            [ListingFilterKeys.name]: 'Listing,name',
+            $comparison: Compare.IN,
           },
           {
-            OR: [
-              {
-                units: {
-                  some: {
-                    numBedrooms: {
-                      gte: 2,
-                      mode: 'insensitive',
-                    },
-                  },
-                },
-              },
-            ],
-          },
-          {
-            name: {
-              contains: 'simple search',
-              mode: 'insensitive',
-            },
+            [ListingFilterKeys.bedrooms]: 2,
+            $comparison: Compare['>='],
           },
         ],
-      },
-    });
-  });
+      };
 
-  it('should get records from findOne() with base view found and units', async () => {
-    const date = new Date();
+      const res = await service.list(params);
 
-    const mockedListing = mockListing(0, { numberToMake: 10, date });
-
-    prisma.listings.findUnique = jest.fn().mockResolvedValue(mockedListing);
-
-    prisma.amiChart.findMany = jest.fn().mockResolvedValue([
-      {
-        id: 'AMI0',
-        items: [],
-        name: '`AMI Name 0`',
-      },
-      {
-        id: 'AMI1',
-        items: [],
-        name: '`AMI Name 1`',
-      },
-    ]);
-
-    const listing: Listing = await service.findOne(
-      'listingId',
-      LanguagesEnum.en,
-      ListingViews.base,
-    );
-
-    expect(listing.id).toEqual('0');
-    expect(listing.name).toEqual('listing 1');
-    expect(listing.units).toEqual(mockedListing.units);
-    expect(listing.unitsSummarized.amiPercentages).toEqual([
-      '0',
-      '1',
-      '2',
-      '3',
-      '4',
-      '5',
-      '6',
-      '7',
-      '8',
-      '9',
-    ]);
-    expect(listing.unitsSummarized?.byAMI).toEqual([
-      {
-        percent: '0',
-        byUnitType: [
+      expect(res.items[0].name).toEqual(`listing ${10}`);
+      expect(res.items[0].units).toEqual(
+        mockListing(9, { numberToMake: 9, date }).units,
+      );
+      expect(res.items[0].unitsSummarized).toEqual({
+        byUnitTypeAndRent: [
           {
-            areaRange: { min: 0, max: 0 },
-            minIncomeRange: { min: '$0', max: '$0' },
-            occupancyRange: { min: 0, max: 0 },
-            rentRange: { min: '$0', max: '$0' },
+            areaRange: { min: 0, max: 7 },
+            minIncomeRange: { min: '$0', max: '$7' },
+            occupancyRange: { min: 0, max: 7 },
+            rentRange: { min: '$0', max: '$7' },
             rentAsPercentIncomeRange: { min: 0, max: 0 },
-            floorRange: { min: 0, max: 0 },
+            floorRange: { min: 0, max: 7 },
             unitTypes: {
               id: 'unitType 0',
               createdAt: date,
@@ -1223,20 +852,15 @@ describe('Testing listing service', () => {
               name: 'SRO',
               numBedrooms: 0,
             },
-            totalAvailable: 1,
+            totalAvailable: 2,
           },
-        ],
-      },
-      {
-        percent: '1',
-        byUnitType: [
           {
-            areaRange: { min: 1, max: 1 },
-            minIncomeRange: { min: '$1', max: '$1' },
-            occupancyRange: { min: 1, max: 1 },
-            rentRange: { min: '$1', max: '$1' },
+            areaRange: { min: 1, max: 8 },
+            minIncomeRange: { min: '$1', max: '$8' },
+            occupancyRange: { min: 1, max: 8 },
+            rentRange: { min: '$1', max: '$8' },
             rentAsPercentIncomeRange: { min: 1, max: 1 },
-            floorRange: { min: 1, max: 1 },
+            floorRange: { min: 1, max: 8 },
             unitTypes: {
               id: 'unitType 1',
               createdAt: date,
@@ -1244,13 +868,8 @@ describe('Testing listing service', () => {
               name: 'studio',
               numBedrooms: 1,
             },
-            totalAvailable: 1,
+            totalAvailable: 2,
           },
-        ],
-      },
-      {
-        percent: '2',
-        byUnitType: [
           {
             areaRange: { min: 2, max: 2 },
             minIncomeRange: { min: '$2', max: '$2' },
@@ -1267,11 +886,6 @@ describe('Testing listing service', () => {
             },
             totalAvailable: 1,
           },
-        ],
-      },
-      {
-        percent: '3',
-        byUnitType: [
           {
             areaRange: { min: 3, max: 3 },
             minIncomeRange: { min: '$3', max: '$3' },
@@ -1288,11 +902,6 @@ describe('Testing listing service', () => {
             },
             totalAvailable: 1,
           },
-        ],
-      },
-      {
-        percent: '4',
-        byUnitType: [
           {
             areaRange: { min: 4, max: 4 },
             minIncomeRange: { min: '$4', max: '$4' },
@@ -1309,11 +918,6 @@ describe('Testing listing service', () => {
             },
             totalAvailable: 1,
           },
-        ],
-      },
-      {
-        percent: '5',
-        byUnitType: [
           {
             areaRange: { min: 5, max: 5 },
             minIncomeRange: { min: '$5', max: '$5' },
@@ -1330,11 +934,6 @@ describe('Testing listing service', () => {
             },
             totalAvailable: 1,
           },
-        ],
-      },
-      {
-        percent: '6',
-        byUnitType: [
           {
             areaRange: { min: 6, max: 6 },
             minIncomeRange: { min: '$6', max: '$6' },
@@ -1352,1559 +951,1996 @@ describe('Testing listing service', () => {
             totalAvailable: 1,
           },
         ],
-      },
-      {
-        percent: '7',
-        byUnitType: [
-          {
-            areaRange: { min: 7, max: 7 },
-            minIncomeRange: { min: '$7', max: '$7' },
-            occupancyRange: { min: 7, max: 7 },
-            rentRange: { min: '$7', max: '$7' },
-            rentAsPercentIncomeRange: { min: 0, max: 0 },
-            floorRange: { min: 7, max: 7 },
-            unitTypes: {
-              id: 'unitType 7',
-              createdAt: date,
-              updatedAt: date,
-              name: 'SRO',
-              numBedrooms: 7,
-            },
-            totalAvailable: 1,
-          },
-        ],
-      },
-      {
-        percent: '8',
-        byUnitType: [
-          {
-            areaRange: { min: 8, max: 8 },
-            minIncomeRange: { min: '$8', max: '$8' },
-            occupancyRange: { min: 8, max: 8 },
-            rentRange: { min: '$8', max: '$8' },
-            rentAsPercentIncomeRange: { min: 1, max: 1 },
-            floorRange: { min: 8, max: 8 },
-            unitTypes: {
-              id: 'unitType 8',
-              createdAt: date,
-              updatedAt: date,
-              name: 'studio',
-              numBedrooms: 8,
-            },
-            totalAvailable: 1,
-          },
-        ],
-      },
-      {
-        percent: '9',
-        byUnitType: [
-          {
-            areaRange: { min: 9, max: 9 },
-            minIncomeRange: { min: '$9', max: '$9' },
-            occupancyRange: { min: 9, max: 9 },
-            rentRange: { min: '$9', max: '$9' },
-            rentAsPercentIncomeRange: { min: 2, max: 2 },
-            floorRange: { min: 9, max: 9 },
-            unitTypes: {
-              id: 'unitType 9',
-              createdAt: date,
-              updatedAt: date,
-              name: 'oneBdrm',
-              numBedrooms: 9,
-            },
-            totalAvailable: 1,
-          },
-        ],
-      },
-    ]);
-    expect(listing.unitsSummarized.unitTypes).toEqual([
-      {
-        createdAt: date,
-        id: 'unitType 0',
-        name: 'SRO',
-        numBedrooms: 0,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 1',
-        name: 'studio',
-        numBedrooms: 1,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 2',
-        name: 'oneBdrm',
-        numBedrooms: 2,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 3',
-        name: 'twoBdrm',
-        numBedrooms: 3,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 4',
-        name: 'threeBdrm',
-        numBedrooms: 4,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 5',
-        name: 'fourBdrm',
-        numBedrooms: 5,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 6',
-        name: 'fiveBdrm',
-        numBedrooms: 6,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 7',
-        name: 'SRO',
-        numBedrooms: 7,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 8',
-        name: 'studio',
-        numBedrooms: 8,
-        updatedAt: date,
-      },
-      {
-        createdAt: date,
-        id: 'unitType 9',
-        name: 'oneBdrm',
-        numBedrooms: 9,
-        updatedAt: date,
-      },
-    ]);
+      });
 
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      where: {
-        id: 'listingId',
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        units: {
-          include: {
-            unitTypes: true,
-            unitAmiChartOverrides: true,
-          },
-        },
-      },
-    });
+      expect(res.meta).toEqual({
+        currentPage: 2,
+        itemCount: 1,
+        itemsPerPage: 10,
+        totalItems: 20,
+        totalPages: 2,
+      });
 
-    expect(prisma.amiChart.findMany).toHaveBeenCalledWith({
-      where: {
-        id: {
-          in: mockedListing.units.map((unit) => unit.amiChart.id),
+      expect(prisma.listings.findMany).toHaveBeenCalledWith({
+        skip: 10,
+        take: 10,
+        orderBy: [
+          {
+            name: 'asc',
+          },
+        ],
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  name: {
+                    in: ['listing', 'name'],
+                    mode: 'insensitive',
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
+                  units: {
+                    some: {
+                      numBedrooms: {
+                        gte: 2,
+                        mode: 'insensitive',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              name: {
+                contains: 'simple search',
+                mode: 'insensitive',
+              },
+            },
+          ],
         },
-      },
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          units: {
+            include: {
+              unitTypes: true,
+              unitAmiChartOverrides: true,
+            },
+          },
+        },
+      });
+
+      expect(prisma.listings.count).toHaveBeenCalledWith({
+        where: {
+          AND: [
+            {
+              OR: [
+                {
+                  name: {
+                    in: ['listing', 'name'],
+                    mode: 'insensitive',
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
+                  units: {
+                    some: {
+                      numBedrooms: {
+                        gte: 2,
+                        mode: 'insensitive',
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              name: {
+                contains: 'simple search',
+                mode: 'insensitive',
+              },
+            },
+          ],
+        },
+      });
     });
   });
 
-  it('should get records from findOne() with details view found and units', async () => {
-    const date = new Date();
+  describe('Test findOne endpoint', () => {
+    it('should return records from findOne() with base view', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(mockListing(0));
 
-    const mockedListing = mockListing(0, { numberToMake: 1, date });
+      await service.findOne('listingId', LanguagesEnum.en, ListingViews.base);
 
-    prisma.listings.findUnique = jest.fn().mockResolvedValue(mockedListing);
-
-    prisma.amiChart.findMany = jest.fn().mockResolvedValue([
-      {
-        id: 'AMI0',
-        items: [],
-        name: '`AMI Name 0`',
-      },
-      {
-        id: 'AMI1',
-        items: [],
-        name: '`AMI Name 1`',
-      },
-    ]);
-
-    const listing: Listing = await service.findOne(
-      'listingId',
-      LanguagesEnum.en,
-      ListingViews.details,
-    );
-
-    expect(listing.id).toEqual('0');
-    expect(listing.name).toEqual('listing 1');
-    expect(listing.units).toEqual(mockedListing.units);
-    expect(listing.unitsSummarized.amiPercentages).toEqual(['0']);
-    expect(listing.unitsSummarized?.byAMI).toEqual([
-      {
-        percent: '0',
-        byUnitType: [
-          {
-            areaRange: { min: 0, max: 0 },
-            minIncomeRange: { min: '$0', max: '$0' },
-            occupancyRange: { min: 0, max: 0 },
-            rentRange: { min: '$0', max: '$0' },
-            rentAsPercentIncomeRange: { min: 0, max: 0 },
-            floorRange: { min: 0, max: 0 },
-            unitTypes: {
-              id: 'unitType 0',
-              createdAt: date,
-              updatedAt: date,
-              name: 'SRO',
-              numBedrooms: 0,
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'listingId',
+        },
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
             },
-            totalAvailable: 1,
           },
-        ],
-      },
-    ]);
-    expect(listing.unitsSummarized.unitTypes).toEqual([
-      {
-        createdAt: date,
-        id: 'unitType 0',
-        name: 'SRO',
-        numBedrooms: 0,
-        updatedAt: date,
-      },
-    ]);
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          units: {
+            include: {
+              unitTypes: true,
+              unitAmiChartOverrides: true,
+            },
+          },
+        },
+      });
+    });
 
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      where: {
-        id: 'listingId',
-      },
-      include: {
-        jurisdictions: true,
-        listingsBuildingAddress: true,
-        requestedChangesUser: true,
-        reservedCommunityTypes: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
+    it('should handle no records returned when findOne() is called with details view', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () =>
+          await service.findOne(
+            'a different listingId',
+            LanguagesEnum.en,
+            ListingViews.details,
+          ),
+      ).rejects.toThrowError();
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'a different listingId',
         },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
           },
-        },
-        listingFeatures: true,
-        listingUtilities: true,
-        applicationMethods: {
-          include: {
-            paperApplications: {
-              include: {
-                assets: true,
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          listingsBuildingSelectionCriteriaFile: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingsResult: true,
+          listingsLeasingAgentAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationMailingAddress: true,
+          units: {
+            include: {
+              unitAmiChartOverrides: true,
+              unitTypes: true,
+              unitRentTypes: true,
+              unitAccessibilityPriorityTypes: true,
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
               },
             },
           },
         },
-        listingsBuildingSelectionCriteriaFile: true,
-        listingEvents: {
-          include: {
-            assets: true,
+      });
+    });
+    it('should get records from findOne() with base view found and units', async () => {
+      const date = new Date();
+
+      const mockedListing = mockListing(0, { numberToMake: 10, date });
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(mockedListing);
+
+      prisma.amiChart.findMany = jest.fn().mockResolvedValue([
+        {
+          id: 'AMI0',
+          items: [],
+          name: '`AMI Name 0`',
+        },
+        {
+          id: 'AMI1',
+          items: [],
+          name: '`AMI Name 1`',
+        },
+      ]);
+
+      const listing: Listing = await service.findOne(
+        'listingId',
+        LanguagesEnum.en,
+        ListingViews.base,
+      );
+
+      expect(listing.id).toEqual('0');
+      expect(listing.name).toEqual('listing 1');
+      expect(listing.units).toEqual(mockedListing.units);
+      expect(listing.unitsSummarized.amiPercentages).toEqual([
+        '0',
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+      ]);
+      expect(listing.unitsSummarized?.byAMI).toEqual([
+        {
+          percent: '0',
+          byUnitType: [
+            {
+              areaRange: { min: 0, max: 0 },
+              minIncomeRange: { min: '$0', max: '$0' },
+              occupancyRange: { min: 0, max: 0 },
+              rentRange: { min: '$0', max: '$0' },
+              rentAsPercentIncomeRange: { min: 0, max: 0 },
+              floorRange: { min: 0, max: 0 },
+              unitTypes: {
+                id: 'unitType 0',
+                createdAt: date,
+                updatedAt: date,
+                name: 'SRO',
+                numBedrooms: 0,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '1',
+          byUnitType: [
+            {
+              areaRange: { min: 1, max: 1 },
+              minIncomeRange: { min: '$1', max: '$1' },
+              occupancyRange: { min: 1, max: 1 },
+              rentRange: { min: '$1', max: '$1' },
+              rentAsPercentIncomeRange: { min: 1, max: 1 },
+              floorRange: { min: 1, max: 1 },
+              unitTypes: {
+                id: 'unitType 1',
+                createdAt: date,
+                updatedAt: date,
+                name: 'studio',
+                numBedrooms: 1,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '2',
+          byUnitType: [
+            {
+              areaRange: { min: 2, max: 2 },
+              minIncomeRange: { min: '$2', max: '$2' },
+              occupancyRange: { min: 2, max: 2 },
+              rentRange: { min: '$2', max: '$2' },
+              rentAsPercentIncomeRange: { min: 2, max: 2 },
+              floorRange: { min: 2, max: 2 },
+              unitTypes: {
+                id: 'unitType 2',
+                createdAt: date,
+                updatedAt: date,
+                name: 'oneBdrm',
+                numBedrooms: 2,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '3',
+          byUnitType: [
+            {
+              areaRange: { min: 3, max: 3 },
+              minIncomeRange: { min: '$3', max: '$3' },
+              occupancyRange: { min: 3, max: 3 },
+              rentRange: { min: '$3', max: '$3' },
+              rentAsPercentIncomeRange: { min: 3, max: 3 },
+              floorRange: { min: 3, max: 3 },
+              unitTypes: {
+                id: 'unitType 3',
+                createdAt: date,
+                updatedAt: date,
+                name: 'twoBdrm',
+                numBedrooms: 3,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '4',
+          byUnitType: [
+            {
+              areaRange: { min: 4, max: 4 },
+              minIncomeRange: { min: '$4', max: '$4' },
+              occupancyRange: { min: 4, max: 4 },
+              rentRange: { min: '$4', max: '$4' },
+              rentAsPercentIncomeRange: { min: 4, max: 4 },
+              floorRange: { min: 4, max: 4 },
+              unitTypes: {
+                id: 'unitType 4',
+                createdAt: date,
+                updatedAt: date,
+                name: 'threeBdrm',
+                numBedrooms: 4,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '5',
+          byUnitType: [
+            {
+              areaRange: { min: 5, max: 5 },
+              minIncomeRange: { min: '$5', max: '$5' },
+              occupancyRange: { min: 5, max: 5 },
+              rentRange: { min: '$5', max: '$5' },
+              rentAsPercentIncomeRange: { min: 5, max: 5 },
+              floorRange: { min: 5, max: 5 },
+              unitTypes: {
+                id: 'unitType 5',
+                createdAt: date,
+                updatedAt: date,
+                name: 'fourBdrm',
+                numBedrooms: 5,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '6',
+          byUnitType: [
+            {
+              areaRange: { min: 6, max: 6 },
+              minIncomeRange: { min: '$6', max: '$6' },
+              occupancyRange: { min: 6, max: 6 },
+              rentRange: { min: '$6', max: '$6' },
+              rentAsPercentIncomeRange: { min: 6, max: 6 },
+              floorRange: { min: 6, max: 6 },
+              unitTypes: {
+                id: 'unitType 6',
+                createdAt: date,
+                updatedAt: date,
+                name: 'fiveBdrm',
+                numBedrooms: 6,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '7',
+          byUnitType: [
+            {
+              areaRange: { min: 7, max: 7 },
+              minIncomeRange: { min: '$7', max: '$7' },
+              occupancyRange: { min: 7, max: 7 },
+              rentRange: { min: '$7', max: '$7' },
+              rentAsPercentIncomeRange: { min: 0, max: 0 },
+              floorRange: { min: 7, max: 7 },
+              unitTypes: {
+                id: 'unitType 7',
+                createdAt: date,
+                updatedAt: date,
+                name: 'SRO',
+                numBedrooms: 7,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '8',
+          byUnitType: [
+            {
+              areaRange: { min: 8, max: 8 },
+              minIncomeRange: { min: '$8', max: '$8' },
+              occupancyRange: { min: 8, max: 8 },
+              rentRange: { min: '$8', max: '$8' },
+              rentAsPercentIncomeRange: { min: 1, max: 1 },
+              floorRange: { min: 8, max: 8 },
+              unitTypes: {
+                id: 'unitType 8',
+                createdAt: date,
+                updatedAt: date,
+                name: 'studio',
+                numBedrooms: 8,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+        {
+          percent: '9',
+          byUnitType: [
+            {
+              areaRange: { min: 9, max: 9 },
+              minIncomeRange: { min: '$9', max: '$9' },
+              occupancyRange: { min: 9, max: 9 },
+              rentRange: { min: '$9', max: '$9' },
+              rentAsPercentIncomeRange: { min: 2, max: 2 },
+              floorRange: { min: 9, max: 9 },
+              unitTypes: {
+                id: 'unitType 9',
+                createdAt: date,
+                updatedAt: date,
+                name: 'oneBdrm',
+                numBedrooms: 9,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+      ]);
+      expect(listing.unitsSummarized.unitTypes).toEqual([
+        {
+          createdAt: date,
+          id: 'unitType 0',
+          name: 'SRO',
+          numBedrooms: 0,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 1',
+          name: 'studio',
+          numBedrooms: 1,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 2',
+          name: 'oneBdrm',
+          numBedrooms: 2,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 3',
+          name: 'twoBdrm',
+          numBedrooms: 3,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 4',
+          name: 'threeBdrm',
+          numBedrooms: 4,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 5',
+          name: 'fourBdrm',
+          numBedrooms: 5,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 6',
+          name: 'fiveBdrm',
+          numBedrooms: 6,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 7',
+          name: 'SRO',
+          numBedrooms: 7,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 8',
+          name: 'studio',
+          numBedrooms: 8,
+          updatedAt: date,
+        },
+        {
+          createdAt: date,
+          id: 'unitType 9',
+          name: 'oneBdrm',
+          numBedrooms: 9,
+          updatedAt: date,
+        },
+      ]);
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'listingId',
+        },
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          units: {
+            include: {
+              unitTypes: true,
+              unitAmiChartOverrides: true,
+            },
           },
         },
-        listingsResult: true,
-        listingsLeasingAgentAddress: true,
-        listingsApplicationPickUpAddress: true,
-        listingsApplicationDropOffAddress: true,
-        listingsApplicationMailingAddress: true,
-        units: {
-          include: {
-            unitAmiChartOverrides: true,
-            unitTypes: true,
-            unitRentTypes: true,
-            unitAccessibilityPriorityTypes: true,
-            amiChart: {
-              include: {
-                jurisdictions: true,
-                unitGroupAmiLevels: true,
+      });
+
+      expect(prisma.amiChart.findMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: mockedListing.units.map((unit) => unit.amiChart.id),
+          },
+        },
+      });
+    });
+
+    it('should get records from findOne() with details view found and units', async () => {
+      const date = new Date();
+
+      const mockedListing = mockListing(0, { numberToMake: 1, date });
+
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(mockedListing);
+
+      prisma.amiChart.findMany = jest.fn().mockResolvedValue([
+        {
+          id: 'AMI0',
+          items: [],
+          name: '`AMI Name 0`',
+        },
+        {
+          id: 'AMI1',
+          items: [],
+          name: '`AMI Name 1`',
+        },
+      ]);
+
+      const listing: Listing = await service.findOne(
+        'listingId',
+        LanguagesEnum.en,
+        ListingViews.details,
+      );
+
+      expect(listing.id).toEqual('0');
+      expect(listing.name).toEqual('listing 1');
+      expect(listing.units).toEqual(mockedListing.units);
+      expect(listing.unitsSummarized.amiPercentages).toEqual(['0']);
+      expect(listing.unitsSummarized?.byAMI).toEqual([
+        {
+          percent: '0',
+          byUnitType: [
+            {
+              areaRange: { min: 0, max: 0 },
+              minIncomeRange: { min: '$0', max: '$0' },
+              occupancyRange: { min: 0, max: 0 },
+              rentRange: { min: '$0', max: '$0' },
+              rentAsPercentIncomeRange: { min: 0, max: 0 },
+              floorRange: { min: 0, max: 0 },
+              unitTypes: {
+                id: 'unitType 0',
+                createdAt: date,
+                updatedAt: date,
+                name: 'SRO',
+                numBedrooms: 0,
+              },
+              totalAvailable: 1,
+            },
+          ],
+        },
+      ]);
+      expect(listing.unitsSummarized.unitTypes).toEqual([
+        {
+          createdAt: date,
+          id: 'unitType 0',
+          name: 'SRO',
+          numBedrooms: 0,
+          updatedAt: date,
+        },
+      ]);
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: 'listingId',
+        },
+        include: {
+          jurisdictions: true,
+          listingsBuildingAddress: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingFeatures: true,
+          listingUtilities: true,
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          listingsBuildingSelectionCriteriaFile: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingsResult: true,
+          listingsLeasingAgentAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationMailingAddress: true,
+          units: {
+            include: {
+              unitAmiChartOverrides: true,
+              unitTypes: true,
+              unitRentTypes: true,
+              unitAccessibilityPriorityTypes: true,
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
               },
             },
           },
         },
-      },
-    });
+      });
 
-    expect(prisma.amiChart.findMany).toHaveBeenCalledWith({
-      where: {
-        id: {
-          in: mockedListing.units.map((unit) => unit.amiChart.id),
+      expect(prisma.amiChart.findMany).toHaveBeenCalledWith({
+        where: {
+          id: {
+            in: mockedListing.units.map((unit) => unit.amiChart.id),
+          },
         },
-      },
+      });
     });
   });
 
-  it('should return listings from findListingsWithMultiSelectQuestion()', async () => {
-    prisma.listings.findMany = jest.fn().mockResolvedValue([
-      {
+  describe('Test findListingsWithMultiSelectQuestion endpoint', () => {
+    it('should return listings from findListingsWithMultiSelectQuestion()', async () => {
+      prisma.listings.findMany = jest.fn().mockResolvedValue([
+        {
+          id: 'example id',
+          name: 'example name',
+        },
+      ]);
+
+      const listings = await service.findListingsWithMultiSelectQuestion(
+        'multiselectQuestionId 1',
+      );
+
+      expect(listings.length).toEqual(1);
+      expect(listings[0].id).toEqual('example id');
+      expect(listings[0].name).toEqual('example name');
+
+      expect(prisma.listings.findMany).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          name: true,
+        },
+        where: {
+          listingMultiselectQuestions: {
+            some: {
+              multiselectQuestionId: 'multiselectQuestionId 1',
+            },
+          },
+        },
+      });
+    });
+  });
+
+  describe('Test create endpoint', () => {
+    it('should create a simple listing', async () => {
+      prisma.listings.create = jest.fn().mockResolvedValue({
         id: 'example id',
         name: 'example name',
-      },
-    ]);
+      });
 
-    const listings = await service.findListingsWithMultiSelectQuestion(
-      'multiselectQuestionId 1',
-    );
+      await service.create(
+        {
+          name: 'example listing name',
+          depositMin: '5',
+          assets: [
+            {
+              fileId: randomUUID(),
+              label: 'example asset',
+            },
+          ],
+          jurisdictions: {
+            id: randomUUID(),
+          },
+          status: ListingsStatusEnum.pending,
+          displayWaitlistSize: false,
+          unitsSummary: null,
+          listingEvents: [],
+        } as ListingCreate,
+        user,
+      );
 
-    expect(listings.length).toEqual(1);
-    expect(listings[0].id).toEqual('example id');
-    expect(listings[0].name).toEqual('example name');
-
-    expect(prisma.listings.findMany).toHaveBeenCalledWith({
-      select: {
-        id: true,
-        name: true,
-      },
-      where: {
-        listingMultiselectQuestions: {
-          some: {
-            multiselectQuestionId: 'multiselectQuestionId 1',
+      expect(prisma.listings.create).toHaveBeenCalledWith({
+        include: {
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          jurisdictions: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingUtilities: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsApplicationMailingAddress: true,
+          listingsBuildingAddress: true,
+          listingsBuildingSelectionCriteriaFile: true,
+          listingsLeasingAgentAddress: true,
+          listingsResult: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          units: {
+            include: {
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
+              },
+              unitAccessibilityPriorityTypes: true,
+              unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
+            },
           },
         },
-      },
+        data: {
+          name: 'example listing name',
+          contentUpdatedAt: expect.anything(),
+          depositMin: '5',
+          assets: {
+            create: [
+              {
+                fileId: expect.anything(),
+                label: 'example asset',
+              },
+            ],
+          },
+          jurisdictions: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          status: ListingsStatusEnum.pending,
+          displayWaitlistSize: false,
+          unitsSummary: undefined,
+          unitsAvailable: 0,
+          listingEvents: {
+            create: [],
+          },
+        },
+      });
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        user,
+        'listing',
+        permissionActions.create,
+        {
+          jurisdictionId: expect.anything(),
+        },
+      );
+    });
+
+    it('should create a complete listing', async () => {
+      prisma.listings.create = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+      });
+
+      const val = constructFullListingData();
+
+      await service.create(val as ListingCreate, user);
+
+      expect(prisma.listings.create).toHaveBeenCalledWith({
+        include: {
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
+              },
+            },
+          },
+          jurisdictions: true,
+          listingEvents: {
+            include: {
+              assets: true,
+            },
+          },
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingUtilities: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsApplicationMailingAddress: true,
+          listingsBuildingAddress: true,
+          listingsBuildingSelectionCriteriaFile: true,
+          listingsLeasingAgentAddress: true,
+          listingsResult: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          units: {
+            include: {
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
+              },
+              unitAccessibilityPriorityTypes: true,
+              unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
+            },
+          },
+        },
+        data: {
+          ...val,
+          contentUpdatedAt: expect.anything(),
+          assets: {
+            create: [exampleAsset],
+          },
+          applicationMethods: {
+            create: [
+              {
+                type: ApplicationMethodsTypeEnum.Internal,
+                label: 'example label',
+                externalReference: 'example reference',
+                acceptsPostmarkedApplications: false,
+                phoneNumber: '520-750-8811',
+                paperApplications: {
+                  create: [
+                    {
+                      language: LanguagesEnum.en,
+                      assets: {
+                        create: {
+                          ...exampleAsset,
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          listingEvents: {
+            create: [
+              {
+                type: ListingEventsTypeEnum.openHouse,
+                startDate: expect.anything(),
+                startTime: expect.anything(),
+                endTime: expect.anything(),
+                url: 'https://www.google.com',
+                note: 'example note',
+                label: 'example label',
+                assets: {
+                  create: {
+                    ...exampleAsset,
+                  },
+                },
+              },
+            ],
+          },
+          listingImages: {
+            create: [
+              {
+                assets: {
+                  create: {
+                    ...exampleAsset,
+                  },
+                },
+                ordinal: 0,
+              },
+            ],
+          },
+          listingMultiselectQuestions: {
+            create: [
+              {
+                ordinal: 0,
+                multiselectQuestions: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+              },
+            ],
+          },
+          listingsApplicationDropOffAddress: {
+            create: {
+              ...exampleAddress,
+            },
+          },
+          reservedCommunityTypes: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          listingsBuildingSelectionCriteriaFile: {
+            create: {
+              ...exampleAsset,
+            },
+          },
+          listingUtilities: {
+            create: {
+              water: false,
+              gas: true,
+              trash: false,
+              sewer: true,
+              electricity: false,
+              cable: true,
+              phone: false,
+              internet: true,
+            },
+          },
+          listingsApplicationMailingAddress: {
+            create: {
+              ...exampleAddress,
+            },
+          },
+          listingsLeasingAgentAddress: {
+            create: {
+              ...exampleAddress,
+            },
+          },
+          listingFeatures: {
+            create: {
+              elevator: true,
+              wheelchairRamp: false,
+              serviceAnimalsAllowed: true,
+              accessibleParking: false,
+              parkingOnSite: true,
+              inUnitWasherDryer: false,
+              laundryInBuilding: true,
+              barrierFreeEntrance: false,
+              rollInShower: true,
+              grabBars: false,
+              heatingInUnit: true,
+              acInUnit: false,
+              hearing: true,
+              visual: false,
+              mobility: true,
+            },
+          },
+          jurisdictions: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          listingsApplicationPickUpAddress: {
+            create: {
+              ...exampleAddress,
+            },
+          },
+          listingsBuildingAddress: {
+            create: {
+              ...exampleAddress,
+            },
+          },
+          units: {
+            create: [
+              {
+                amiPercentage: '1',
+                annualIncomeMin: '2',
+                monthlyIncomeMin: '3',
+                floor: 4,
+                annualIncomeMax: '5',
+                maxOccupancy: 6,
+                minOccupancy: 7,
+                monthlyRent: '8',
+                numBathrooms: 9,
+                numBedrooms: 10,
+                number: '11',
+                sqFeet: '12',
+                monthlyRentAsPercentOfIncome: '13',
+                bmrProgramChart: true,
+                unitTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                amiChart: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                unitAmiChartOverrides: {
+                  create: {
+                    items: [
+                      {
+                        percentOfAmi: 10,
+                        householdSize: 20,
+                        income: 30,
+                      },
+                    ],
+                  },
+                },
+                unitAccessibilityPriorityTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                unitRentTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+              },
+            ],
+          },
+          unitsSummary: {
+            create: [
+              {
+                monthlyRentMin: 1,
+                monthlyRentMax: 2,
+                monthlyRentAsPercentOfIncome: '3',
+                amiPercentage: 4,
+                minimumIncomeMin: '5',
+                minimumIncomeMax: '6',
+                maxOccupancy: 7,
+                minOccupancy: 8,
+                floorMin: 9,
+                floorMax: 10,
+                sqFeetMin: '11',
+                sqFeetMax: '12',
+                totalCount: 13,
+                totalAvailable: 14,
+                unitTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                unitAccessibilityPriorityTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+              },
+            ],
+          },
+          listingsResult: {
+            create: {
+              ...exampleAsset,
+            },
+          },
+        },
+      });
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        user,
+        'listing',
+        permissionActions.create,
+        {
+          jurisdictionId: val.jurisdictions.id,
+        },
+      );
     });
   });
 
-  it('should create a simple listing', async () => {
-    prisma.listings.create = jest.fn().mockResolvedValue({
-      id: 'example id',
-      name: 'example name',
+  describe('Test delete endpoint', () => {
+    it('should delete a listing', async () => {
+      const id = randomUUID();
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id,
+      });
+      prisma.listings.delete = jest.fn().mockResolvedValue({
+        id,
+      });
+
+      await service.delete(id, {
+        id: 'requestingUser id',
+        userRoles: { isAdmin: true },
+      } as unknown as User);
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        {
+          id: 'requestingUser id',
+          userRoles: { isAdmin: true },
+        } as unknown as User,
+        'listing',
+        permissionActions.delete,
+        {
+          id,
+        },
+      );
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: id,
+        },
+      });
+
+      expect(prisma.listings.delete).toHaveBeenCalledWith({
+        where: {
+          id: id,
+        },
+      });
     });
 
-    await service.create(
-      {
-        name: 'example listing name',
-        depositMin: '5',
-        assets: [
-          {
-            fileId: randomUUID(),
-            label: 'example asset',
-          },
-        ],
-        jurisdictions: {
-          id: randomUUID(),
-        },
-        status: ListingsStatusEnum.pending,
-        displayWaitlistSize: false,
-        unitsSummary: null,
-        listingEvents: [],
-      } as ListingCreate,
-      user,
-    );
+    it('should error when nonexistent id is passed to delete()', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
+      prisma.listings.delete = jest.fn().mockResolvedValue(null);
 
-    expect(prisma.listings.create).toHaveBeenCalledWith({
-      include: {
-        applicationMethods: {
-          include: {
-            paperApplications: {
-              include: {
-                assets: true,
+      await expect(
+        async () =>
+          await service.delete(randomUUID(), {
+            id: 'requestingUser id',
+            userRoles: { isAdmin: true },
+          } as unknown as User),
+      ).rejects.toThrowError();
+
+      expect(canOrThrowMock).not.toHaveBeenCalled();
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: expect.anything(),
+        },
+      });
+
+      expect(prisma.listings.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Test findOrThrow endpoint', () => {
+    it('should return listing from call to findOrThrow()', async () => {
+      const id = randomUUID();
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id,
+      });
+
+      await service.findOrThrow(id, ListingViews.fundamentals);
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        include: {
+          jurisdictions: true,
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingUtilities: true,
+          listingsBuildingAddress: true,
+          reservedCommunityTypes: true,
+        },
+        where: {
+          id: id,
+        },
+      });
+    });
+
+    it('should error when nonexistent id is passed to findOrThrow()', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
+
+      await expect(
+        async () => await service.findOrThrow(randomUUID()),
+      ).rejects.toThrowError();
+
+      expect(prisma.listings.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: expect.anything(),
+        },
+      });
+    });
+  });
+
+  describe('Test update endpoint', () => {
+    it('should update a simple listing', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
+      });
+      prisma.$transaction = jest
+        .fn()
+        .mockResolvedValue([{ id: 'example id', name: 'example name' }]);
+
+      await service.update(
+        {
+          id: randomUUID(),
+          name: 'example listing name',
+          depositMin: '5',
+          assets: [
+            {
+              fileId: randomUUID(),
+              label: 'example asset',
+            },
+          ],
+          jurisdictions: {
+            id: randomUUID(),
+          },
+          status: ListingsStatusEnum.pending,
+          displayWaitlistSize: false,
+          unitsSummary: null,
+          listingEvents: [],
+        } as ListingUpdate,
+        user,
+      );
+
+      expect(prisma.listings.update).toHaveBeenCalledWith({
+        include: {
+          applicationMethods: {
+            include: {
+              paperApplications: {
+                include: {
+                  assets: true,
+                },
               },
             },
           },
-        },
-        jurisdictions: true,
-        listingEvents: {
-          include: {
-            assets: true,
-          },
-        },
-        listingFeatures: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingUtilities: true,
-        listingsApplicationDropOffAddress: true,
-        listingsApplicationPickUpAddress: true,
-        listingsApplicationMailingAddress: true,
-        listingsBuildingAddress: true,
-        listingsBuildingSelectionCriteriaFile: true,
-        listingsLeasingAgentAddress: true,
-        listingsResult: true,
-        requestedChangesUser: true,
-        reservedCommunityTypes: true,
-        units: {
-          include: {
-            amiChart: {
-              include: {
-                jurisdictions: true,
-                unitGroupAmiLevels: true,
-              },
+          jurisdictions: true,
+          listingEvents: {
+            include: {
+              assets: true,
             },
-            unitAccessibilityPriorityTypes: true,
-            unitAmiChartOverrides: true,
-            unitRentTypes: true,
-            unitTypes: true,
+          },
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
+            },
+          },
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
+          },
+          listingUtilities: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsBuildingAddress: true,
+          listingsBuildingSelectionCriteriaFile: true,
+          listingsApplicationMailingAddress: true,
+          listingsLeasingAgentAddress: true,
+          listingsResult: true,
+          requestedChangesUser: true,
+          reservedCommunityTypes: true,
+          units: {
+            include: {
+              amiChart: {
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
+                },
+              },
+              unitAccessibilityPriorityTypes: true,
+              unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
+            },
           },
         },
-      },
-      data: {
-        name: 'example listing name',
-        contentUpdatedAt: expect.anything(),
-        depositMin: '5',
-        assets: {
-          create: [
+        data: {
+          name: 'example listing name',
+          contentUpdatedAt: expect.anything(),
+          depositMin: '5',
+          assets: [
             {
               fileId: expect.anything(),
               label: 'example asset',
             },
           ],
-        },
-        jurisdictions: {
-          connect: {
-            id: expect.anything(),
+
+          jurisdictions: {
+            connect: {
+              id: expect.anything(),
+            },
           },
+          status: ListingsStatusEnum.pending,
+          displayWaitlistSize: false,
+          unitsSummary: undefined,
+          listingEvents: {
+            create: [],
+          },
+          listingsBuildingSelectionCriteriaFile: {
+            disconnect: true,
+          },
+          unitsAvailable: 0,
         },
-        status: ListingsStatusEnum.pending,
-        displayWaitlistSize: false,
-        unitsSummary: undefined,
-        unitsAvailable: 0,
-        listingEvents: {
-          create: [],
+        where: {
+          id: expect.anything(),
         },
-      },
+      });
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        user,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
     });
 
-    expect(canOrThrowMock).toHaveBeenCalledWith(
-      user,
-      'listing',
-      permissionActions.create,
-      {
-        jurisdictionId: expect.anything(),
-      },
-    );
-  });
-
-  it('should create a complete listing', async () => {
-    prisma.listings.create = jest.fn().mockResolvedValue({
-      id: 'example id',
-      name: 'example name',
-    });
-
-    const val = constructFullListingData();
-
-    await service.create(val as ListingCreate, user);
-
-    expect(prisma.listings.create).toHaveBeenCalledWith({
-      include: {
-        applicationMethods: {
-          include: {
-            paperApplications: {
-              include: {
-                assets: true,
-              },
-            },
-          },
-        },
-        jurisdictions: true,
-        listingEvents: {
-          include: {
-            assets: true,
-          },
-        },
-        listingFeatures: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingUtilities: true,
-        listingsApplicationDropOffAddress: true,
-        listingsApplicationPickUpAddress: true,
-        listingsApplicationMailingAddress: true,
-        listingsBuildingAddress: true,
-        listingsBuildingSelectionCriteriaFile: true,
-        listingsLeasingAgentAddress: true,
-        listingsResult: true,
-        requestedChangesUser: true,
-        reservedCommunityTypes: true,
-        units: {
-          include: {
-            amiChart: {
-              include: {
-                jurisdictions: true,
-                unitGroupAmiLevels: true,
-              },
-            },
-            unitAccessibilityPriorityTypes: true,
-            unitAmiChartOverrides: true,
-            unitRentTypes: true,
-            unitTypes: true,
-          },
-        },
-      },
-      data: {
-        ...val,
-        contentUpdatedAt: expect.anything(),
-        assets: {
-          create: [exampleAsset],
-        },
-        applicationMethods: {
-          create: [
-            {
-              type: ApplicationMethodsTypeEnum.Internal,
-              label: 'example label',
-              externalReference: 'example reference',
-              acceptsPostmarkedApplications: false,
-              phoneNumber: '520-750-8811',
-              paperApplications: {
-                create: [
-                  {
-                    language: LanguagesEnum.en,
-                    assets: {
-                      create: {
-                        ...exampleAsset,
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        },
-        listingEvents: {
-          create: [
-            {
-              type: ListingEventsTypeEnum.openHouse,
-              startDate: expect.anything(),
-              startTime: expect.anything(),
-              endTime: expect.anything(),
-              url: 'https://www.google.com',
-              note: 'example note',
-              label: 'example label',
-              assets: {
-                create: {
-                  ...exampleAsset,
-                },
-              },
-            },
-          ],
-        },
-        listingImages: {
-          create: [
-            {
-              assets: {
-                create: {
-                  ...exampleAsset,
-                },
-              },
-              ordinal: 0,
-            },
-          ],
-        },
-        listingMultiselectQuestions: {
-          create: [
-            {
-              ordinal: 0,
-              multiselectQuestions: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-            },
-          ],
-        },
-        listingsApplicationDropOffAddress: {
-          create: {
-            ...exampleAddress,
-          },
-        },
+    it('should do a complete listing update', async () => {
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'example id',
+        name: 'example name',
         reservedCommunityTypes: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        listingsBuildingSelectionCriteriaFile: {
-          create: {
-            ...exampleAsset,
-          },
-        },
-        listingUtilities: {
-          create: {
-            water: false,
-            gas: true,
-            trash: false,
-            sewer: true,
-            electricity: false,
-            cable: true,
-            phone: false,
-            internet: true,
-          },
-        },
-        listingsApplicationMailingAddress: {
-          create: {
-            ...exampleAddress,
-          },
-        },
-        listingsLeasingAgentAddress: {
-          create: {
-            ...exampleAddress,
-          },
-        },
-        listingFeatures: {
-          create: {
-            elevator: true,
-            wheelchairRamp: false,
-            serviceAnimalsAllowed: true,
-            accessibleParking: false,
-            parkingOnSite: true,
-            inUnitWasherDryer: false,
-            laundryInBuilding: true,
-            barrierFreeEntrance: false,
-            rollInShower: true,
-            grabBars: false,
-            heatingInUnit: true,
-            acInUnit: false,
-            hearing: true,
-            visual: false,
-            mobility: true,
-          },
-        },
-        jurisdictions: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        listingsApplicationPickUpAddress: {
-          create: {
-            ...exampleAddress,
-          },
-        },
-        listingsBuildingAddress: {
-          create: {
-            ...exampleAddress,
-          },
-        },
-        units: {
-          create: [
-            {
-              amiPercentage: '1',
-              annualIncomeMin: '2',
-              monthlyIncomeMin: '3',
-              floor: 4,
-              annualIncomeMax: '5',
-              maxOccupancy: 6,
-              minOccupancy: 7,
-              monthlyRent: '8',
-              numBathrooms: 9,
-              numBedrooms: 10,
-              number: '11',
-              sqFeet: '12',
-              monthlyRentAsPercentOfIncome: '13',
-              bmrProgramChart: true,
-              unitTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-              amiChart: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-              unitAmiChartOverrides: {
-                create: {
-                  items: [
-                    {
-                      percentOfAmi: 10,
-                      householdSize: 20,
-                      income: 30,
-                    },
-                  ],
-                },
-              },
-              unitAccessibilityPriorityTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-              unitRentTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-            },
-          ],
-        },
-        unitsSummary: {
-          create: [
-            {
-              monthlyRentMin: 1,
-              monthlyRentMax: 2,
-              monthlyRentAsPercentOfIncome: '3',
-              amiPercentage: 4,
-              minimumIncomeMin: '5',
-              minimumIncomeMax: '6',
-              maxOccupancy: 7,
-              minOccupancy: 8,
-              floorMin: 9,
-              floorMax: 10,
-              sqFeetMin: '11',
-              sqFeetMax: '12',
-              totalCount: 13,
-              totalAvailable: 14,
-              unitTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-              unitAccessibilityPriorityTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-            },
-          ],
-        },
-        listingsResult: {
-          create: {
-            ...exampleAsset,
-          },
-        },
-      },
-    });
-
-    expect(canOrThrowMock).toHaveBeenCalledWith(
-      user,
-      'listing',
-      permissionActions.create,
-      {
-        jurisdictionId: val.jurisdictions.id,
-      },
-    );
-  });
-
-  it('should delete a listing', async () => {
-    const id = randomUUID();
-    prisma.listings.findUnique = jest.fn().mockResolvedValue({
-      id,
-    });
-    prisma.listings.delete = jest.fn().mockResolvedValue({
-      id,
-    });
-
-    await service.delete(id, {
-      id: 'requestingUser id',
-      userRoles: { isAdmin: true },
-    } as unknown as User);
-
-    expect(canOrThrowMock).toHaveBeenCalledWith(
-      {
-        id: 'requestingUser id',
-        userRoles: { isAdmin: true },
-      } as unknown as User,
-      'listing',
-      permissionActions.delete,
-      {
-        id,
-      },
-    );
-
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      where: {
-        id: id,
-      },
-    });
-
-    expect(prisma.listings.delete).toHaveBeenCalledWith({
-      where: {
-        id: id,
-      },
-    });
-  });
-
-  it('should error when nonexistent id is passed to delete()', async () => {
-    prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
-    prisma.listings.delete = jest.fn().mockResolvedValue(null);
-
-    await expect(
-      async () =>
-        await service.delete(randomUUID(), {
-          id: 'requestingUser id',
-          userRoles: { isAdmin: true },
-        } as unknown as User),
-    ).rejects.toThrowError();
-
-    expect(canOrThrowMock).not.toHaveBeenCalled();
-
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      where: {
-        id: expect.anything(),
-      },
-    });
-
-    expect(prisma.listings.delete).not.toHaveBeenCalled();
-  });
-
-  it('should return listing from call to findOrThrow()', async () => {
-    const id = randomUUID();
-    prisma.listings.findUnique = jest.fn().mockResolvedValue({
-      id,
-    });
-
-    await service.findOrThrow(id, ListingViews.fundamentals);
-
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      include: {
-        jurisdictions: true,
-        listingFeatures: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingUtilities: true,
-        listingsBuildingAddress: true,
-        reservedCommunityTypes: true,
-      },
-      where: {
-        id: id,
-      },
-    });
-  });
-
-  it('should error when nonexistent id is passed to findOrThrow()', async () => {
-    prisma.listings.findUnique = jest.fn().mockResolvedValue(null);
-
-    await expect(
-      async () => await service.findOrThrow(randomUUID()),
-    ).rejects.toThrowError();
-
-    expect(prisma.listings.findUnique).toHaveBeenCalledWith({
-      where: {
-        id: expect.anything(),
-      },
-    });
-  });
-
-  it('should update a simple listing', async () => {
-    prisma.listings.findUnique = jest.fn().mockResolvedValue({
-      id: 'example id',
-      name: 'example name',
-    });
-    prisma.listings.update = jest.fn().mockResolvedValue({
-      id: 'example id',
-      name: 'example name',
-    });
-    prisma.$transaction = jest
-      .fn()
-      .mockResolvedValue([{ id: 'example id', name: 'example name' }]);
-
-    await service.update(
-      {
-        id: randomUUID(),
-        name: 'example listing name',
-        depositMin: '5',
-        assets: [
-          {
-            fileId: randomUUID(),
-            label: 'example asset',
-          },
-        ],
-        jurisdictions: {
           id: randomUUID(),
         },
-        status: ListingsStatusEnum.pending,
-        displayWaitlistSize: false,
-        unitsSummary: null,
-        listingEvents: [],
-      } as ListingUpdate,
-      user,
-    );
-
-    expect(prisma.listings.update).toHaveBeenCalledWith({
-      include: {
-        applicationMethods: {
-          include: {
-            paperApplications: {
-              include: {
-                assets: true,
-              },
-            },
-          },
-        },
-        jurisdictions: true,
-        listingEvents: {
-          include: {
-            assets: true,
-          },
-        },
-        listingFeatures: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingUtilities: true,
-        listingsApplicationDropOffAddress: true,
-        listingsApplicationPickUpAddress: true,
-        listingsBuildingAddress: true,
-        listingsBuildingSelectionCriteriaFile: true,
-        listingsApplicationMailingAddress: true,
-        listingsLeasingAgentAddress: true,
-        listingsResult: true,
-        requestedChangesUser: true,
-        reservedCommunityTypes: true,
-        units: {
-          include: {
-            amiChart: {
-              include: {
-                jurisdictions: true,
-                unitGroupAmiLevels: true,
-              },
-            },
-            unitAccessibilityPriorityTypes: true,
-            unitAmiChartOverrides: true,
-            unitRentTypes: true,
-            unitTypes: true,
-          },
-        },
-      },
-      data: {
-        name: 'example listing name',
-        contentUpdatedAt: expect.anything(),
-        depositMin: '5',
-        assets: [
-          {
-            fileId: expect.anything(),
-            label: 'example asset',
-          },
-        ],
-
-        jurisdictions: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        status: ListingsStatusEnum.pending,
-        displayWaitlistSize: false,
-        unitsSummary: undefined,
-        listingEvents: {
-          create: [],
-        },
-        listingsBuildingSelectionCriteriaFile: {
-          disconnect: true,
-        },
-        unitsAvailable: 0,
-      },
-      where: {
-        id: expect.anything(),
-      },
-    });
-
-    expect(canOrThrowMock).toHaveBeenCalledWith(
-      user,
-      'listing',
-      permissionActions.update,
-      {
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue({
         id: 'example id',
-      },
-    );
-  });
+        name: 'example name',
+      });
+      const updateMock = jest
+        .fn()
+        .mockResolvedValue({ id: 'example id', name: 'example name' });
 
-  it('should do a complete listing update', async () => {
-    prisma.listings.findUnique = jest.fn().mockResolvedValue({
-      id: 'example id',
-      name: 'example name',
-    });
-    prisma.listings.update = jest.fn().mockResolvedValue({
-      id: 'example id',
-      name: 'example name',
-    });
-    const updateMock = jest
-      .fn()
-      .mockResolvedValue({ id: 'example id', name: 'example name' });
+      prisma.$transaction = jest
+        .fn()
+        .mockResolvedValue([
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          jest.fn(),
+          updateMock,
+        ]);
 
-    prisma.$transaction = jest
-      .fn()
-      .mockResolvedValue([
-        jest.fn(),
-        jest.fn(),
-        jest.fn(),
-        jest.fn(),
-        jest.fn(),
-        updateMock,
-      ]);
+      const val = constructFullListingData(randomUUID());
+      val.reservedCommunityTypes = null;
 
-    const val = constructFullListingData(randomUUID());
+      await service.update(val as ListingUpdate, user);
 
-    await service.update(val as ListingUpdate, user);
-
-    expect(prisma.listings.update).toHaveBeenCalledWith({
-      include: {
-        applicationMethods: {
-          include: {
-            paperApplications: {
-              include: {
-                assets: true,
-              },
-            },
-          },
-        },
-        jurisdictions: true,
-        listingEvents: {
-          include: {
-            assets: true,
-          },
-        },
-        listingFeatures: true,
-        listingImages: {
-          include: {
-            assets: true,
-          },
-        },
-        listingMultiselectQuestions: {
-          include: {
-            multiselectQuestions: true,
-          },
-        },
-        listingUtilities: true,
-        listingsApplicationDropOffAddress: true,
-        listingsApplicationPickUpAddress: true,
-        listingsApplicationMailingAddress: true,
-        listingsBuildingAddress: true,
-        listingsBuildingSelectionCriteriaFile: true,
-        listingsLeasingAgentAddress: true,
-        listingsResult: true,
-        reservedCommunityTypes: true,
-        requestedChangesUser: true,
-        units: {
-          include: {
-            amiChart: {
-              include: {
-                jurisdictions: true,
-                unitGroupAmiLevels: true,
-              },
-            },
-            unitAccessibilityPriorityTypes: true,
-            unitAmiChartOverrides: true,
-            unitRentTypes: true,
-            unitTypes: true,
-          },
-        },
-      },
-      data: {
-        ...val,
-        id: undefined,
-        publishedAt: expect.anything(),
-        contentUpdatedAt: expect.anything(),
-        assets: [exampleAsset],
-        applicationMethods: {
-          create: [
-            {
-              type: ApplicationMethodsTypeEnum.Internal,
-              label: 'example label',
-              externalReference: 'example reference',
-              acceptsPostmarkedApplications: false,
-              phoneNumber: '520-750-8811',
+      expect(prisma.listings.update).toHaveBeenCalledWith({
+        include: {
+          applicationMethods: {
+            include: {
               paperApplications: {
-                create: [
-                  {
-                    language: LanguagesEnum.en,
-                    assets: {
-                      create: {
-                        ...exampleAsset,
-                      },
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        },
-        listingEvents: {
-          create: [
-            {
-              type: ListingEventsTypeEnum.openHouse,
-              startDate: expect.anything(),
-              startTime: expect.anything(),
-              endTime: expect.anything(),
-              url: 'https://www.google.com',
-              note: 'example note',
-              label: 'example label',
-              assets: {
-                create: {
-                  ...exampleAsset,
+                include: {
+                  assets: true,
                 },
               },
             },
-          ],
-        },
-        listingImages: {
-          create: [
-            {
-              assets: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
-              ordinal: 0,
+          },
+          jurisdictions: true,
+          listingEvents: {
+            include: {
+              assets: true,
             },
-          ],
-        },
-        listingMultiselectQuestions: {
-          create: [
-            {
-              multiselectQuestionId: expect.anything(),
-              ordinal: 0,
+          },
+          listingFeatures: true,
+          listingImages: {
+            include: {
+              assets: true,
             },
-          ],
-        },
-        listingsApplicationDropOffAddress: {
-          connect: {
-            id: expect.anything(),
           },
-        },
-        reservedCommunityTypes: {
-          connect: {
-            id: expect.anything(),
+          listingMultiselectQuestions: {
+            include: {
+              multiselectQuestions: true,
+            },
           },
-        },
-        listingsBuildingSelectionCriteriaFile: {
-          create: {
-            ...exampleAsset,
-          },
-        },
-        listingUtilities: {
-          create: {
-            water: false,
-            gas: true,
-            trash: false,
-            sewer: true,
-            electricity: false,
-            cable: true,
-            phone: false,
-            internet: true,
-          },
-        },
-        listingsApplicationMailingAddress: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        listingsLeasingAgentAddress: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        listingFeatures: {
-          create: {
-            elevator: true,
-            wheelchairRamp: false,
-            serviceAnimalsAllowed: true,
-            accessibleParking: false,
-            parkingOnSite: true,
-            inUnitWasherDryer: false,
-            laundryInBuilding: true,
-            barrierFreeEntrance: false,
-            rollInShower: true,
-            grabBars: false,
-            heatingInUnit: true,
-            acInUnit: false,
-            hearing: true,
-            visual: false,
-            mobility: true,
-          },
-        },
-        jurisdictions: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        listingsApplicationPickUpAddress: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        listingsBuildingAddress: {
-          connect: {
-            id: expect.anything(),
-          },
-        },
-        units: {
-          create: [
-            {
-              amiPercentage: '1',
-              annualIncomeMin: '2',
-              monthlyIncomeMin: '3',
-              floor: 4,
-              annualIncomeMax: '5',
-              maxOccupancy: 6,
-              minOccupancy: 7,
-              monthlyRent: '8',
-              numBathrooms: 9,
-              numBedrooms: 10,
-              number: '11',
-              sqFeet: '12',
-              monthlyRentAsPercentOfIncome: '13',
-              bmrProgramChart: true,
-              unitTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
-              },
+          listingUtilities: true,
+          listingsApplicationDropOffAddress: true,
+          listingsApplicationPickUpAddress: true,
+          listingsApplicationMailingAddress: true,
+          listingsBuildingAddress: true,
+          listingsBuildingSelectionCriteriaFile: true,
+          listingsLeasingAgentAddress: true,
+          listingsResult: true,
+          reservedCommunityTypes: true,
+          requestedChangesUser: true,
+          units: {
+            include: {
               amiChart: {
-                connect: {
-                  id: expect.anything(),
+                include: {
+                  jurisdictions: true,
+                  unitGroupAmiLevels: true,
                 },
               },
-              unitAmiChartOverrides: {
-                create: {
-                  items: [
+              unitAccessibilityPriorityTypes: true,
+              unitAmiChartOverrides: true,
+              unitRentTypes: true,
+              unitTypes: true,
+            },
+          },
+        },
+        data: {
+          ...val,
+          id: undefined,
+          publishedAt: expect.anything(),
+          contentUpdatedAt: expect.anything(),
+          assets: [exampleAsset],
+          applicationMethods: {
+            create: [
+              {
+                type: ApplicationMethodsTypeEnum.Internal,
+                label: 'example label',
+                externalReference: 'example reference',
+                acceptsPostmarkedApplications: false,
+                phoneNumber: '520-750-8811',
+                paperApplications: {
+                  create: [
                     {
-                      percentOfAmi: 10,
-                      householdSize: 20,
-                      income: 30,
+                      language: LanguagesEnum.en,
+                      assets: {
+                        create: {
+                          ...exampleAsset,
+                        },
+                      },
                     },
                   ],
                 },
               },
-              unitAccessibilityPriorityTypes: {
-                connect: {
-                  id: expect.anything(),
+            ],
+          },
+          listingEvents: {
+            create: [
+              {
+                type: ListingEventsTypeEnum.openHouse,
+                startDate: expect.anything(),
+                startTime: expect.anything(),
+                endTime: expect.anything(),
+                url: 'https://www.google.com',
+                note: 'example note',
+                label: 'example label',
+                assets: {
+                  create: {
+                    ...exampleAsset,
+                  },
                 },
               },
-              unitRentTypes: {
-                connect: {
-                  id: expect.anything(),
+            ],
+          },
+          listingImages: {
+            create: [
+              {
+                assets: {
+                  connect: {
+                    id: expect.anything(),
+                  },
                 },
+                ordinal: 0,
               },
+            ],
+          },
+          listingMultiselectQuestions: {
+            create: [
+              {
+                multiselectQuestionId: expect.anything(),
+                ordinal: 0,
+              },
+            ],
+          },
+          listingsApplicationDropOffAddress: {
+            connect: {
+              id: expect.anything(),
             },
-          ],
+          },
+          reservedCommunityTypes: {
+            disconnect: {
+              id: expect.anything(),
+            },
+          },
+          listingsBuildingSelectionCriteriaFile: {
+            create: {
+              ...exampleAsset,
+            },
+          },
+          listingUtilities: {
+            create: {
+              water: false,
+              gas: true,
+              trash: false,
+              sewer: true,
+              electricity: false,
+              cable: true,
+              phone: false,
+              internet: true,
+            },
+          },
+          listingsApplicationMailingAddress: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          listingsLeasingAgentAddress: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          listingFeatures: {
+            create: {
+              elevator: true,
+              wheelchairRamp: false,
+              serviceAnimalsAllowed: true,
+              accessibleParking: false,
+              parkingOnSite: true,
+              inUnitWasherDryer: false,
+              laundryInBuilding: true,
+              barrierFreeEntrance: false,
+              rollInShower: true,
+              grabBars: false,
+              heatingInUnit: true,
+              acInUnit: false,
+              hearing: true,
+              visual: false,
+              mobility: true,
+            },
+          },
+          jurisdictions: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          listingsApplicationPickUpAddress: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          listingsBuildingAddress: {
+            connect: {
+              id: expect.anything(),
+            },
+          },
+          units: {
+            create: [
+              {
+                amiPercentage: '1',
+                annualIncomeMin: '2',
+                monthlyIncomeMin: '3',
+                floor: 4,
+                annualIncomeMax: '5',
+                maxOccupancy: 6,
+                minOccupancy: 7,
+                monthlyRent: '8',
+                numBathrooms: 9,
+                numBedrooms: 10,
+                number: '11',
+                sqFeet: '12',
+                monthlyRentAsPercentOfIncome: '13',
+                bmrProgramChart: true,
+                unitTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                amiChart: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                unitAmiChartOverrides: {
+                  create: {
+                    items: [
+                      {
+                        percentOfAmi: 10,
+                        householdSize: 20,
+                        income: 30,
+                      },
+                    ],
+                  },
+                },
+                unitAccessibilityPriorityTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                unitRentTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+              },
+            ],
+          },
+          unitsSummary: {
+            create: [
+              {
+                monthlyRentMin: 1,
+                monthlyRentMax: 2,
+                monthlyRentAsPercentOfIncome: '3',
+                amiPercentage: 4,
+                minimumIncomeMin: '5',
+                minimumIncomeMax: '6',
+                maxOccupancy: 7,
+                minOccupancy: 8,
+                floorMin: 9,
+                floorMax: 10,
+                sqFeetMin: '11',
+                sqFeetMax: '12',
+                totalCount: 13,
+                totalAvailable: 14,
+                unitTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+                unitAccessibilityPriorityTypes: {
+                  connect: {
+                    id: expect.anything(),
+                  },
+                },
+              },
+            ],
+          },
+          listingsResult: {
+            create: {
+              ...exampleAsset,
+            },
+          },
         },
-        unitsSummary: {
-          create: [
+        where: {
+          id: expect.anything(),
+        },
+      });
+
+      expect(canOrThrowMock).toHaveBeenCalledWith(
+        user,
+        'listing',
+        permissionActions.update,
+        {
+          id: 'example id',
+        },
+      );
+    });
+  });
+
+  describe('Test listingApprovalNotify endpoint', () => {
+    it('listingApprovalNotify request approval email', async () => {
+      jest
+        .spyOn(service, 'getUserEmailInfo')
+        .mockResolvedValueOnce({ emails: ['admin@email.com'] });
+      await service.listingApprovalNotify({
+        user,
+        listingInfo: { id: 'id', name: 'name' },
+        status: ListingsStatusEnum.pendingReview,
+        approvingRoles: [UserRoleEnum.admin],
+        jurisId: 'jurisId',
+      });
+
+      expect(service.getUserEmailInfo).toBeCalledWith(
+        ['admin'],
+        'id',
+        'jurisId',
+      );
+      expect(requestApprovalMock).toBeCalledWith(
+        { id: 'jurisId' },
+        { id: 'id', name: 'name' },
+        ['admin@email.com'],
+        config.get('PARTNERS_PORTAL_URL'),
+      );
+    });
+
+    it('listingApprovalNotify changes requested email', async () => {
+      jest.spyOn(service, 'getUserEmailInfo').mockResolvedValueOnce({
+        emails: ['jurisAdmin@email.com', 'partner@email.com'],
+      });
+      await service.listingApprovalNotify({
+        user,
+        listingInfo: { id: 'id', name: 'name' },
+        status: ListingsStatusEnum.changesRequested,
+        approvingRoles: [UserRoleEnum.admin],
+        jurisId: 'jurisId',
+      });
+
+      expect(service.getUserEmailInfo).toBeCalledWith(
+        ['partner', 'jurisdictionAdmin'],
+        'id',
+        'jurisId',
+      );
+      expect(changesRequestedMock).toBeCalledWith(
+        user,
+        { id: 'id', name: 'name', juris: 'jurisId' },
+        ['jurisAdmin@email.com', 'partner@email.com'],
+        config.get('PARTNERS_PORTAL_URL'),
+      );
+    });
+
+    it('listingApprovalNotify listing approved email', async () => {
+      jest.spyOn(service, 'getUserEmailInfo').mockResolvedValueOnce({
+        emails: ['jurisAdmin@email.com', 'partner@email.com'],
+        publicUrl: 'public.housing.gov',
+      });
+      await service.listingApprovalNotify({
+        user,
+        listingInfo: { id: 'id', name: 'name' },
+        status: ListingsStatusEnum.active,
+        previousStatus: ListingsStatusEnum.pendingReview,
+        approvingRoles: [UserRoleEnum.admin],
+        jurisId: 'jurisId',
+      });
+
+      expect(service.getUserEmailInfo).toBeCalledWith(
+        ['partner', 'jurisdictionAdmin'],
+        'id',
+        'jurisId',
+        true,
+      );
+      expect(listingApprovedMock).toBeCalledWith(
+        expect.objectContaining({ id: 'jurisId' }),
+        { id: 'id', name: 'name' },
+        ['jurisAdmin@email.com', 'partner@email.com'],
+        'public.housing.gov',
+      );
+    });
+
+    it('listingApprovalNotify active listing not requiring email', async () => {
+      await service.listingApprovalNotify({
+        user,
+        listingInfo: { id: 'id', name: 'name' },
+        status: ListingsStatusEnum.active,
+        previousStatus: ListingsStatusEnum.active,
+        approvingRoles: [UserRoleEnum.admin],
+        jurisId: 'jurisId',
+      });
+
+      expect(listingApprovedMock).toBeCalledTimes(0);
+    });
+  });
+
+  describe('Test cachePurge endpoint', () => {
+    it('should purge single listing', async () => {
+      const id = randomUUID();
+      process.env.PROXY_URL = 'https://www.google.com';
+      await service.cachePurge(
+        ListingsStatusEnum.pending,
+        ListingsStatusEnum.pending,
+        id,
+      );
+      expect(httpServiceMock.request).toHaveBeenCalledWith({
+        baseURL: 'https://www.google.com',
+        method: 'PURGE',
+        url: `/listings/${id}*`,
+      });
+
+      process.env.PROXY_URL = undefined;
+    });
+
+    it('should purge all listings', async () => {
+      const id = randomUUID();
+      process.env.PROXY_URL = 'https://www.google.com';
+      await service.cachePurge(
+        ListingsStatusEnum.active,
+        ListingsStatusEnum.pending,
+        id,
+      );
+      expect(httpServiceMock.request).toHaveBeenCalledWith({
+        baseURL: 'https://www.google.com',
+        method: 'PURGE',
+        url: `/listings?*`,
+      });
+
+      process.env.PROXY_URL = undefined;
+    });
+  });
+
+  describe('Test process endpoint', () => {
+    it('should call the purge if no listings needed to get processed', async () => {
+      prisma.listings.updateMany = jest.fn().mockResolvedValue({ count: 2 });
+      prisma.cronJob.findFirst = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+      prisma.cronJob.update = jest.fn().mockResolvedValue(true);
+
+      process.env.PROXY_URL = 'https://www.google.com';
+      await service.process();
+      expect(httpServiceMock.request).toHaveBeenCalledWith({
+        baseURL: 'https://www.google.com',
+        method: 'PURGE',
+        url: `/listings?*`,
+      });
+      expect(prisma.listings.updateMany).toHaveBeenCalledWith({
+        data: {
+          status: ListingsStatusEnum.closed,
+          closedAt: expect.anything(),
+        },
+        where: {
+          status: ListingsStatusEnum.active,
+          AND: [
             {
-              monthlyRentMin: 1,
-              monthlyRentMax: 2,
-              monthlyRentAsPercentOfIncome: '3',
-              amiPercentage: 4,
-              minimumIncomeMin: '5',
-              minimumIncomeMax: '6',
-              maxOccupancy: 7,
-              minOccupancy: 8,
-              floorMin: 9,
-              floorMax: 10,
-              sqFeetMin: '11',
-              sqFeetMax: '12',
-              totalCount: 13,
-              totalAvailable: 14,
-              unitTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
+              applicationDueDate: {
+                not: null,
               },
-              unitAccessibilityPriorityTypes: {
-                connect: {
-                  id: expect.anything(),
-                },
+            },
+            {
+              applicationDueDate: {
+                lte: expect.anything(),
               },
             },
           ],
         },
-        listingsResult: {
-          create: {
-            ...exampleAsset,
-          },
+      });
+      expect(prisma.cronJob.findFirst).toHaveBeenCalled();
+      expect(prisma.cronJob.update).toHaveBeenCalled();
+      process.env.PROXY_URL = undefined;
+    });
+
+    it('should not call the purge if no listings needed to get processed', async () => {
+      prisma.listings.updateMany = jest.fn().mockResolvedValue({ count: 0 });
+      prisma.cronJob.findFirst = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+      prisma.cronJob.update = jest.fn().mockResolvedValue(true);
+
+      process.env.PROXY_URL = 'https://www.google.com';
+      await service.process();
+      expect(httpServiceMock.request).not.toHaveBeenCalled();
+      expect(prisma.listings.updateMany).toHaveBeenCalledWith({
+        data: {
+          status: ListingsStatusEnum.closed,
+          closedAt: expect.anything(),
         },
-      },
-      where: {
-        id: expect.anything(),
-      },
-    });
-
-    expect(canOrThrowMock).toHaveBeenCalledWith(
-      user,
-      'listing',
-      permissionActions.update,
-      {
-        id: 'example id',
-      },
-    );
-  });
-
-  it('listingApprovalNotify request approval email', async () => {
-    jest
-      .spyOn(service, 'getUserEmailInfo')
-      .mockResolvedValueOnce({ emails: ['admin@email.com'] });
-    await service.listingApprovalNotify({
-      user,
-      listingInfo: { id: 'id', name: 'name' },
-      status: ListingsStatusEnum.pendingReview,
-      approvingRoles: [UserRoleEnum.admin],
-      jurisId: 'jurisId',
-    });
-
-    expect(service.getUserEmailInfo).toBeCalledWith(['admin'], 'id', 'jurisId');
-    expect(requestApprovalMock).toBeCalledWith(
-      { id: 'jurisId' },
-      { id: 'id', name: 'name' },
-      ['admin@email.com'],
-      config.get('PARTNERS_PORTAL_URL'),
-    );
-  });
-
-  it('listingApprovalNotify changes requested email', async () => {
-    jest.spyOn(service, 'getUserEmailInfo').mockResolvedValueOnce({
-      emails: ['jurisAdmin@email.com', 'partner@email.com'],
-    });
-    await service.listingApprovalNotify({
-      user,
-      listingInfo: { id: 'id', name: 'name' },
-      status: ListingsStatusEnum.changesRequested,
-      approvingRoles: [UserRoleEnum.admin],
-      jurisId: 'jurisId',
-    });
-
-    expect(service.getUserEmailInfo).toBeCalledWith(
-      ['partner', 'jurisdictionAdmin'],
-      'id',
-      'jurisId',
-    );
-    expect(changesRequestedMock).toBeCalledWith(
-      user,
-      { id: 'id', name: 'name', juris: 'jurisId' },
-      ['jurisAdmin@email.com', 'partner@email.com'],
-      config.get('PARTNERS_PORTAL_URL'),
-    );
-  });
-
-  it('listingApprovalNotify listing approved email', async () => {
-    jest.spyOn(service, 'getUserEmailInfo').mockResolvedValueOnce({
-      emails: ['jurisAdmin@email.com', 'partner@email.com'],
-      publicUrl: 'public.housing.gov',
-    });
-    await service.listingApprovalNotify({
-      user,
-      listingInfo: { id: 'id', name: 'name' },
-      status: ListingsStatusEnum.active,
-      previousStatus: ListingsStatusEnum.pendingReview,
-      approvingRoles: [UserRoleEnum.admin],
-      jurisId: 'jurisId',
-    });
-
-    expect(service.getUserEmailInfo).toBeCalledWith(
-      ['partner', 'jurisdictionAdmin'],
-      'id',
-      'jurisId',
-      true,
-    );
-    expect(listingApprovedMock).toBeCalledWith(
-      expect.objectContaining({ id: 'jurisId' }),
-      { id: 'id', name: 'name' },
-      ['jurisAdmin@email.com', 'partner@email.com'],
-      'public.housing.gov',
-    );
-  });
-
-  it('listingApprovalNotify active listing not requiring email', async () => {
-    await service.listingApprovalNotify({
-      user,
-      listingInfo: { id: 'id', name: 'name' },
-      status: ListingsStatusEnum.active,
-      previousStatus: ListingsStatusEnum.active,
-      approvingRoles: [UserRoleEnum.admin],
-      jurisId: 'jurisId',
-    });
-
-    expect(listingApprovedMock).toBeCalledTimes(0);
-  });
-
-  it('should purge single listing', async () => {
-    const id = randomUUID();
-    process.env.PROXY_URL = 'https://www.google.com';
-    await service.cachePurge(
-      ListingsStatusEnum.pending,
-      ListingsStatusEnum.pending,
-      id,
-    );
-    expect(httpServiceMock.request).toHaveBeenCalledWith({
-      baseURL: 'https://www.google.com',
-      method: 'PURGE',
-      url: `/listings/${id}*`,
-    });
-
-    process.env.PROXY_URL = undefined;
-  });
-
-  it('should purge all listings', async () => {
-    const id = randomUUID();
-    process.env.PROXY_URL = 'https://www.google.com';
-    await service.cachePurge(
-      ListingsStatusEnum.active,
-      ListingsStatusEnum.pending,
-      id,
-    );
-    expect(httpServiceMock.request).toHaveBeenCalledWith({
-      baseURL: 'https://www.google.com',
-      method: 'PURGE',
-      url: `/listings?*`,
-    });
-
-    process.env.PROXY_URL = undefined;
-  });
-
-  it('should call the purge if no listings needed to get processed', async () => {
-    prisma.listings.updateMany = jest.fn().mockResolvedValue({ count: 2 });
-    prisma.cronJob.findFirst = jest
-      .fn()
-      .mockResolvedValue({ id: randomUUID() });
-    prisma.cronJob.update = jest.fn().mockResolvedValue(true);
-
-    process.env.PROXY_URL = 'https://www.google.com';
-    await service.process();
-    expect(httpServiceMock.request).toHaveBeenCalledWith({
-      baseURL: 'https://www.google.com',
-      method: 'PURGE',
-      url: `/listings?*`,
-    });
-    expect(prisma.listings.updateMany).toHaveBeenCalledWith({
-      data: {
-        status: ListingsStatusEnum.closed,
-        closedAt: expect.anything(),
-      },
-      where: {
-        status: ListingsStatusEnum.active,
-        AND: [
-          {
-            applicationDueDate: {
-              not: null,
+        where: {
+          status: ListingsStatusEnum.active,
+          AND: [
+            {
+              applicationDueDate: {
+                not: null,
+              },
             },
-          },
-          {
-            applicationDueDate: {
-              lte: expect.anything(),
+            {
+              applicationDueDate: {
+                lte: expect.anything(),
+              },
             },
-          },
-        ],
-      },
-    });
-    expect(prisma.cronJob.findFirst).toHaveBeenCalled();
-    expect(prisma.cronJob.update).toHaveBeenCalled();
-    process.env.PROXY_URL = undefined;
-  });
-
-  it('should not call the purge if no listings needed to get processed', async () => {
-    prisma.listings.updateMany = jest.fn().mockResolvedValue({ count: 0 });
-    prisma.cronJob.findFirst = jest
-      .fn()
-      .mockResolvedValue({ id: randomUUID() });
-    prisma.cronJob.update = jest.fn().mockResolvedValue(true);
-
-    process.env.PROXY_URL = 'https://www.google.com';
-    await service.process();
-    expect(httpServiceMock.request).not.toHaveBeenCalled();
-    expect(prisma.listings.updateMany).toHaveBeenCalledWith({
-      data: {
-        status: ListingsStatusEnum.closed,
-        closedAt: expect.anything(),
-      },
-      where: {
-        status: ListingsStatusEnum.active,
-        AND: [
-          {
-            applicationDueDate: {
-              not: null,
-            },
-          },
-          {
-            applicationDueDate: {
-              lte: expect.anything(),
-            },
-          },
-        ],
-      },
-    });
-    expect(prisma.cronJob.findFirst).toHaveBeenCalled();
-    expect(prisma.cronJob.update).toHaveBeenCalled();
-    process.env.PROXY_URL = undefined;
-  });
-
-  it('should create new cronjob entry if none is present', async () => {
-    prisma.cronJob.findFirst = jest.fn().mockResolvedValue(null);
-    prisma.cronJob.create = jest.fn().mockResolvedValue(true);
-
-    await service.markCronJobAsStarted();
-
-    expect(prisma.cronJob.findFirst).toHaveBeenCalledWith({
-      where: {
-        name: 'LISTING_CRON_JOB',
-      },
-    });
-    expect(prisma.cronJob.create).toHaveBeenCalledWith({
-      data: {
-        lastRunDate: expect.anything(),
-        name: 'LISTING_CRON_JOB',
-      },
+          ],
+        },
+      });
+      expect(prisma.cronJob.findFirst).toHaveBeenCalled();
+      expect(prisma.cronJob.update).toHaveBeenCalled();
+      process.env.PROXY_URL = undefined;
     });
   });
 
-  it('should update cronjob entry if one is present', async () => {
-    prisma.cronJob.findFirst = jest
-      .fn()
-      .mockResolvedValue({ id: randomUUID() });
-    prisma.cronJob.update = jest.fn().mockResolvedValue(true);
+  describe('Test markCronJobAsStarted endpoint', () => {
+    it('should create new cronjob entry if none is present', async () => {
+      prisma.cronJob.findFirst = jest.fn().mockResolvedValue(null);
+      prisma.cronJob.create = jest.fn().mockResolvedValue(true);
 
-    await service.markCronJobAsStarted();
+      await service.markCronJobAsStarted();
 
-    expect(prisma.cronJob.findFirst).toHaveBeenCalledWith({
-      where: {
-        name: 'LISTING_CRON_JOB',
-      },
+      expect(prisma.cronJob.findFirst).toHaveBeenCalledWith({
+        where: {
+          name: 'LISTING_CRON_JOB',
+        },
+      });
+      expect(prisma.cronJob.create).toHaveBeenCalledWith({
+        data: {
+          lastRunDate: expect.anything(),
+          name: 'LISTING_CRON_JOB',
+        },
+      });
     });
-    expect(prisma.cronJob.update).toHaveBeenCalledWith({
-      data: {
-        lastRunDate: expect.anything(),
-      },
-      where: {
-        id: expect.anything(),
-      },
+
+    it('should update cronjob entry if one is present', async () => {
+      prisma.cronJob.findFirst = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+      prisma.cronJob.update = jest.fn().mockResolvedValue(true);
+
+      await service.markCronJobAsStarted();
+
+      expect(prisma.cronJob.findFirst).toHaveBeenCalledWith({
+        where: {
+          name: 'LISTING_CRON_JOB',
+        },
+      });
+      expect(prisma.cronJob.update).toHaveBeenCalledWith({
+        data: {
+          lastRunDate: expect.anything(),
+        },
+        where: {
+          id: expect.anything(),
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
This PR addresses #4140 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When a reserved community type already exists on a listing and should be removed it was not properly being removed because it needs to be "disconnected" rather than just set to undefined

## How Can This Be Tested/Reviewed?

Add a community type to a listing and save the listing. Then re-edit the listing and remove the reserved community type. The community type should no longer be on the listing

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
