### PR TITLE
fix: ami import formatting instructions

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -142,6 +142,11 @@ export class ScriptRunnerService {
    *
    * @param amiChartImportDTO this is a string in a very specific format like:
    * percentOfAmiValue_1 householdSize_1_income_value householdSize_2_income_value \n percentOfAmiValue_2 householdSize_1_income_value householdSize_2_income_value
+   *
+   * Copying and pasting from google sheets will not match the format above. You will need to perform the following:
+   * 1) Find and delete all instances of "%"
+   * 2) Using the Regex option in the Find and Replace tool, replace /\t with " " and /\n with "\\n"
+   * See "How to format AMI data for script runner import" in Notion for a more detailed example
    * @returns successDTO
    * @description takes the incoming AMI Chart string and stores it as a new AMI Chart in the database
    */


### PR DESCRIPTION
This PR addresses #4094 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

This PR updates the ami import script runner service to include more detailed instructions on how to pre-process ami data from Google Sheets. 

## How Can This Be Tested/Reviewed?

Read the comments and look through the notion page based on the commenting instructions

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
