### PR TITLE
feat: adding preference sheets to lottery export

### DIFF
--- a/api/prisma/seed-helpers/address-factory.ts
+++ b/api/prisma/seed-helpers/address-factory.ts
@@ -12,7 +12,7 @@ export const addressFactory =
       grandCanyonAddress,
       glacierAddress,
       carlsbadAddress,
-    ][randomInt(5)];
+    ][randomInt(8)];
 
 export const yellowstoneAddress = {
   placeName: 'Yellowstone National Park',

--- a/api/prisma/seed-helpers/application-preference-factory.ts
+++ b/api/prisma/seed-helpers/application-preference-factory.ts
@@ -22,7 +22,7 @@ export const preferenceFactory = (
         extraData: option.collectAddress
           ? [
               {
-                key: 'Address',
+                key: 'address',
                 type: InputType.address,
                 value: addressFactory(),
               },

--- a/api/prisma/seed-helpers/application-preference-factory.ts
+++ b/api/prisma/seed-helpers/application-preference-factory.ts
@@ -1,31 +1,30 @@
-import { MultiselectQuestions, Prisma } from '@prisma/client';
-import { randomNoun } from './word-generator';
+import { Prisma } from '@prisma/client';
 import { randomBoolean } from './boolean-generator';
 import { InputType } from '../../src/enums/shared/input-type-enum';
+import { addressFactory } from './address-factory';
 
 export const preferenceFactory = (
-  multiselectQuestions: Partial<MultiselectQuestions>[],
+  multiselectQuestions: {
+    id?: string;
+    text?: string;
+    options?: Prisma.JsonValue | null;
+  }[],
+  randomize = false,
 ): Prisma.InputJsonValue => {
   return multiselectQuestions.map((question) => ({
     multiselectQuestionId: question.id,
     key: question.text,
-    claimed: randomBoolean(),
-    options: JSON.parse(JSON.stringify(question.options)).map((option) => {
+    claimed: randomize ? randomBoolean() : true,
+    options: JSON.parse(JSON.stringify(question?.options)).map((option) => {
       return {
-        key: option.key,
-        checked: randomBoolean(),
+        key: option.text,
+        checked: randomize ? randomBoolean() : true,
         extraData: option.collectAddress
           ? [
               {
                 key: 'Address',
                 type: InputType.address,
-                value: {
-                  city: randomNoun(),
-                  state: randomNoun(),
-                  street: '123 4th St',
-                  street2: 'Apt 5',
-                  zipCode: '67890',
-                },
+                value: addressFactory(),
               },
             ]
           : [],

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -127,7 +127,7 @@ export const stagingSeed = async (
   const mapLayer = await prismaClient.mapLayers.create({
     data: mapLayerFactory(jurisdiction.id, 'Washington DC', simplifiedDCMap),
   });
-  const multiselectQuestion1 = await prismaClient.multiselectQuestions.create({
+  const cityEmployeeQuestion = await prismaClient.multiselectQuestions.create({
     data: multiselectQuestionFactory(jurisdiction.id, {
       multiselectQuestion: {
         text: 'City Employees',
@@ -144,7 +144,7 @@ export const stagingSeed = async (
       },
     }),
   });
-  const multiselectQuestion2 = await prismaClient.multiselectQuestions.create({
+  const workInCityQuestion = await prismaClient.multiselectQuestions.create({
     data: multiselectQuestionFactory(jurisdiction.id, {
       multiselectQuestion: {
         text: 'Work in the city',
@@ -173,21 +173,24 @@ export const stagingSeed = async (
       },
     }),
   });
-  const multiselectQuestion3 = await prismaClient.multiselectQuestions.create({
-    data: multiselectQuestionFactory(jurisdiction.id, {
-      multiselectQuestion: {
-        text: 'Veteran',
-        description:
-          'Have you or anyone in your household served in the US military?',
-        applicationSection: MultiselectQuestionsApplicationSectionEnum.programs,
-        optOutText: 'Prefer not to say',
-        options: [
-          { text: 'Yes', exclusive: true, ordinal: 1 },
-          { text: 'No', exclusive: true, ordinal: 2 },
-        ],
-      },
-    }),
-  });
+  const veteranProgramQuestion = await prismaClient.multiselectQuestions.create(
+    {
+      data: multiselectQuestionFactory(jurisdiction.id, {
+        multiselectQuestion: {
+          text: 'Veteran',
+          description:
+            'Have you or anyone in your household served in the US military?',
+          applicationSection:
+            MultiselectQuestionsApplicationSectionEnum.programs,
+          optOutText: 'Prefer not to say',
+          options: [
+            { text: 'Yes', exclusive: true, ordinal: 1 },
+            { text: 'No', exclusive: true, ordinal: 2 },
+          ],
+        },
+      }),
+    },
+  );
   const multiselectQuestionPrograms =
     await prismaClient.multiselectQuestions.create({
       data: multiselectQuestionFactory(jurisdiction.id, {
@@ -349,8 +352,8 @@ export const stagingSeed = async (
         },
       ],
       multiselectQuestions: [
-        multiselectQuestion1,
-        multiselectQuestion2,
+        cityEmployeeQuestion,
+        workInCityQuestion,
         multiselectQuestionPrograms,
       ],
       applications: [await applicationFactory(), await applicationFactory()],
@@ -481,7 +484,7 @@ export const stagingSeed = async (
           },
         },
       ],
-      multiselectQuestions: [multiselectQuestion1],
+      multiselectQuestions: [cityEmployeeQuestion],
       // has applications that are the same email
       applications: [
         await applicationFactory({
@@ -808,7 +811,7 @@ export const stagingSeed = async (
           ],
         },
       },
-      multiselectQuestions: [multiselectQuestion2],
+      multiselectQuestions: [workInCityQuestion],
     },
     {
       listing: {
@@ -908,10 +911,32 @@ export const stagingSeed = async (
           ],
         },
       },
+      applications: [
+        await applicationFactory({
+          multiselectQuestions: [workInCityQuestion, cityEmployeeQuestion],
+        }),
+        await applicationFactory({
+          multiselectQuestions: [
+            cityEmployeeQuestion,
+            workInCityQuestion,
+            veteranProgramQuestion,
+          ],
+        }),
+        await applicationFactory({
+          multiselectQuestions: [workInCityQuestion, cityEmployeeQuestion],
+        }),
+        await applicationFactory({
+          multiselectQuestions: [workInCityQuestion],
+        }),
+        await applicationFactory({
+          multiselectQuestions: [workInCityQuestion],
+        }),
+        await applicationFactory(),
+      ],
       multiselectQuestions: [
-        multiselectQuestion2,
-        multiselectQuestion1,
-        multiselectQuestion3,
+        workInCityQuestion,
+        cityEmployeeQuestion,
+        veteranProgramQuestion,
       ],
       units: [
         {

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -639,11 +639,9 @@ export class LotteryService {
         (header) => header.header === 'Raw Lottery Rank',
       );
 
-      res[indx].header = `${preference.name} Rank`;
-
       res.splice(indx + 1, 0, {
         key: 'Raw Lottery Rank',
-        header: 'Raw Lottery Rank',
+        header: `${preference.name} Rank`,
       });
     }
     return res;

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -289,7 +289,7 @@ export class LotteryService {
       }-${new Date().getTime()}.zip`,
     );
 
-    await this.createLotterySheet(workbook, {
+    await this.createLotterySheets(workbook, {
       ...queryParams,
     });
 
@@ -320,9 +320,9 @@ export class LotteryService {
    *
    * @param filename
    * @param queryParams
-   * @returns generates the lottery sheet
+   * @returns generates the lottery sheets
    */
-  async createLotterySheet<QueryParams extends ApplicationCsvQueryParams>(
+  async createLotterySheets<QueryParams extends ApplicationCsvQueryParams>(
     workbook: Excel.Workbook,
     queryParams: QueryParams,
   ): Promise<void> {
@@ -388,7 +388,7 @@ export class LotteryService {
     );
 
     const mappedApps = mapTo(Application, applications);
-    await this.lotteryExportHelper(
+    await this.generateSpreadsheetData(
       workbook,
       mappedApps,
       columns,
@@ -402,7 +402,7 @@ export class LotteryService {
         MultiselectQuestionsApplicationSectionEnum.preferences,
     );
     for (const preference of preferences) {
-      await this.lotteryExportHelper(
+      await this.generateSpreadsheetData(
         workbook,
         mappedApps,
         columns,
@@ -450,7 +450,7 @@ export class LotteryService {
    * @param preference if present, then builds the preference specific spreadsheet page
    * @returns void but writes the output to a file
    */
-  async lotteryExportHelper(
+  async generateSpreadsheetData(
     workbook: Excel.Workbook,
     applications: Application[],
     csvHeaders: CsvHeader[],
@@ -458,14 +458,11 @@ export class LotteryService {
     forLottery = false,
     preference?: IdDTO,
   ): Promise<void> {
-    // create raw rank spreadsheet
-    const rawRankSpreadsheet = workbook.addWorksheet(
+    // create a spreadsheet. If the preference is passed in use that as a title otherwise 'raw'
+    const spreadsheet = workbook.addWorksheet(
       preference ? preference.name : 'Raw',
     );
-    rawRankSpreadsheet.columns = this.buildExportColumns(
-      csvHeaders,
-      preference,
-    );
+    spreadsheet.columns = this.buildExportColumns(csvHeaders, preference);
 
     const filteredApplications = preference
       ? applications.filter((app) =>
@@ -624,7 +621,7 @@ export class LotteryService {
 
     // add rows to spreadsheet
     res.forEach((elem) => {
-      rawRankSpreadsheet.addRows(elem);
+      spreadsheet.addRows(elem);
     });
   }
 

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -639,9 +639,11 @@ export class LotteryService {
         (header) => header.header === 'Raw Lottery Rank',
       );
 
-      res.splice(indx + 1, 0, {
+      res[indx].header = `${preference.name} Rank`;
+
+      res.splice(indx, 0, {
         key: 'Raw Lottery Rank',
-        header: `${preference.name} Rank`,
+        header: 'Raw Lottery Rank',
       });
     }
     return res;

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -460,7 +460,7 @@ export class LotteryService {
   ): Promise<void> {
     // create a spreadsheet. If the preference is passed in use that as a title otherwise 'raw'
     const spreadsheet = workbook.addWorksheet(
-      preference ? preference.name : 'Raw',
+      preference ? preference.name : 'Raw Lottery Rank',
     );
     spreadsheet.columns = this.buildExportColumns(csvHeaders, preference);
 
@@ -541,7 +541,7 @@ export class LotteryService {
             let programs: ApplicationMultiselectQuestion[];
 
             if (preference) {
-              row['Raw Rank'] = slicedApplications.find(
+              row['Raw Lottery Rank'] = slicedApplications.find(
                 (slicedApp) => slicedApp.id === app.id,
               ).applicationLotteryPositions[0].ordinal;
             }
@@ -642,8 +642,8 @@ export class LotteryService {
       res[indx].header = `${preference.name} Rank`;
 
       res.splice(indx + 1, 0, {
-        key: 'Raw Rank',
-        header: 'Raw Rank',
+        key: 'Raw Lottery Rank',
+        header: 'Raw Lottery Rank',
       });
     }
     return res;

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -545,7 +545,7 @@ export class LotteryService {
 
             if (preference) {
               row['Raw Rank'] = slicedApplications.find(
-                (slicedApp) => (slicedApp.id = app.id),
+                (slicedApp) => slicedApp.id === app.id,
               ).applicationLotteryPositions[0].ordinal;
             }
             csvHeaders.forEach((header) => {

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -369,7 +369,7 @@ export const constructMultiselectQuestionHeaders = (
           });
           if (option.validationMethod) {
             headers.push({
-              path: `${applicationSection}.${question.text}.address`,
+              path: `${applicationSection}.${question.text}.geocodingVerified`,
               label: `${labelString} ${question.text} - ${option.text} - Passed Address Check`,
               format: (val: ApplicationMultiselectQuestion): string => {
                 return multiselectQuestionFormat(
@@ -382,7 +382,7 @@ export const constructMultiselectQuestionHeaders = (
           }
           if (option.collectName) {
             headers.push({
-              path: `${applicationSection}.${question.text}.address`,
+              path: `${applicationSection}.${question.text}.addressHolderName`,
               label: `${labelString} ${question.text} - ${option.text} - Name of Address Holder`,
               format: (val: ApplicationMultiselectQuestion): string => {
                 return multiselectQuestionFormat(
@@ -395,7 +395,7 @@ export const constructMultiselectQuestionHeaders = (
           }
           if (option.collectRelationship) {
             headers.push({
-              path: `${applicationSection}.${question.text}.address`,
+              path: `${applicationSection}.${question.text}.addressHolderRelationship`,
               label: `${labelString} ${question.text} - ${option.text} - Relationship to Address Holder`,
               format: (val: ApplicationMultiselectQuestion): string => {
                 return multiselectQuestionFormat(

--- a/api/test/unit/services/application.service.spec.ts
+++ b/api/test/unit/services/application.service.spec.ts
@@ -59,7 +59,7 @@ export const mockApplication = (options: {
     incomeVouchers: true,
     income: `income ${options.position}`,
     incomePeriod: IncomePeriodEnum.perMonth,
-    preferences: options.preferences,
+    preferences: options.preferences || [],
     programs: [{ claimed: true, key: 'example key', options: null }],
     preferredUnitTypes: [{ name: 'studio' }, { name: 'oneBdrm' }],
     status: ApplicationStatusEnum.submitted,

--- a/api/test/unit/services/application.service.spec.ts
+++ b/api/test/unit/services/application.service.spec.ts
@@ -29,16 +29,17 @@ import { GeocodingService } from '../../../src/services/geocoding.service';
 import { AlternateContactRelationship } from '../../../src/enums/applications/alternate-contact-relationship-enum';
 import { HouseholdMemberRelationship } from '../../../src/enums/applications/household-member-relationship-enum';
 
-export const mockApplication = (
-  position: number,
-  date: Date,
-  numberOfHouseholdMembers?: number,
-  includeLotteryPosition?: boolean,
-) => {
+export const mockApplication = (options: {
+  date: Date;
+  position?: number;
+  numberOfHouseholdMembers?: number;
+  includeLotteryPosition?: boolean;
+  preferences?: any;
+}) => {
   let householdMember = undefined;
-  if (numberOfHouseholdMembers) {
+  if (options.numberOfHouseholdMembers) {
     householdMember = [];
-    for (let i = 0; i < numberOfHouseholdMembers; i++) {
+    for (let i = 0; i < options.numberOfHouseholdMembers; i++) {
       householdMember.push({
         id: randomUUID(),
       });
@@ -46,74 +47,74 @@ export const mockApplication = (
   }
   return {
     id: randomUUID(),
-    appUrl: `appUrl ${position}`,
+    appUrl: `appUrl ${options.position}`,
     additionalPhone: true,
-    additionalPhoneNumber: `additionalPhoneNumber ${position}`,
-    additionalPhoneNumberType: `additionalPhoneNumberType ${position}`,
-    householdSize: position,
-    housingStatus: `housingStatus ${position}`,
+    additionalPhoneNumber: `additionalPhoneNumber ${options.position}`,
+    additionalPhoneNumberType: `additionalPhoneNumberType ${options.position}`,
+    householdSize: options.position,
+    housingStatus: `housingStatus ${options.position}`,
     sendMailToMailingAddress: true,
     householdExpectingChanges: true,
     householdStudent: true,
     incomeVouchers: true,
-    income: `income ${position}`,
+    income: `income ${options.position}`,
     incomePeriod: IncomePeriodEnum.perMonth,
-    preferences: [{ claimed: true, key: 'example key', options: null }],
+    preferences: options.preferences,
     programs: [{ claimed: true, key: 'example key', options: null }],
     preferredUnitTypes: [{ name: 'studio' }, { name: 'oneBdrm' }],
     status: ApplicationStatusEnum.submitted,
     submissionType: ApplicationSubmissionTypeEnum.electronical,
     acceptedTerms: true,
-    submissionDate: date,
+    submissionDate: options.date,
     markedAsDuplicate: false,
-    confirmationCode: `confirmationCode ${position}`,
+    confirmationCode: `confirmationCode ${options.position}`,
     reviewStatus: ApplicationReviewStatusEnum.valid,
     applicant: {
-      firstName: `application ${position} firstName`,
-      middleName: `application ${position} middleName`,
-      lastName: `application ${position} lastName`,
-      birthMonth: `application ${position} birthMonth`,
-      birthDay: `application ${position} birthDay`,
-      birthYear: `application ${position} birthYear`,
-      emailAddress: `application ${position} emailaddress`,
+      firstName: `application ${options.position} firstName`,
+      middleName: `application ${options.position} middleName`,
+      lastName: `application ${options.position} lastName`,
+      birthMonth: `application ${options.position} birthMonth`,
+      birthDay: `application ${options.position} birthDay`,
+      birthYear: `application ${options.position} birthYear`,
+      emailAddress: `application ${options.position} emailaddress`,
       noEmail: false,
-      phoneNumber: `application ${position} phoneNumber`,
-      phoneNumberType: `application ${position} phoneNumberType`,
+      phoneNumber: `application ${options.position} phoneNumber`,
+      phoneNumberType: `application ${options.position} phoneNumberType`,
       noPhone: false,
       workInRegion: YesNoEnum.yes,
       applicantWorkAddress: {
-        placeName: `application ${position} applicantWorkAddress placeName`,
-        city: `application ${position} applicantWorkAddress city`,
-        county: `application ${position} applicantWorkAddress county`,
-        state: `application ${position} applicantWorkAddress state`,
-        street: `application ${position} applicantWorkAddress street`,
-        street2: `application ${position} applicantWorkAddress street2`,
-        zipCode: `application ${position} applicantWorkAddress zipCode`,
-        latitude: position,
-        longitude: position,
+        placeName: `application ${options.position} applicantWorkAddress placeName`,
+        city: `application ${options.position} applicantWorkAddress city`,
+        county: `application ${options.position} applicantWorkAddress county`,
+        state: `application ${options.position} applicantWorkAddress state`,
+        street: `application ${options.position} applicantWorkAddress street`,
+        street2: `application ${options.position} applicantWorkAddress street2`,
+        zipCode: `application ${options.position} applicantWorkAddress zipCode`,
+        latitude: options.position,
+        longitude: options.position,
       },
       applicantAddress: {
-        placeName: `application ${position} applicantAddress placeName`,
-        city: `application ${position} applicantAddress city`,
-        county: `application ${position} applicantAddress county`,
-        state: `application ${position} applicantAddress state`,
-        street: `application ${position} applicantAddress street`,
-        street2: `application ${position} applicantAddress street2`,
-        zipCode: `application ${position} applicantAddress zipCode`,
-        latitude: position,
-        longitude: position,
+        placeName: `application ${options.position} applicantAddress placeName`,
+        city: `application ${options.position} applicantAddress city`,
+        county: `application ${options.position} applicantAddress county`,
+        state: `application ${options.position} applicantAddress state`,
+        street: `application ${options.position} applicantAddress street`,
+        street2: `application ${options.position} applicantAddress street2`,
+        zipCode: `application ${options.position} applicantAddress zipCode`,
+        latitude: options.position,
+        longitude: options.position,
       },
     },
     demographics: {
       race: ['declineToRespond'],
     },
-    createdAt: date,
-    updatedAt: date,
+    createdAt: options.date,
+    updatedAt: options.date,
     householdMember: householdMember,
-    applicationLotteryPositions: includeLotteryPosition
+    applicationLotteryPositions: options.includeLotteryPosition
       ? [
           {
-            ordinal: position,
+            ordinal: options.position + 1,
           },
         ]
       : undefined,
@@ -129,12 +130,12 @@ export const mockApplicationSet = (
   const toReturn = [];
   for (let i = 0; i < numberToCreate; i++) {
     toReturn.push(
-      mockApplication(
-        i,
+      mockApplication({
+        position: i,
         date,
         numberOfHouseholdMembers,
         includeLotteryPosition,
-      ),
+      }),
     );
   }
   return toReturn;

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -920,10 +920,10 @@ describe('Testing lottery service', () => {
       expect(workbook.worksheets[0].columnCount).toEqual(56);
       expect(workbook.worksheets[0].rowCount).toEqual(3); // header and 2 applications
       expect(workbook.worksheets[0].getColumn(3).header).toEqual(
-        'sample preference Rank',
+        'Raw Lottery Rank',
       );
       expect(workbook.worksheets[0].getColumn(4).header).toEqual(
-        'Raw Lottery Rank',
+        'sample preference Rank',
       );
       expect(workbook.worksheets[0].getRow(2).getCell(3).value).toEqual('1');
       expect(workbook.worksheets[0].getRow(3).getCell(3).value).toEqual('2');

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -925,10 +925,10 @@ describe('Testing lottery service', () => {
       expect(workbook.worksheets[0].getColumn(4).header).toEqual(
         'sample preference Rank',
       );
-      expect(workbook.worksheets[0].getRow(2).getCell(3).value).toEqual('1');
-      expect(workbook.worksheets[0].getRow(3).getCell(3).value).toEqual('2');
-      expect(workbook.worksheets[0].getRow(2).getCell(4).value).toEqual(3);
-      expect(workbook.worksheets[0].getRow(3).getCell(4).value).toEqual(4);
+      expect(workbook.worksheets[0].getRow(2).getCell(3).value).toEqual(3);
+      expect(workbook.worksheets[0].getRow(3).getCell(3).value).toEqual(4);
+      expect(workbook.worksheets[0].getRow(2).getCell(4).value).toEqual('1');
+      expect(workbook.worksheets[0].getRow(3).getCell(4).value).toEqual('2');
     });
   });
 });

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -6,12 +6,16 @@ import {
   MultiselectQuestionsApplicationSectionEnum,
 } from '@prisma/client';
 import { HttpModule } from '@nestjs/axios';
+import Excel from 'exceljs';
 import { Request as ExpressRequest, Response } from 'express';
 import { PrismaService } from '../../../src/services/prisma.service';
 import { ApplicationCsvExporterService } from '../../../src/services/application-csv-export.service';
 import { MultiselectQuestionService } from '../../../src/services/multiselect-question.service';
 import { User } from '../../../src/dtos/users/user.dto';
-import { mockApplicationSet } from './application.service.spec';
+import {
+  mockApplication,
+  mockApplicationSet,
+} from './application.service.spec';
 import { mockMultiselectQuestion } from './multiselect-question.service.spec';
 import { ListingService } from '../../../src/services/listing.service';
 import { PermissionService } from '../../../src/services/permission.service';
@@ -26,6 +30,7 @@ import { Application } from '../../../src/dtos/applications/application.dto';
 import MultiselectQuestion from '../../../src/dtos/multiselect-questions/multiselect-question.dto';
 import { OrderByEnum } from '../../../src/enums/shared/order-by-enum';
 import { LotteryService } from '../../../src/services/lottery.service';
+import { getExportHeaders } from '../../../src/utilities/application-export-helpers';
 
 describe('Testing lottery service', () => {
   let service: LotteryService;
@@ -416,6 +421,512 @@ describe('Testing lottery service', () => {
         prisma.applicationLotteryPositions.createMany,
       ).not.toHaveBeenCalled();
       expect(prisma.listings.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Testing generateSpreadsheetData', () => {
+    it('should generate spreadsheet and the data', async () => {
+      const applicationSet = mockApplicationSet(5, new Date(), 0, true);
+      prisma.applications.findMany = jest
+        .fn()
+        .mockResolvedValueOnce(applicationSet);
+      const workbook = new Excel.Workbook();
+      const listingId = randomUUID();
+      const headers = getExportHeaders(
+        0,
+        [],
+        'America/Los_Angeles',
+        false,
+        true,
+      );
+      await service.generateSpreadsheetData(
+        workbook,
+        applicationSet,
+        headers,
+        {
+          listingId: listingId,
+          includeDemographics: false,
+          timeZone: 'America/Los_Angeles',
+        },
+        true,
+      );
+
+      expect(prisma.applications.findMany).toBeCalledWith({
+        include: {
+          accessibility: {
+            select: {
+              hearing: true,
+              id: true,
+              mobility: true,
+              vision: true,
+            },
+          },
+          alternateContact: {
+            select: {
+              address: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              agency: true,
+              emailAddress: true,
+              firstName: true,
+              id: true,
+              lastName: true,
+              otherType: true,
+              phoneNumber: true,
+              type: true,
+            },
+          },
+          applicant: {
+            select: {
+              applicantAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              applicantWorkAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              birthDay: true,
+              birthMonth: true,
+              birthYear: true,
+              emailAddress: true,
+              firstName: true,
+              id: true,
+              lastName: true,
+              middleName: true,
+              noEmail: true,
+              noPhone: true,
+              phoneNumber: true,
+              phoneNumberType: true,
+              workInRegion: true,
+            },
+          },
+          applicationFlaggedSet: {
+            select: {
+              id: true,
+            },
+          },
+          applicationLotteryPositions: {
+            select: {
+              ordinal: true,
+            },
+            where: {
+              multiselectQuestionId: null,
+            },
+          },
+          applicationsAlternateAddress: {
+            select: {
+              city: true,
+              county: true,
+              id: true,
+              latitude: true,
+              longitude: true,
+              placeName: true,
+              state: true,
+              street: true,
+              street2: true,
+              zipCode: true,
+            },
+          },
+          applicationsMailingAddress: {
+            select: {
+              city: true,
+              county: true,
+              id: true,
+              latitude: true,
+              longitude: true,
+              placeName: true,
+              state: true,
+              street: true,
+              street2: true,
+              zipCode: true,
+            },
+          },
+          demographics: false,
+          householdMember: {
+            select: {
+              birthDay: true,
+              birthMonth: true,
+              birthYear: true,
+              firstName: true,
+              householdMemberAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              householdMemberWorkAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              id: true,
+              lastName: true,
+              middleName: true,
+              orderId: true,
+              relationship: true,
+              sameAddress: true,
+              workInRegion: true,
+            },
+          },
+          listings: false,
+          preferredUnitTypes: {
+            select: {
+              id: true,
+              name: true,
+              numBedrooms: true,
+            },
+          },
+          userAccounts: {
+            select: {
+              email: true,
+              firstName: true,
+              id: true,
+              lastName: true,
+            },
+          },
+        },
+        where: {
+          deletedAt: null,
+          id: {
+            in: applicationSet.map((appSet) => appSet.id),
+          },
+          listingId: listingId,
+          markedAsDuplicate: false,
+        },
+      });
+      expect(workbook.worksheets).toHaveLength(1);
+      expect(workbook.worksheets[0].columnCount).toEqual(55);
+      expect(workbook.worksheets[0].rowCount).toEqual(6); // header and 5 applications
+      expect(workbook.worksheets[0].getColumn(3).header).toEqual(
+        'Raw Lottery Rank',
+      );
+      expect(workbook.worksheets[0].getRow(2).getCell(3).value).toEqual('1');
+      expect(workbook.worksheets[0].getRow(3).getCell(3).value).toEqual('2');
+      expect(workbook.worksheets[0].getRow(4).getCell(3).value).toEqual('3');
+      expect(workbook.worksheets[0].getRow(5).getCell(3).value).toEqual('4');
+      expect(workbook.worksheets[0].getRow(6).getCell(3).value).toEqual('5');
+    });
+
+    it('should generate spreadsheet and the data for preference sheet', async () => {
+      const preferenceId = randomUUID();
+      const preference = { name: 'sample preference', id: preferenceId };
+      const applicationSet = [
+        mockApplication({
+          date: new Date(),
+          position: 2,
+          numberOfHouseholdMembers: 0,
+          includeLotteryPosition: true,
+          preferences: [{ claimed: true, multiselectQuestionId: preferenceId }],
+        }),
+        mockApplication({
+          date: new Date(),
+          position: 0,
+          numberOfHouseholdMembers: 0,
+          includeLotteryPosition: true,
+          preferences: [
+            { claimed: false, multiselectQuestionId: preferenceId },
+          ],
+        }),
+        mockApplication({
+          date: new Date(),
+          position: 1,
+          numberOfHouseholdMembers: 0,
+          includeLotteryPosition: true,
+          preferences: [],
+        }),
+        mockApplication({
+          date: new Date(),
+          position: 3,
+          numberOfHouseholdMembers: 0,
+          includeLotteryPosition: true,
+          preferences: [{ claimed: true, multiselectQuestionId: preferenceId }],
+        }),
+      ];
+      prisma.applications.findMany = jest.fn().mockResolvedValueOnce([
+        {
+          ...applicationSet[0],
+          applicationLotteryPositions: [{ ordinal: 1 }],
+        },
+        {
+          ...applicationSet[3],
+          applicationLotteryPositions: [{ ordinal: 2 }],
+        },
+        ,
+      ]);
+      const workbook = new Excel.Workbook();
+      const listingId = randomUUID();
+      const headers = getExportHeaders(
+        0,
+        [],
+        'America/Los_Angeles',
+        false,
+        true,
+      );
+      await service.generateSpreadsheetData(
+        workbook,
+        applicationSet as Application[],
+        headers,
+        {
+          listingId: listingId,
+          includeDemographics: false,
+          timeZone: 'America/Los_Angeles',
+        },
+        true,
+        preference,
+      );
+
+      expect(prisma.applications.findMany).toBeCalledWith({
+        include: {
+          accessibility: {
+            select: {
+              hearing: true,
+              id: true,
+              mobility: true,
+              vision: true,
+            },
+          },
+          alternateContact: {
+            select: {
+              address: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              agency: true,
+              emailAddress: true,
+              firstName: true,
+              id: true,
+              lastName: true,
+              otherType: true,
+              phoneNumber: true,
+              type: true,
+            },
+          },
+          applicant: {
+            select: {
+              applicantAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              applicantWorkAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              birthDay: true,
+              birthMonth: true,
+              birthYear: true,
+              emailAddress: true,
+              firstName: true,
+              id: true,
+              lastName: true,
+              middleName: true,
+              noEmail: true,
+              noPhone: true,
+              phoneNumber: true,
+              phoneNumberType: true,
+              workInRegion: true,
+            },
+          },
+          applicationFlaggedSet: {
+            select: {
+              id: true,
+            },
+          },
+          applicationLotteryPositions: {
+            select: {
+              ordinal: true,
+            },
+            where: {
+              multiselectQuestionId: preferenceId,
+            },
+          },
+          applicationsAlternateAddress: {
+            select: {
+              city: true,
+              county: true,
+              id: true,
+              latitude: true,
+              longitude: true,
+              placeName: true,
+              state: true,
+              street: true,
+              street2: true,
+              zipCode: true,
+            },
+          },
+          applicationsMailingAddress: {
+            select: {
+              city: true,
+              county: true,
+              id: true,
+              latitude: true,
+              longitude: true,
+              placeName: true,
+              state: true,
+              street: true,
+              street2: true,
+              zipCode: true,
+            },
+          },
+          demographics: false,
+          householdMember: {
+            select: {
+              birthDay: true,
+              birthMonth: true,
+              birthYear: true,
+              firstName: true,
+              householdMemberAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              householdMemberWorkAddress: {
+                select: {
+                  city: true,
+                  county: true,
+                  id: true,
+                  latitude: true,
+                  longitude: true,
+                  placeName: true,
+                  state: true,
+                  street: true,
+                  street2: true,
+                  zipCode: true,
+                },
+              },
+              id: true,
+              lastName: true,
+              middleName: true,
+              orderId: true,
+              relationship: true,
+              sameAddress: true,
+              workInRegion: true,
+            },
+          },
+          listings: false,
+          preferredUnitTypes: {
+            select: {
+              id: true,
+              name: true,
+              numBedrooms: true,
+            },
+          },
+          userAccounts: {
+            select: {
+              email: true,
+              firstName: true,
+              id: true,
+              lastName: true,
+            },
+          },
+        },
+        where: {
+          deletedAt: null,
+          id: {
+            in: [applicationSet[0].id, applicationSet[3].id],
+          },
+          listingId: listingId,
+          markedAsDuplicate: false,
+        },
+      });
+      expect(workbook.worksheets).toHaveLength(1);
+      expect(workbook.worksheets[0].columnCount).toEqual(56);
+      expect(workbook.worksheets[0].rowCount).toEqual(3); // header and 2 applications
+      expect(workbook.worksheets[0].getColumn(3).header).toEqual(
+        'sample preference Rank',
+      );
+      expect(workbook.worksheets[0].getColumn(4).header).toEqual('Raw Rank');
+      expect(workbook.worksheets[0].getRow(2).getCell(3).value).toEqual('1');
+      expect(workbook.worksheets[0].getRow(3).getCell(3).value).toEqual('2');
+      expect(workbook.worksheets[0].getRow(2).getCell(4).value).toEqual(3);
+      expect(workbook.worksheets[0].getRow(3).getCell(4).value).toEqual(4);
     });
   });
 });

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -922,7 +922,9 @@ describe('Testing lottery service', () => {
       expect(workbook.worksheets[0].getColumn(3).header).toEqual(
         'sample preference Rank',
       );
-      expect(workbook.worksheets[0].getColumn(4).header).toEqual('Raw Rank');
+      expect(workbook.worksheets[0].getColumn(4).header).toEqual(
+        'Raw Lottery Rank',
+      );
       expect(workbook.worksheets[0].getRow(2).getCell(3).value).toEqual('1');
       expect(workbook.worksheets[0].getRow(3).getCell(3).value).toEqual('2');
       expect(workbook.worksheets[0].getRow(2).getCell(4).value).toEqual(3);

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -521,7 +521,7 @@ export const useApplicationsExport = (listingId: string, includeDemographics: bo
   )
 }
 
-export const useLotteryExport = (listingId: string) => {
+export const useLotteryExport = (listingId: string, includeDemographics: boolean) => {
   const { lotteryService } = useContext(AuthContext)
   const [exportLoading, setExportLoading] = useState(false)
   const { addToast } = useContext(MessageContext)
@@ -530,7 +530,7 @@ export const useLotteryExport = (listingId: string) => {
     setExportLoading(true)
     try {
       const content = await lotteryService.lotteryResults(
-        { listingId },
+        { listingId, includeDemographics },
         { responseType: "arraybuffer" }
       )
       const blob = new Blob([new Uint8Array(content)], { type: "application/zip" })

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -44,7 +44,21 @@ const Lottery = (props: { listing: Listing }) => {
   const [loading, setLoading] = useState(false)
 
   const { listingsService, lotteryService, profile } = useContext(AuthContext)
-  const { onExport, exportLoading } = useLotteryExport(listing?.id)
+
+  const listingJurisdiction = profile?.jurisdictions.find(
+    (jurisdiction) => jurisdiction.id === listing?.jurisdictions.id
+  )
+
+  const includeDemographicsPartner =
+    profile?.userRoles?.isPartner && listingJurisdiction?.enablePartnerDemographics
+
+  const { onExport, exportLoading } = useLotteryExport(
+    listing?.id,
+    (profile?.userRoles?.isAdmin ||
+      profile?.userRoles?.isJurisdictionalAdmin ||
+      includeDemographicsPartner) ??
+      false
+  )
   const { data } = useFlaggedApplicationsMeta(listing?.id)
   const duplicatesExist = data?.totalPendingCount > 0
   let formattedExpiryDate: string

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -45,10 +45,7 @@ const Lottery = (props: { listing: Listing }) => {
 
   const { listingsService, lotteryService, profile } = useContext(AuthContext)
 
-  console.log("48:", listing)
-  console.log("49:", profile)
-
-  const listingJurisdiction = profile?.jurisdictions.find(
+  const listingJurisdiction = profile?.jurisdictions?.find(
     (jurisdiction) => jurisdiction.id === listing?.jurisdictions.id
   )
 

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -45,6 +45,9 @@ const Lottery = (props: { listing: Listing }) => {
 
   const { listingsService, lotteryService, profile } = useContext(AuthContext)
 
+  console.log("48:", listing)
+  console.log("49:", profile)
+
   const listingJurisdiction = profile?.jurisdictions.find(
     (jurisdiction) => jurisdiction.id === listing?.jurisdictions.id
   )
@@ -649,11 +652,12 @@ const Lottery = (props: { listing: Listing }) => {
             <Dialog.Footer>
               <Button
                 variant="primary"
-                onClick={() => {
-                  // export lottery
+                onClick={async () => {
+                  await onExport()
                   setTermsExportModal(false)
                 }}
                 size="sm"
+                loadingMessage={loading || exportLoading ? t("t.loading") : undefined}
               >
                 {t("t.export")}
               </Button>


### PR DESCRIPTION
This PR addresses #4056 

- [x] Addresses the issue in full

## Description
This adds the preference sheets to the lottery export as well as a few other things:

- preference sheets
    - added
- demographics
    - now based on role just like application csv export
- columns
    - added preference rank
    - still need to double check column order
- permissions
    - UI is now hooked up to do a partner export

## How Can This Be Tested/Reviewed?
- head to the partners site
- on a closed listing with applications and preferences on the listing (and to make it easier claimed preferences on at least some of the applications)
- generate the lottery results
- get the spreadsheet export

you should notice individual sheets for each preference as well as the original raw sheet

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
