### PR TITLE
fix: add duplicates view

### DIFF
--- a/api/prisma/migrations/16_add_duplicates_view/migration.sql
+++ b/api/prisma/migrations/16_add_duplicates_view/migration.sql
@@ -1,0 +1,39 @@
+CREATE VIEW "application_flagged_set_possibilities" AS (
+    SELECT
+        LOWER(a.first_name) || '-' || LOWER(a.last_name) || '-' || a.birth_month || '-' || a.birth_day || '-' || a.birth_year as "key",
+        app.listing_id,
+        app.id as "application_id",
+        'nameAndDOB' as "type"
+    from
+        applicant a,
+        applications app
+    where
+        a.id = app.applicant_id
+)
+UNION
+(
+    SELECT
+        a.email_address as "key",
+        app.listing_id,
+        app.id as "application_id",
+        'email' as "type"
+    from
+        applications app,
+        applicant a
+    where
+        a.id = app.applicant_id
+        and a.email_address is not null
+)
+UNION
+(
+    SELECT
+        LOWER(hm.first_name) || '-' || LOWER(hm.last_name) || '-' || hm.birth_month || '-' || hm.birth_day || '-' || hm.birth_year as "key",
+        app.listing_id,
+        app.id as "application_id",
+        'nameAndDOB' as "type"
+    from
+        applications app,
+        household_member hm
+    where
+        hm.application_id = app.id
+)

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["postgresqlExtensions"]
+  previewFeatures = ["postgresqlExtensions", "views"]
 }
 
 datasource db {
@@ -912,6 +912,16 @@ model ScriptRuns {
   didScriptRun   Boolean  @default(false) @map("did_script_run")
 
   @@map("script_runs")
+}
+
+view ApplicationFlaggedSetPossibilities {
+  key           String
+  listingId     String    @map("listing_id") @db.Uuid
+  applicationId String    @map("application_id") @db.Uuid
+  type          String
+
+  @@id([key, applicationId])
+  @@map("application_flagged_set_possibilities")
 }
 
 enum ApplicationMethodsTypeEnum {

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -482,10 +482,17 @@ export const stagingSeed = async (
         },
       ],
       multiselectQuestions: [multiselectQuestion1],
-      // has applications that are the same email
+      // has applications that are the same email and also same name/dob
       applications: [
         await applicationFactory({
-          applicant: { emailAddress: 'user1@example.com' },
+          applicant: {
+            emailAddress: 'user1@example.com',
+            firstName: 'first',
+            lastName: 'last',
+            birthDay: 1,
+            birthMonth: 1,
+            birthYear: 1970,
+          },
         }),
         await applicationFactory({
           applicant: { emailAddress: 'user1@example.com' },
@@ -494,6 +501,42 @@ export const stagingSeed = async (
         await applicationFactory(),
         await applicationFactory({
           submissionType: ApplicationSubmissionTypeEnum.paper,
+        }),
+        await applicationFactory({
+          applicant: {
+            emailAddress: 'user1@example.com',
+            firstName: 'first',
+            lastName: 'last',
+            birthDay: 1,
+            birthMonth: 1,
+            birthYear: 1970,
+          },
+        }),
+        await applicationFactory({
+          applicant: { emailAddress: 'user2@example.com' },
+        }),
+        await applicationFactory({
+          applicant: { emailAddress: 'user2@example.com' },
+        }),
+        await applicationFactory({
+          applicant: {
+            emailAddress: 'user3@example.com',
+            firstName: 'first3',
+            lastName: 'last3',
+            birthDay: 1,
+            birthMonth: 1,
+            birthYear: 1970,
+          },
+        }),
+        await applicationFactory({
+          applicant: {
+            emailAddress: 'user3@example.com',
+            firstName: 'first3',
+            lastName: 'last3',
+            birthDay: 1,
+            birthMonth: 1,
+            birthYear: 1970,
+          },
         }),
       ],
     },


### PR DESCRIPTION
This PR addresses #4199 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Creates a View that represents all possible flagged sets in the system. We can then use this to query for specific listings to see if there are any duplicates.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
