### PR TITLE
feat: lottery opt in

### DIFF
--- a/api/prisma/migrations/15_lottery_opt_in/migration.sql
+++ b/api/prisma/migrations/15_lottery_opt_in/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "listings" ADD COLUMN     "lottery_opt_in" BOOLEAN;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -467,6 +467,7 @@ model Listings {
   commonDigitalApplication              Boolean?                      @map("common_digital_application")
   paperApplication                      Boolean?                      @map("paper_application")
   referralOpportunity                   Boolean?                      @map("referral_opportunity")
+  lotteryOptIn                          Boolean?                      @map("lottery_opt_in")
   assets                                Json
   accessibility                         String?
   amenities                             String?

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -587,6 +587,11 @@ class Listing extends AbstractDTO {
     },
   )
   requestedChangesUser?: IdDTO;
+
+  @Expose()
+  @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
+  @ApiPropertyOptional()
+  lotteryOptIn?: boolean;
 }
 
 export { Listing as default, Listing };

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -354,7 +354,7 @@ export class ListingsService {
       body?: ListingLotteryStatus
     } = {} as any,
     options: IRequestOptions = {}
-  ): Promise<Listing> {
+  ): Promise<SuccessDTO> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/listings/lotteryStatus"
 
@@ -3081,6 +3081,9 @@ export interface Listing {
 
   /**  */
   requestedChangesUser?: IdDTO
+
+  /**  */
+  lotteryOptIn?: boolean
 }
 
 export interface PaginationMeta {
@@ -3527,6 +3530,9 @@ export interface ListingCreate {
   requestedChangesDate?: Date
 
   /**  */
+  lotteryOptIn?: boolean
+
+  /**  */
   listingMultiselectQuestions?: IdDTO[]
 
   /**  */
@@ -3790,6 +3796,9 @@ export interface ListingUpdate {
 
   /**  */
   requestedChangesDate?: Date
+
+  /**  */
+  lotteryOptIn?: boolean
 
   /**  */
   listingMultiselectQuestions?: IdDTO[]

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -251,6 +251,8 @@
   "listings.lotteryDateNotes": "Lottery Date Notes",
   "listings.lotteryDateQuestion": "When will the lottery be run?",
   "listings.lotteryEndTime": "Lottery End Time",
+  "listings.lotteryOptInQuestion": "Will the lottery be run in the partner portal?",
+  "listings.lotteryPreferenceSubtitle": "Sort preferences to establish the order in which questions will appear in the application. This is how ranked buckets will appear in the lottery export file.",
   "listings.lotteryStartTime": "Lottery Start Time",
   "listings.lotteryTitle": "Lottery",
   "listings.mapPinAutomaticDescription": "Map pin position is based on the address provided",

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -32,6 +32,13 @@ const DetailRankingsAndResults = () => {
           </FieldValue>
         </Grid.Row>
       )}
+      {listing.reviewOrderType === ReviewOrderTypeEnum.lottery && process.env.showLottery && (
+        <Grid.Row>
+          <FieldValue id="lotteryOptInQuestion" label={t("listings.lotteryOptInQuestion")}>
+            {listing?.lotteryOptIn ? t("t.yes") : t("t.no")}
+          </FieldValue>
+        </Grid.Row>
+      )}
       {lotteryEvent && (
         <>
           <Grid.Row>

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -13,7 +13,6 @@ import {
   ListingsStatusEnum,
   MultiselectQuestion,
   MultiselectQuestionsApplicationSectionEnum,
-  YesNoEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { useForm, FormProvider } from "react-hook-form"
 import {

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -312,7 +312,7 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                             addText={t("listings.addPreference")}
                             drawerTitle={t("listings.addPreferences")}
                             drawerSubtitle={
-                              process.env.showLottery && listing.lotteryOptIn
+                              process.env.showLottery && listing?.lotteryOptIn
                                 ? t("listings.lotteryPreferenceSubtitle")
                                 : null
                             }

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -13,6 +13,7 @@ import {
   ListingsStatusEnum,
   MultiselectQuestion,
   MultiselectQuestionsApplicationSectionEnum,
+  YesNoEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { useForm, FormProvider } from "react-hook-form"
 import {
@@ -310,6 +311,11 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                           <SelectAndOrder
                             addText={t("listings.addPreference")}
                             drawerTitle={t("listings.addPreferences")}
+                            drawerSubtitle={
+                              process.env.showLottery && listing.lotteryOptIn
+                                ? t("listings.lotteryPreferenceSubtitle")
+                                : null
+                            }
                             editText={t("listings.editPreferences")}
                             listingData={preferences || []}
                             setListingData={setPreferences}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -131,7 +131,8 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
                       {
                         ...yesNoRadioOptions[0],
                         id: "lotteryOptInYes",
-                        defaultChecked: !listing || listing.lotteryOptIn === true,
+                        defaultChecked:
+                          !listing || listing.lotteryOptIn === true || !listing.lotteryOptIn,
                       },
 
                       {

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -119,6 +119,31 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
         )}
         {reviewOrder === "reviewOrderLottery" && (
           <>
+            {process.env.showLottery && (
+              <Grid.Row columns={2} className={"flex items-center"}>
+                <Grid.Cell>
+                  <p className={`field-label m-4 ml-0`}>{t("listings.lotteryOptInQuestion")}</p>
+                  <FieldGroup
+                    name="lotteryOptInQuestion"
+                    type="radio"
+                    register={register}
+                    fields={[
+                      {
+                        ...yesNoRadioOptions[0],
+                        id: "lotteryOptInYes",
+                        defaultChecked: !listing || listing.lotteryOptIn === true,
+                      },
+
+                      {
+                        ...yesNoRadioOptions[1],
+                        id: "lotteryOptInNo",
+                        defaultChecked: listing && listing.lotteryOptIn === false,
+                      },
+                    ]}
+                  />
+                </Grid.Cell>
+              </Grid.Row>
+            )}
             <Grid.Row columns={3}>
               <Grid.Cell>
                 <DateField

--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -20,6 +20,7 @@ type SelectAndOrderProps = {
   editText: string
   addText: string
   drawerTitle: string
+  drawerSubtitle?: string
   drawerButtonText: string
   dataFetcher: (
     jurisdiction?: string,
@@ -43,6 +44,7 @@ const SelectAndOrder = ({
   editText,
   addText,
   drawerTitle,
+  drawerSubtitle,
   drawerButtonText,
   dataFetcher,
   formKey,
@@ -303,6 +305,11 @@ const SelectAndOrder = ({
         <Drawer.Header id="select-and-order-drawer-header">{drawerTitle}</Drawer.Header>
         <Drawer.Content>
           <Card>
+            {drawerSubtitle && (
+              <Card.Section>
+                <p>{drawerSubtitle}</p>
+              </Card.Section>
+            )}
             <Card.Section>
               {!!draftListingData.length && (
                 <div className="mb-5">

--- a/sites/partners/src/lib/listings/AdditionalMetadataFormatter.ts
+++ b/sites/partners/src/lib/listings/AdditionalMetadataFormatter.ts
@@ -61,6 +61,10 @@ export default class AdditionalMetadataFormatter extends Formatter {
         ? ReviewOrderTypeEnum.lottery
         : ReviewOrderTypeEnum.firstComeFirstServe
 
+    if (this.data.reviewOrderType !== ReviewOrderTypeEnum.lottery) {
+      this.data.lotteryOptIn = null
+    }
+
     if (this.data.listingAvailabilityQuestion === "openWaitlist") {
       this.data.reviewOrderType = ReviewOrderTypeEnum.waitlist
     }

--- a/sites/partners/src/lib/listings/BooleansFormatter.ts
+++ b/sites/partners/src/lib/listings/BooleansFormatter.ts
@@ -69,5 +69,9 @@ export default class BooleansFormatter extends Formatter {
       when: this.data.referralOpportunityChoice === YesNoEnum.yes,
       falseCase: () => (this.data.referralOpportunityChoice === YesNoEnum.no ? false : null),
     })
+    this.processBoolean("lotteryOptIn", {
+      when: this.data.lotteryOptInQuestion === YesNoEnum.yes,
+      falseCase: () => (this.data.lotteryOptInQuestion === YesNoEnum.no ? false : null),
+    })
   }
 }

--- a/sites/partners/src/lib/listings/formTypes.ts
+++ b/sites/partners/src/lib/listings/formTypes.ts
@@ -69,6 +69,7 @@ export type FormListing = Omit<Listing, "countyCode"> & {
     year: string
   }
   reviewOrderQuestion?: string
+  lotteryOptInQuestion?: YesNoEnum
   listingAvailabilityQuestion?: string
   waitlistOpenQuestion?: YesNoEnum
   waitlistSizeQuestion?: YesNoEnum

--- a/sites/partners/src/pages/listings/[id]/applications/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/index.tsx
@@ -126,6 +126,7 @@ const ApplicationsList = () => {
           applicationsLabel: t("nav.applications"),
           lotteryLabel:
             listingDto?.status === ListingsStatusEnum.closed &&
+            listingDto?.lotteryOptIn &&
             listingDto?.reviewOrderType === ReviewOrderTypeEnum.lottery
               ? t("listings.lotteryTitle")
               : undefined,

--- a/sites/partners/src/pages/listings/[id]/applications/pending/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/pending/index.tsx
@@ -137,6 +137,7 @@ const ApplicationsList = () => {
           applicationsLabel: t("nav.applications"),
           lotteryLabel:
             listingDto?.status === ListingsStatusEnum.closed &&
+            listingDto?.lotteryOptIn &&
             listingDto?.reviewOrderType === ReviewOrderTypeEnum.lottery
               ? t("listings.lotteryTitle")
               : undefined,

--- a/sites/partners/src/pages/listings/[id]/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/index.tsx
@@ -65,6 +65,7 @@ export default function ListingDetail(props: ListingProps) {
                 applicationsLabel: t("nav.applications"),
                 lotteryLabel:
                   listing.status === ListingsStatusEnum.closed &&
+                  listing.lotteryOptIn &&
                   listing.reviewOrderType === ReviewOrderTypeEnum.lottery
                     ? t("listings.lotteryTitle")
                     : undefined,

--- a/sites/partners/src/pages/listings/[id]/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/index.tsx
@@ -65,8 +65,8 @@ export default function ListingDetail(props: ListingProps) {
                 applicationsLabel: t("nav.applications"),
                 lotteryLabel:
                   listing.status === ListingsStatusEnum.closed &&
-                  listing.lotteryOptIn &&
-                  listing.reviewOrderType === ReviewOrderTypeEnum.lottery
+                  listing?.lotteryOptIn &&
+                  listing?.reviewOrderType === ReviewOrderTypeEnum.lottery
                     ? t("listings.lotteryTitle")
                     : undefined,
               }}

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -216,6 +216,7 @@ const Lottery = (props: { listing: Listing }) => {
                 applicationsLabel: t("nav.applications"),
                 lotteryLabel:
                   listing.status === ListingsStatusEnum.closed &&
+                  listing.lotteryOptIn &&
                   listing.reviewOrderType === ReviewOrderTypeEnum.lottery
                     ? t("listings.lotteryTitle")
                     : undefined,

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -216,8 +216,8 @@ const Lottery = (props: { listing: Listing }) => {
                 applicationsLabel: t("nav.applications"),
                 lotteryLabel:
                   listing.status === ListingsStatusEnum.closed &&
-                  listing.lotteryOptIn &&
-                  listing.reviewOrderType === ReviewOrderTypeEnum.lottery
+                  listing?.lotteryOptIn &&
+                  listing?.reviewOrderType === ReviewOrderTypeEnum.lottery
                     ? t("listings.lotteryTitle")
                     : undefined,
               }}


### PR DESCRIPTION
This PR addresses #4049

- [x] Addresses the issue in full

## Description

Adds the lottery opt-in question on the partners listing form if the feature is toggled on. If a listing is saved with the opt-in toggle on, then there is also new copy in the preference drawer.

## How Can This Be Tested/Reviewed?

With the toggle on, create/edit a listing - in the rankings and results section, if the review order is lottery, a `Will the lottery be run in the partner portal?` question will toggle on. You should be able to save it as both values. When the toggle is saved as on, there will be new copy in the preference drawer. If the toggle is off, you should not be able to see the lottery tab.

I do think this deserves a partners Cypress test, but I think that would be a larger effort bc we would need to set up a new job that turns the toggle on ([ticket](https://github.com/bloom-housing/bloom/issues/4206)).

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes (linked ticket)
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
