### PR TITLE
feat: export with terms for partners

### DIFF
--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -257,6 +257,8 @@
   "listings.lottery.runLottery": "Run lottery",
   "listings.lottery.runLotteryContent": "Make sure to add all paper applications before running the lottery.",
   "listings.lottery.runLotteryDuplicates": "Run lottery without resolving duplicates",
+  "listings.lottery.terms": "I acknowledge that downloading and using the information contained in the Application(s), Excel or CSV files is subject to the <a className='lined' href='https://www.exygy.com' target='_blank'>Terms of Use</a>, and further, the use, storage, possession and retention of personal identifiable information contained in the Application is subject to state and federal privacy laws. I agree on behalf of the Local Government or Professional Partner that such Professional Partner or Local Government will comply with the Terms of Use and applicable state and federal privacy laws in viewing, using, storing and possessing the Application and the information contained therein. I warrant that I am authorized to enter into agreements such as the Terms of Use on behalf of such Professional Partner or Local Government.  <span className='font-semibold'>I agree to review for accuracy the spreadsheet(s) I download, per the guidance in the <a className='lined' href='https://www.exygy.com' target='_blank'>Partners Manual</a>, and to notify staff of any errors within 30 days of the close of the listing, or if a lottery will be conducted, at least three working days before the lottery is scheduled to be conducted.</span>",
+  "listings.lottery.termsAccept": "You must accept the Terms of Use before exporting this data.",
   "listings.lotteryDateNotes": "Lottery Date Notes",
   "listings.lotteryDateQuestion": "When will the lottery be run?",
   "listings.lotteryEndTime": "Lottery End Time",

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -5,6 +5,7 @@ import dayjs from "dayjs"
 import Ticket from "@heroicons/react/24/solid/TicketIcon"
 import Download from "@heroicons/react/24/solid/ArrowDownTrayIcon"
 import ExclamationCirleIcon from "@heroicons/react/24/solid/ExclamationCircleIcon"
+import Markdown from "markdown-to-jsx"
 import { t, Breadcrumbs, BreadcrumbLink } from "@bloom-housing/ui-components"
 import { Button, Card, Dialog, Heading, Icon, Message } from "@bloom-housing/ui-seeds"
 import { CardHeader, CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
@@ -37,6 +38,7 @@ const Lottery = (props: { listing: Listing }) => {
   const [reRunModal, setReRunModal] = useState(false)
   const [releaseModal, setReleaseModal] = useState(false)
   const [exportModal, setExportModal] = useState(false)
+  const [termsExportModal, setTermsExportModal] = useState(false)
   const [publishModal, setPublishModal] = useState(false)
   const [retractModal, setRetractModal] = useState(false)
   const [newApplicationsModal, setNewApplicationsModal] = useState(false)
@@ -82,7 +84,16 @@ const Lottery = (props: { listing: Listing }) => {
             : t("listings.lottery.exportFileNoPreferences")}
         </div>
         <div>
-          <Button disabled={loading || csvExportLoading} onClick={() => setExportModal(true)}>
+          <Button
+            disabled={loading || csvExportLoading}
+            onClick={() => {
+              if (profile?.userRoles?.isAdmin) {
+                setExportModal(true)
+              } else {
+                setTermsExportModal(true)
+              }
+            }}
+          >
             {t("t.export")}
           </Button>
         </div>
@@ -590,6 +601,53 @@ const Lottery = (props: { listing: Listing }) => {
                 variant="primary-outlined"
                 onClick={() => {
                   setExportModal(false)
+                }}
+                size="sm"
+              >
+                {t("t.cancel")}
+              </Button>
+            </Dialog.Footer>
+          </Dialog>
+          <Dialog
+            isOpen={!!termsExportModal}
+            ariaLabelledBy="terms-export-lottery-modal-header"
+            ariaDescribedBy="terms-export-lottery-modal-content"
+            onClose={() => setTermsExportModal(false)}
+          >
+            <Dialog.Header id="terms-export-lottery-modal-header">
+              {t("listings.lottery.export")}
+            </Dialog.Header>
+            <Dialog.Content id="terms-export-lottery-modal-content">
+              <p>
+                {listing.listingMultiselectQuestions.length
+                  ? t("listings.lottery.exportFile")
+                  : t("listings.lottery.exportFileNoPreferences")}{" "}
+                {t("listings.lottery.exportContentTimestamp", {
+                  date: dayjs(listing.lotteryLastRunAt).format("MM/DD/YYYY"),
+                  time: dayjs(listing.lotteryLastRunAt).format("h:mm a"),
+                })}
+              </p>
+              <p>{t("listings.lottery.termsAccept")}</p>
+              <h2 className={styles["terms-of-use-header"]}>
+                {t("authentication.terms.termsOfUse")}
+              </h2>
+              <Markdown>{t("listings.lottery.terms")}</Markdown>
+            </Dialog.Content>
+            <Dialog.Footer>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  // export lottery
+                  setTermsExportModal(false)
+                }}
+                size="sm"
+              >
+                {t("t.export")}
+              </Button>
+              <Button
+                variant="primary-outlined"
+                onClick={() => {
+                  setTermsExportModal(false)
                 }}
                 size="sm"
               >

--- a/sites/partners/styles/lottery.module.scss
+++ b/sites/partners/styles/lottery.module.scss
@@ -74,3 +74,9 @@
   --message-max-width: 100%;
   margin-bottom: var(--seeds-s4);
 }
+
+.terms-of-use-header {
+  font-size: var(--seeds-font-size-lg);
+  font-weight: var(--seeds-font-weight-semibold);
+  font-family: var(--seeds-font-sans);
+}


### PR DESCRIPTION
This PR addresses #4210

- [x] Addresses the issue in full

## Description

If you export lottery data as a partner, you should see a terms modal.

## How Can This Be Tested/Reviewed?

On a closed listing with a lottery as a partner where the lottery has been published to public, export the lottery data and ensure you see a terms modal with [this copy](https://docs.google.com/document/d/130OuxoQnKnukoVr_SPQq57A0JZ4vycdcS9q0EX2Gkso/edit?pli=1#heading=h.n9kz6ajsfrz) (Doorway-specific references removed).

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
