### PR TITLE
fix: swap lingering UIC Modal for Seeds Dialog

### DIFF
--- a/sites/partners/src/components/users/FormUserConfirm.tsx
+++ b/sites/partners/src/components/users/FormUserConfirm.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useContext, useEffect, useState } from "react"
 import { useRouter } from "next/router"
 import { t, FormCard, Form, Field, useMutate, AlertBox, Modal } from "@bloom-housing/ui-components"
-import { Button, Icon } from "@bloom-housing/ui-seeds"
+import { Button, Dialog, Icon } from "@bloom-housing/ui-seeds"
 import { AuthContext, MessageContext, passwordRegex } from "@bloom-housing/shared-helpers"
 import { useForm } from "react-hook-form"
 import { ReRequestConfirmation } from "./ReRequestConfirmation"
@@ -181,18 +181,18 @@ const FormUserConfirm = () => {
         </Form>
       </FormCard>
 
-      <Modal
-        open={rerequestModalOpen}
-        title={t("authentication.createAccount.errors.tokenExpired")}
-        ariaDescription={t("users.requestResendDescription")}
+      <Dialog
+        isOpen={rerequestModalOpen}
         onClose={() => setRerequestModalOpen(false)}
+        ariaLabelledBy="request-resend-dialog-header"
+        ariaDescribedBy="request-resend-dialog-explanation"
       >
         <ReRequestConfirmation
           onClose={setRerequestModalOpen}
           clearExistingErrors={resetMutation}
           setAlert={setNewConfirmationRequested}
         />
-      </Modal>
+      </Dialog>
     </>
   )
 }

--- a/sites/partners/src/components/users/ReRequestConfirmation.tsx
+++ b/sites/partners/src/components/users/ReRequestConfirmation.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react"
-import { Button } from "@bloom-housing/ui-seeds"
+import { Button, Dialog } from "@bloom-housing/ui-seeds"
 import { Field, Form, FormCard, t } from "@bloom-housing/ui-components"
 import { AuthContext } from "@bloom-housing/shared-helpers"
 import { useForm } from "react-hook-form"
@@ -43,48 +43,44 @@ const ReRequestConfirmation = ({
   }
 
   return (
-    <FormCard>
-      <div className="form-card__lead text-center border-b mx-0 px-5">
-        <p className="mt-4 field-note">{t("users.requestResendExplanation")}</p>
-      </div>
-
+    <>
+      <Dialog.Header id="request-resend-dialog-header">
+        {t("authentication.createAccount.errors.tokenExpired")}
+      </Dialog.Header>
       <Form id="re-request-confirmation" onSubmit={handleSubmit(onSubmit)}>
-        <div className="form-card__group is-borderless">
-          <fieldset>
-            <div className="mt-5">
-              <Field
-                name="email"
-                id="email"
-                label={t("t.email")}
-                validation={{
-                  required: true,
-                }}
-                error={!!errors?.email}
-                errorMessage={t("authentication.signIn.loginError")}
-                register={register}
-                className={"mb-1"}
-              />
-            </div>
-          </fieldset>
-        </div>
+        <Dialog.Content>
+          <p id="request-resend-dialog-explanation">{t("users.requestResendExplanation")}</p>
 
-        <div className="form-card__pager mt-8">
-          <div className="form-card__pager-row primary">
-            <Button type="submit" variant="primary" className={"items-center"}>
-              {t("users.requestResend")}
-            </Button>
-            <Button
-              variant="primary-outlined"
-              onClick={() => {
-                clearErrors(), onClose(false)
+          <fieldset>
+            <Field
+              name="email"
+              id="email"
+              label={t("t.email")}
+              validation={{
+                required: true,
               }}
-            >
-              {t("t.cancel")}
-            </Button>
-          </div>
-        </div>
+              error={!!errors?.email}
+              errorMessage={t("authentication.signIn.loginError")}
+              register={register}
+              className={"mb-1"}
+            />
+          </fieldset>
+        </Dialog.Content>
+        <Dialog.Footer>
+          <Button type="submit" variant="primary" className={"items-center"}>
+            {t("users.requestResend")}
+          </Button>
+          <Button
+            variant="primary-outlined"
+            onClick={() => {
+              clearErrors(), onClose(false)
+            }}
+          >
+            {t("t.cancel")}
+          </Button>
+        </Dialog.Footer>
       </Form>
-    </FormCard>
+    </>
   )
 }
 


### PR DESCRIPTION
This PR addresses #4203

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

There was a remaining UIC Modal usage in the Partners app related to resending a user confirmation token in Partners. This PR swaps it out for a Seeds Dialog.

## How Can This Be Tested/Reviewed?

~~I'm not entirely sure~~ @mcgarrye says: You can test this by adding a new user and resending their invite. The first email link will be expired and if you click it the dialog will appear. If you click the newer invite it will not be present

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
