### PR TITLE
fix: filter ami charts by jurisdition

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -117,6 +117,10 @@ export const stagingSeed = async (
   const amiChart = await prismaClient.amiChart.create({
     data: amiChartFactory(10, jurisdiction.id),
   });
+  await prismaClient.amiChart.create({
+    data: amiChartFactory(8, additionalJurisdiction.id),
+  });
+  // Create map layers
   await prismaClient.mapLayers.create({
     data: mapLayerFactory(jurisdiction.id, 'Redlined Districts', redlinedMap),
   });

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -36,7 +36,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
   const formMethods = useFormContext()
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { watch } = formMethods
-  const jurisdiction: string = watch("jurisdiction.id")
+  const jurisdiction: string = watch("jurisdictions.id")
   /**
    * fetch form options
    */


### PR DESCRIPTION
This PR addresses #4174 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When making the backend call to get AMI charts on the partner site the jurisdiction id was not getting set. This was due to a change in Prisma where the jurisdiction field was changed to "jurisdictions" so the `watch` function was not looking for the correct field

## How Can This Be Tested/Reviewed?

*Note*: a new ami chart was added to the stage seeded data tied to the second jurisdiction so I'd recommend a reseed before testing
- Log into the partner site as an admin
- Add a new listing.
- Go to add a new unit within the listing and make sure that all AMI charts are accessible in the dropdown
- Set a jurisdiction to the listing and then try to add a unit. Only the AMI charts for that jurisdiction are accessible


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
