### PR TITLE
fix: lottery rebase issues

### DIFF
--- a/sites/partners/src/components/shared/NavigationHeader.tsx
+++ b/sites/partners/src/components/shared/NavigationHeader.tsx
@@ -66,7 +66,7 @@ const NavigationHeader = ({
       },
     ]
 
-    if (process.env.showLottery && tabs?.lotteryLabel) {
+    if (process.env.showLottery === "TRUE" && tabs?.lotteryLabel) {
       elements.push({
         label: tabs.lotteryLabel,
         path: `/listings/${listingId}/lottery`,

--- a/sites/partners/src/pages/listings/[id]/applications/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/index.tsx
@@ -124,8 +124,8 @@ const ApplicationsList = () => {
           listingLabel: t("t.listingSingle"),
           applicationsLabel: t("nav.applications"),
           lotteryLabel:
-            listingDto.status === ListingsStatusEnum.closed &&
-            listingDto.reviewOrderType === ReviewOrderTypeEnum.lottery
+            listingDto?.status === ListingsStatusEnum.closed &&
+            listingDto?.reviewOrderType === ReviewOrderTypeEnum.lottery
               ? t("listings.lotteryTitle")
               : undefined,
         }}

--- a/sites/partners/src/pages/listings/[id]/applications/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/index.tsx
@@ -8,6 +8,7 @@ import {
   ApplicationOrderByKeys,
   ListingsStatusEnum,
   OrderByEnum,
+  ReviewOrderTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import {
   useSingleListingData,
@@ -122,6 +123,11 @@ const ApplicationsList = () => {
           flagsQty: flaggedApps?.meta?.totalFlagged,
           listingLabel: t("t.listingSingle"),
           applicationsLabel: t("nav.applications"),
+          lotteryLabel:
+            listingDto.status === ListingsStatusEnum.closed &&
+            listingDto.reviewOrderType === ReviewOrderTypeEnum.lottery
+              ? t("listings.lotteryTitle")
+              : undefined,
         }}
         breadcrumbs={
           <Breadcrumbs>

--- a/sites/partners/src/pages/listings/[id]/applications/pending/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/pending/index.tsx
@@ -136,8 +136,8 @@ const ApplicationsList = () => {
           listingLabel: t("t.listingSingle"),
           applicationsLabel: t("nav.applications"),
           lotteryLabel:
-            listingDto.status === ListingsStatusEnum.closed &&
-            listingDto.reviewOrderType === ReviewOrderTypeEnum.lottery
+            listingDto?.status === ListingsStatusEnum.closed &&
+            listingDto?.reviewOrderType === ReviewOrderTypeEnum.lottery
               ? t("listings.lotteryTitle")
               : undefined,
         }}

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -125,13 +125,19 @@ const Lottery = (props: { listing: Listing }) => {
   )
 }
 
-export async function getServerSideProps(context: { params: Record<string, string> }) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getServerSideProps(context: { params: Record<string, string>; req: any }) {
   let response
 
   try {
-    response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`)
+    response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`, {
+      headers: {
+        passkey: process.env.API_PASS_KEY,
+        "x-forwarded-for":
+          context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
+      },
+    })
   } catch (e) {
-    console.log("e = ", e)
     return { notFound: true }
   }
 

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -138,6 +138,7 @@ export async function getServerSideProps(context: { params: Record<string, strin
       },
     })
   } catch (e) {
+    console.log("e = ", e)
     return { notFound: true }
   }
 

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -51,7 +51,7 @@
     "qs": "^6.10.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-google-recaptcha-v3": "^1.9.8",
+    "react-google-recaptcha-v3": "^1.10.1",
     "react-hook-form": "^6.15.5",
     "swr": "^2.1.5",
     "tailwindcss": "2.2.10",

--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -62,6 +62,7 @@ export async function getServerSideProps(context: {
       },
     })
   } catch (e) {
+    console.log("e = ", e)
     return { notFound: true }
   }
 

--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -62,7 +62,6 @@ export async function getServerSideProps(context: {
       },
     })
   } catch (e) {
-    console.log("e = ", e)
     return { notFound: true }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16813,7 +16813,7 @@ react-focus-lock@^2.9.4:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
-react-google-recaptcha-v3@^1.9.8:
+react-google-recaptcha-v3@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/react-google-recaptcha-v3/-/react-google-recaptcha-v3-1.10.1.tgz#5b125bc0dec123206431860e8800e188fc735aff"
   integrity sha512-K3AYzSE0SasTn+XvV2tq+6YaxM+zQypk9rbCgG4OVUt7Rh4ze9basIKefoBz9sC0CNslJj9N1uwTTgRMJQbQJQ==


### PR DESCRIPTION
I ran into two issues with the Doorway release of the lottery empty state ([this core PR](https://github.com/bloom-housing/bloom/commit/4dbb6e3d10beeefa90798c904c5c797c497c8ee4))

* We weren't adding the API pass key on the lottery page
* The new lottery tab was missing from the applications page

These were added into the [Doorway release branch](https://github.com/metrotranscom/doorway/pull/706) already