### PR TITLE
feat: disable lottery upload if using system lottery

### DIFF
--- a/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
+++ b/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
@@ -1078,4 +1078,48 @@ describe("<ListingFormActions>", () => {
       })
     })
   })
+
+  describe("with lotteries on", () => {
+    beforeAll(() => {
+      process.env.showLottery = "TRUE"
+      adminUser = { ...adminUser, jurisdictions: [mockBaseJurisdiction] }
+    })
+
+    it("renders correct buttons in a closed edit state with lottery opted in", () => {
+      const { queryByText } = render(
+        <AuthContext.Provider value={{ profile: adminUser }}>
+          <ListingContext.Provider
+            value={{
+              ...listing,
+              status: ListingsStatusEnum.closed,
+              lotteryOptIn: true,
+              listingEvents: [],
+            }}
+          >
+            <ListingFormActions type={ListingFormActionsType.edit} />
+          </ListingContext.Provider>
+        </AuthContext.Provider>
+      )
+      expect(queryByText("Post Results")).not.toBeInTheDocument()
+    })
+
+    it("renders correct buttons in a closed edit state with lottery opted out", () => {
+      const { queryByText } = render(
+        <AuthContext.Provider value={{ profile: adminUser }}>
+          <ListingContext.Provider
+            value={{
+              ...listing,
+              status: ListingsStatusEnum.closed,
+              lotteryOptIn: false,
+              listingEvents: [],
+            }}
+          >
+            <ListingFormActions type={ListingFormActionsType.edit} />
+          </ListingContext.Provider>
+        </AuthContext.Provider>
+      )
+
+      expect(queryByText("Post Results")).toBeTruthy()
+    })
+  })
 })

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -418,7 +418,10 @@ const ListingFormActions = ({
         // all users can manage lottery results on closed listings
         if (lotteryResults) {
           elements.push(editPostedResultsButton(lotteryResults))
-        } else if (listing.status === ListingsStatusEnum.closed) {
+        } else if (
+          listing.status === ListingsStatusEnum.closed &&
+          (!listing?.lotteryOptIn || !process.env.showLottery)
+        ) {
           elements.push(postResultsButton)
         }
 
@@ -471,7 +474,10 @@ const ListingFormActions = ({
 
         if (lotteryResults) {
           elements.push(editPostedResultsButton(lotteryResults))
-        } else if (listing.status === ListingsStatusEnum.closed) {
+        } else if (
+          listing.status === ListingsStatusEnum.closed &&
+          (!listing?.lotteryOptIn || !process.env.showLottery)
+        ) {
           elements.push(postResultsButton)
         }
 

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -397,15 +397,16 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                         </Tabs.TabPanel>
                       </Tabs>
 
-                      {listing?.status === ListingsStatusEnum.closed && (
-                        <LotteryResults
-                          submitCallback={(data) => {
-                            triggerSubmitWithStatus(false, ListingsStatusEnum.closed, data)
-                          }}
-                          drawerState={lotteryResultsDrawer}
-                          showDrawer={(toggle: boolean) => setLotteryResultsDrawer(toggle)}
-                        />
-                      )}
+                      {listing?.status === ListingsStatusEnum.closed &&
+                        (!listing?.lotteryOptIn || !process.env.showLottery) && (
+                          <LotteryResults
+                            submitCallback={(data) => {
+                              triggerSubmitWithStatus(false, ListingsStatusEnum.closed, data)
+                            }}
+                            drawerState={lotteryResultsDrawer}
+                            showDrawer={(toggle: boolean) => setLotteryResultsDrawer(toggle)}
+                          />
+                        )}
                     </div>
 
                     <aside className="w-full md:w-3/12 md:pl-6">


### PR DESCRIPTION
This PR addresses [#747](https://github.com/metrotranscom/doorway/issues/747)

- [x] Addresses the issue in full

## Description

When the lottery toggle is on, on a closed listing with a lottery type, if a user is opted into the system lottery they cannot "post results" in the button list, but if a user is opted out they are able to post results.

## How Can This Be Tested/Reviewed?

When the lottery toggle is on, on a closed listing with a lottery type, if a user is opted into the system lottery ensure they cannot see the post results button. Opt out of the lottery and save, and when re-entering the edit state the post results button should be available. You will have to save in between states.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
