### PR TITLE
feat: adding randomization tooling to export service

### DIFF
--- a/api/prisma/migrations/13_application_lottery_positioning/migration.sql
+++ b/api/prisma/migrations/13_application_lottery_positioning/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "application_lottery_positions" (
+    "ordinal" INTEGER NOT NULL,
+    "listing_id" UUID NOT NULL,
+    "multiselect_question_id" UUID,
+    "application_id" UUID NOT NULL,
+
+    CONSTRAINT "application_lottery_positions_pkey" PRIMARY KEY ("listing_id","application_id")
+);
+
+-- AddForeignKey
+ALTER TABLE "application_lottery_positions" ADD CONSTRAINT "application_lottery_positions_listing_id_fkey" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "application_lottery_positions" ADD CONSTRAINT "application_lottery_positions_multiselect_question_id_fkey" FOREIGN KEY ("multiselect_question_id") REFERENCES "multiselect_questions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "application_lottery_positions" ADD CONSTRAINT "application_lottery_positions_application_id_fkey" FOREIGN KEY ("application_id") REFERENCES "applications"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -222,7 +222,7 @@ model Applications {
   demographics                 Demographics?                 @relation(fields: [demographicsId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   preferredUnitTypes           UnitTypes[]
   householdMember              HouseholdMember[]
-  ApplicationLotteryPositions  ApplicationLotteryPositions[]
+  applicationLotteryPositions  ApplicationLotteryPositions[]
 
   @@unique([listingId, confirmationCode])
   @@index([listingId])
@@ -585,7 +585,7 @@ model Listings {
   requestedChangesDate                  DateTime?                     @default(dbgenerated("'1970-01-01 00:00:00-07'::timestamp with time zone")) @map("requested_changes_date") @db.Timestamptz(6)
   requestedChangesUserId                String?                       @map("requested_changes_user_id") @db.Uuid
   requestedChangesUser                  UserAccounts?                 @relation("requested_changes_user", fields: [requestedChangesUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  ApplicationLotteryPositions           ApplicationLotteryPositions[]
+  applicationLotteryPositions           ApplicationLotteryPositions[]
 
   @@index([jurisdictionId])
   @@map("listings")
@@ -625,7 +625,7 @@ model MultiselectQuestions {
   applicationSection          MultiselectQuestionsApplicationSectionEnum @map("application_section")
   jurisdictions               Jurisdictions[]
   listings                    ListingMultiselectQuestions[]
-  ApplicationLotteryPositions ApplicationLotteryPositions[]
+  applicationLotteryPositions ApplicationLotteryPositions[]
 
   @@map("multiselect_questions")
 }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -222,6 +222,7 @@ model Applications {
   demographics                 Demographics?                 @relation(fields: [demographicsId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   preferredUnitTypes           UnitTypes[]
   householdMember              HouseholdMember[]
+  ApplicationLotteryPositions  ApplicationLotteryPositions[]
 
   @@unique([listingId, confirmationCode])
   @@index([listingId])
@@ -424,6 +425,19 @@ model ListingMultiselectQuestions {
   @@map("listing_multiselect_questions")
 }
 
+model ApplicationLotteryPositions {
+  ordinal               Int
+  listingId             String                @map("listing_id") @db.Uuid
+  listings              Listings              @relation(fields: [listingId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  multiselectQuestionId String?               @map("multiselect_question_id") @db.Uuid
+  multiselectQuestions  MultiselectQuestions? @relation(fields: [multiselectQuestionId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  applicationId         String                @map("application_id") @db.Uuid
+  applications          Applications          @relation(fields: [applicationId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@id([listingId, applicationId])
+  @@map("application_lottery_positions")
+}
+
 model ListingUtilities {
   id          String    @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamp(6)
@@ -571,6 +585,7 @@ model Listings {
   requestedChangesDate                  DateTime?                     @default(dbgenerated("'1970-01-01 00:00:00-07'::timestamp with time zone")) @map("requested_changes_date") @db.Timestamptz(6)
   requestedChangesUserId                String?                       @map("requested_changes_user_id") @db.Uuid
   requestedChangesUser                  UserAccounts?                 @relation("requested_changes_user", fields: [requestedChangesUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  ApplicationLotteryPositions           ApplicationLotteryPositions[]
 
   @@index([jurisdictionId])
   @@map("listings")
@@ -597,19 +612,20 @@ model Migrations {
 // Note: missing [untranslatedText, untranslatedOptOutText] virtual fields
 // Note: [options] formerly had array max length 64
 model MultiselectQuestions {
-  id                 String                                     @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
-  createdAt          DateTime                                   @default(now()) @map("created_at") @db.Timestamp(6)
-  updatedAt          DateTime                                   @updatedAt @map("updated_at") @db.Timestamp(6)
-  text               String
-  subText            String?                                    @map("sub_text")
-  description        String?
-  links              Json?
-  options            Json?
-  optOutText         String?                                    @map("opt_out_text")
-  hideFromListing    Boolean?                                   @map("hide_from_listing")
-  applicationSection MultiselectQuestionsApplicationSectionEnum @map("application_section")
-  jurisdictions      Jurisdictions[]
-  listings           ListingMultiselectQuestions[]
+  id                          String                                     @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt                   DateTime                                   @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt                   DateTime                                   @updatedAt @map("updated_at") @db.Timestamp(6)
+  text                        String
+  subText                     String?                                    @map("sub_text")
+  description                 String?
+  links                       Json?
+  options                     Json?
+  optOutText                  String?                                    @map("opt_out_text")
+  hideFromListing             Boolean?                                   @map("hide_from_listing")
+  applicationSection          MultiselectQuestionsApplicationSectionEnum @map("application_section")
+  jurisdictions               Jurisdictions[]
+  listings                    ListingMultiselectQuestions[]
+  ApplicationLotteryPositions ApplicationLotteryPositions[]
 
   @@map("multiselect_questions")
 }

--- a/api/src/dtos/applications/application-lottery-position.dto.ts
+++ b/api/src/dtos/applications/application-lottery-position.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsDefined, IsNumber, IsString, IsUUID } from 'class-validator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class ApplicationLotteryPosition {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  listingId: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  applicationId: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  multiselectQuestionId: string;
+
+  @Expose()
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  ordinal: number;
+}

--- a/api/src/dtos/applications/application-update.dto.ts
+++ b/api/src/dtos/applications/application-update.dto.ts
@@ -26,7 +26,7 @@ export class ApplicationUpdate extends OmitType(Application, [
   'flagged',
   'confirmationCode',
   'preferredUnitTypes',
-  'ApplicationLotteryPositions',
+  'applicationLotteryPositions',
 ]) {
   @Expose()
   @ValidateNested({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/dtos/applications/application-update.dto.ts
+++ b/api/src/dtos/applications/application-update.dto.ts
@@ -26,6 +26,7 @@ export class ApplicationUpdate extends OmitType(Application, [
   'flagged',
   'confirmationCode',
   'preferredUnitTypes',
+  'ApplicationLotteryPositions',
 ]) {
   @Expose()
   @ValidateNested({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/dtos/applications/application.dto.ts
+++ b/api/src/dtos/applications/application.dto.ts
@@ -9,6 +9,7 @@ import {
 import { Expose, Type } from 'class-transformer';
 import {
   ArrayMaxSize,
+  IsArray,
   IsBoolean,
   IsDate,
   IsDefined,
@@ -29,6 +30,7 @@ import { ApplicationMultiselectQuestion } from './application-multiselect-questi
 import { Demographic } from './demographic.dto';
 import { HouseholdMember } from './household-member.dto';
 import { UnitType } from '../unit-types/unit-type.dto';
+import { ApplicationLotteryPosition } from './application-lottery-position.dto';
 
 export class Application extends AbstractDTO {
   @Expose()
@@ -265,4 +267,12 @@ export class Application extends AbstractDTO {
   @Type(() => IdDTO)
   @ApiProperty({ type: IdDTO })
   listings: IdDTO;
+
+  @Expose()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
+  @Type(() => ApplicationLotteryPosition)
+  @ApiProperty({ type: ApplicationLotteryPosition, isArray: true })
+  ApplicationLotteryPositions: ApplicationLotteryPosition[];
 }

--- a/api/src/dtos/applications/application.dto.ts
+++ b/api/src/dtos/applications/application.dto.ts
@@ -274,5 +274,5 @@ export class Application extends AbstractDTO {
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => ApplicationLotteryPosition)
   @ApiProperty({ type: ApplicationLotteryPosition, isArray: true })
-  ApplicationLotteryPositions: ApplicationLotteryPosition[];
+  applicationLotteryPositions: ApplicationLotteryPosition[];
 }

--- a/api/src/services/application-csv-export.service.ts
+++ b/api/src/services/application-csv-export.service.ts
@@ -798,16 +798,16 @@ export class ApplicationCsvExporterService
     const ordinalArray = this.lotteryRandomizerHelper(filteredApplications);
 
     // attach ordinal info to filteredApplications
-    for (let i = 0; i < ordinalArray.length; i++) {
+    ordinalArray.forEach((value, i) => {
       filteredApplications[i].applicationLotteryPositions = [
         {
           listingId,
           applicationId: filteredApplications[i].id,
-          ordinal: ordinalArray[i],
+          ordinal: value,
           multiselectQuestionId: null,
         },
       ];
-    }
+    });
 
     // store raw positional score in db
     await this.prisma.applicationLotteryPositions.createMany({
@@ -863,21 +863,23 @@ export class ApplicationCsvExporterService
 
   lotteryRandomizerHelper(filterApplicationsArray: Application[]): number[] {
     // prep our supporting array
-    const numberOfUniqueApplications = filterApplicationsArray.length;
     const ordinalArray: number[] = [];
+
+    const indexArray: number[] = [];
+    filterApplicationsArray.forEach((_, index) => {
+      indexArray.push(index + 1);
+    });
 
     // fill array with random values
     filterApplicationsArray.forEach(() => {
-      // initial random value
-      let possibleRandomPosition =
-        Math.floor(Math.random() * numberOfUniqueApplications) + 1;
-      // ensure random value not already in array
-      while (ordinalArray.some((val) => val === possibleRandomPosition)) {
-        possibleRandomPosition =
-          Math.floor(Math.random() * numberOfUniqueApplications) + 1;
-      }
+      // get random value
+      const randomPosition = Math.floor(Math.random() * indexArray.length);
+
+      // remove selected value from indexArray
+      const randomValue = indexArray.splice(randomPosition, 1);
+
       // push unique random value into array
-      ordinalArray.push(possibleRandomPosition);
+      ordinalArray.push(randomValue[0]);
     });
 
     return ordinalArray;

--- a/api/test/unit/services/application-csv-export.service.spec.ts
+++ b/api/test/unit/services/application-csv-export.service.spec.ts
@@ -714,137 +714,141 @@ describe('Testing application CSV export service', () => {
     }
   });
 
-  it('should store randomized ordinals when no preferences on listing', async () => {
-    const listingId = randomUUID();
-    const applications: Application[] = [];
-    for (let i = 0; i < 10; i++) {
-      applications.push({
-        id: randomUUID(),
-        markedAsDuplicate: false,
-      } as unknown as Application);
-    }
+  describe('Testing lotteryRandomizerHelper()', () => {
+    it('should store randomized ordinals when no preferences on listing', async () => {
+      const listingId = randomUUID();
+      const applications: Application[] = [];
+      for (let i = 0; i < 10; i++) {
+        applications.push({
+          id: randomUUID(),
+          markedAsDuplicate: false,
+        } as unknown as Application);
+      }
 
-    prisma.applicationLotteryPositions.createMany = jest
-      .fn()
-      .mockResolvedValue({ id: randomUUID() });
+      prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
 
-    await service.lotteryRandomizer(listingId, applications, []);
+      await service.lotteryRandomizer(listingId, applications, []);
 
-    expect(prisma.applicationLotteryPositions.createMany).toHaveBeenCalled();
+      expect(prisma.applicationLotteryPositions.createMany).toHaveBeenCalled();
 
-    const args = (prisma.applicationLotteryPositions.createMany as any).mock
-      .calls[0][0].data;
+      const args = (prisma.applicationLotteryPositions.createMany as any).mock
+        .calls[0][0].data;
 
-    for (let i = 1; i < 11; i++) {
-      expect(args.find((val) => val.ordinal === i)).toEqual({
-        listingId,
-        applicationId: expect.anything(),
-        ordinal: i,
-        multiselectQuestionId: null,
-      });
-    }
+      for (let i = 1; i < 11; i++) {
+        expect(args.find((val) => val.ordinal === i)).toEqual({
+          listingId,
+          applicationId: expect.anything(),
+          ordinal: i,
+          multiselectQuestionId: null,
+        });
+      }
+    });
   });
 
-  it('should store randomized ordinals when every application has a preference', async () => {
-    const listingId = randomUUID();
-    const applications: Application[] = [];
-    const preferences: MultiselectQuestion[] = [
-      {
-        id: randomUUID(),
-        text: 'example text',
-      } as unknown as MultiselectQuestion,
-    ];
-    for (let i = 0; i < 10; i++) {
-      applications.push({
-        id: randomUUID(),
-        markedAsDuplicate: false,
-        preferences: [
-          {
-            key: 'example text',
-            claimed: false,
-          },
-        ],
-      } as unknown as Application);
-    }
+  describe('Testing lotteryRandomizer()', () => {
+    it('should store randomized ordinals when every application has a preference', async () => {
+      const listingId = randomUUID();
+      const applications: Application[] = [];
+      const preferences: MultiselectQuestion[] = [
+        {
+          id: randomUUID(),
+          text: 'example text',
+        } as unknown as MultiselectQuestion,
+      ];
+      for (let i = 0; i < 10; i++) {
+        applications.push({
+          id: randomUUID(),
+          markedAsDuplicate: false,
+          preferences: [
+            {
+              key: 'example text',
+              claimed: false,
+            },
+          ],
+        } as unknown as Application);
+      }
 
-    prisma.applicationLotteryPositions.createMany = jest
-      .fn()
-      .mockResolvedValue({ id: randomUUID() });
+      prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
 
-    await service.lotteryRandomizer(listingId, applications, preferences);
+      await service.lotteryRandomizer(listingId, applications, preferences);
 
-    const args = (prisma.applicationLotteryPositions.createMany as any).mock
-      .calls[0][0].data;
+      const args = (prisma.applicationLotteryPositions.createMany as any).mock
+        .calls[0][0].data;
 
-    for (let i = 1; i < 11; i++) {
-      expect(args.find((val) => val.ordinal === i)).toEqual({
-        listingId,
-        applicationId: expect.anything(),
-        ordinal: i,
-        multiselectQuestionId: null,
-      });
-    }
+      for (let i = 1; i < 11; i++) {
+        expect(args.find((val) => val.ordinal === i)).toEqual({
+          listingId,
+          applicationId: expect.anything(),
+          ordinal: i,
+          multiselectQuestionId: null,
+        });
+      }
 
-    expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(1);
-  });
+      expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(1);
+    });
 
-  it('should store randomized ordinals and preference specific ordinals', async () => {
-    const listingId = randomUUID();
-    const applications: Application[] = [];
-    const preferences: MultiselectQuestion[] = [
-      {
-        id: randomUUID(),
-        text: 'example text',
-      } as unknown as MultiselectQuestion,
-    ];
-    for (let i = 0; i < 10; i++) {
-      applications.push({
-        id: randomUUID(),
-        markedAsDuplicate: false,
-        preferences: [
-          {
-            key: 'example text',
-            claimed: i % 2 === 0,
-          },
-        ],
-      } as unknown as Application);
-    }
+    it('should store randomized ordinals and preference specific ordinals', async () => {
+      const listingId = randomUUID();
+      const applications: Application[] = [];
+      const preferences: MultiselectQuestion[] = [
+        {
+          id: randomUUID(),
+          text: 'example text',
+        } as unknown as MultiselectQuestion,
+      ];
+      for (let i = 0; i < 10; i++) {
+        applications.push({
+          id: randomUUID(),
+          markedAsDuplicate: false,
+          preferences: [
+            {
+              key: 'example text',
+              claimed: i % 2 === 0,
+            },
+          ],
+        } as unknown as Application);
+      }
 
-    prisma.applicationLotteryPositions.createMany = jest
-      .fn()
-      .mockResolvedValue({ id: randomUUID() });
+      prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
 
-    await service.lotteryRandomizer(listingId, applications, preferences);
+      await service.lotteryRandomizer(listingId, applications, preferences);
 
-    const args = (prisma.applicationLotteryPositions.createMany as any).mock
-      .calls[0][0].data;
+      const args = (prisma.applicationLotteryPositions.createMany as any).mock
+        .calls[0][0].data;
 
-    for (let i = 1; i < 11; i++) {
-      expect(args.find((val) => val.ordinal === i)).toEqual({
-        listingId,
-        applicationId: expect.anything(),
-        ordinal: i,
-        multiselectQuestionId: null,
-      });
-    }
+      for (let i = 1; i < 11; i++) {
+        expect(args.find((val) => val.ordinal === i)).toEqual({
+          listingId,
+          applicationId: expect.anything(),
+          ordinal: i,
+          multiselectQuestionId: null,
+        });
+      }
 
-    const argsWithPreference = (
-      prisma.applicationLotteryPositions.createMany as any
-    ).mock.calls[1][0].data;
+      const argsWithPreference = (
+        prisma.applicationLotteryPositions.createMany as any
+      ).mock.calls[1][0].data;
 
-    for (let i = 1; i < 5; i++) {
-      expect(argsWithPreference.find((val) => val.ordinal === i)).toEqual({
-        listingId,
-        applicationId: expect.anything(),
-        ordinal: i,
-        multiselectQuestionId: expect.anything(),
-      });
-    }
+      for (let i = 1; i < 5; i++) {
+        expect(argsWithPreference.find((val) => val.ordinal === i)).toEqual({
+          listingId,
+          applicationId: expect.anything(),
+          ordinal: i,
+          multiselectQuestionId: expect.anything(),
+        });
+      }
 
-    expect(argsWithPreference.find((val) => val.ordinal === 6)).toEqual(
-      undefined,
-    );
+      expect(argsWithPreference.find((val) => val.ordinal === 6)).toEqual(
+        undefined,
+      );
 
-    expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(2);
+      expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(2);
+    });
   });
 });

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -3982,6 +3982,20 @@ export interface ApplicationMultiselectQuestion {
   options: ApplicationMultiselectQuestionOption[]
 }
 
+export interface ApplicationLotteryPosition {
+  /**  */
+  listingId: string
+
+  /**  */
+  applicationId: string
+
+  /**  */
+  multiselectQuestionId: string
+
+  /**  */
+  ordinal: number
+}
+
 export interface Application {
   /**  */
   id: string
@@ -4093,6 +4107,9 @@ export interface Application {
 
   /**  */
   listings: IdDTO
+
+  /**  */
+  ApplicationLotteryPositions: ApplicationLotteryPosition[]
 }
 
 export interface ApplicationFlaggedSet {

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -4109,7 +4109,7 @@ export interface Application {
   listings: IdDTO
 
   /**  */
-  ApplicationLotteryPositions: ApplicationLotteryPosition[]
+  applicationLotteryPositions: ApplicationLotteryPosition[]
 }
 
 export interface ApplicationFlaggedSet {


### PR DESCRIPTION
This PR addresses https://github.com/bloom-housing/bloom/issues/4055

- [x] Addresses only certain aspects of the issue

## Description
This adds the randomizer for lottery to the csv export 
it doesn't expose a way to do this, but there are unit tests to demo how it'll work

## How Can This Be Tested/Reviewed?
the endpoints and stuff are coming in a part 2, this is just the randomization logic and unit tests 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
