### PR TITLE
feat: change email update copy

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -30,7 +30,7 @@
   "account.reviewTermsHelper": "Debe aceptar los términos de uso antes de crear una cuenta.",
   "account.settings.alerts.currentPassword": "Contraseña inválida. Por favor, vuelva a intentarlo.",
   "account.settings.alerts.dobSuccess": "La fecha de nacimiento se ha actualizado de manera exitosa",
-  "account.settings.alerts.emailSuccess": "El correo electrónico se ha actualizado de manera exitosa",
+  "account.settings.alerts.emailSuccess": "Vaya a su correo electrónico para confirmar esta actualización",
   "account.settings.alerts.genericError": "Hubo un error. Por favor, inténtelo nuevamente o comuníquese con el servicio de asistencia para obtener ayuda.",
   "account.settings.alerts.nameSuccess": "El nombre se ha actualizado de manera exitosa",
   "account.settings.alerts.passwordEmpty": "Los campos de contraseña no pueden estar vacíos",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -24,7 +24,7 @@
   "account.signUpSaveTime.title": "Sign up quickly and check application status at anytime",
   "account.settings.alerts.currentPassword": "Invalid current password. Please try again.",
   "account.settings.alerts.dobSuccess": "Birthdate update successful",
-  "account.settings.alerts.emailSuccess": "Email update successful",
+  "account.settings.alerts.emailSuccess": "Please go to your email to confirm this update",
   "account.settings.alerts.genericError": "There was an error. Please try again, or contact support for help.",
   "account.settings.alerts.nameSuccess": "Name update successful",
   "account.settings.alerts.passwordEmpty": "Password fields may not be empty",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -30,7 +30,7 @@
   "account.reviewTermsHelper": "Dapat mong tanggapin ang mga tuntunin ng paggamit bago gumawa ng account.",
   "account.settings.alerts.currentPassword": "Hindi tama ang kasalukuyang password. Pakisubukan muli.",
   "account.settings.alerts.dobSuccess": "Matagumpay na na-update ang petsa ng kapanganakan",
-  "account.settings.alerts.emailSuccess": "Matagumpay na na-update ang email",
+  "account.settings.alerts.emailSuccess": "Mangyaring pumunta sa iyong email upang kumpirmahin ang pag -update na ito",
   "account.settings.alerts.genericError": "Nagkaproblema. Pakisubukan muli, o kontakin ang support para sa tulong.",
   "account.settings.alerts.nameSuccess": "Matagumpay na na-update ang pangalan",
   "account.settings.alerts.passwordEmpty": "Hindi pwedeng walang laman ang mga puwang",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -30,7 +30,7 @@
   "account.reviewTermsHelper": "Bạn phải chấp nhận các điều khoản sử dụng trước khi tạo tài khoản.",
   "account.settings.alerts.currentPassword": "Mật khẩu hiện tại không hợp lệ. Vui lòng thử lại.",
   "account.settings.alerts.dobSuccess": "Cập nhật ngày sinh thành công",
-  "account.settings.alerts.emailSuccess": "Cập nhật email thành công",
+  "account.settings.alerts.emailSuccess": "Vui lòng truy cập email của bạn để xác nhận bản cập nhật này",
   "account.settings.alerts.genericError": "Đã xảy ra lỗi. Vui lòng thử lại hoặc liên hệ với bộ phận hỗ trợ để được trợ giúp.",
   "account.settings.alerts.nameSuccess": "Cập nhật tên thành công",
   "account.settings.alerts.passwordEmpty": "Không được để trống các trường mật khẩu",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -30,7 +30,7 @@
   "account.reviewTermsHelper": "在创建帐户之前，您必须接受使用条款。",
   "account.settings.alerts.currentPassword": "目前密碼無效。請再試一次。",
   "account.settings.alerts.dobSuccess": "出生日期更新成功",
-  "account.settings.alerts.emailSuccess": "電子郵件更新成功",
+  "account.settings.alerts.emailSuccess": "請轉到您的電子郵件確認此更新",
   "account.settings.alerts.genericError": "發生錯誤。請再試一次，或是聯絡客戶支援以尋求服務。",
   "account.settings.alerts.nameSuccess": "姓名更新成功",
   "account.settings.alerts.passwordEmpty": "密碼欄位不可為空白",


### PR DESCRIPTION
This PR addresses [#(4122)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4122)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Previous copy was misleading, changed to "Please go to your email to confirm this update". Translations also updated.

## How Can This Be Tested/Reviewed?

Using each language, change the email address in the public Account Settings page and verify the new copy appears in the alert.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
