### PR TITLE
fix: return proper exception for email in use

### DIFF
--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ForbiddenException,
+  ConflictException,
   Injectable,
   NotFoundException,
   UnauthorizedException,
@@ -79,7 +80,7 @@ export class UserService {
 
   /*
     this will get a set of users given the params passed in
-    Only users with a user role of admin or jurisdictional admin can get the list of available users. 
+    Only users with a user role of admin or jurisdictional admin can get the list of available users.
     This means we don't need to account for a user with only the partner role when it comes to accessing this function
   */
   async list(params: UserQueryParams, user: User): Promise<PaginatedUserDto> {
@@ -614,7 +615,7 @@ export class UserService {
         return mapTo(User, res);
       } else {
         // existing user && ((partner user -> trying to recreate user) || (public user -> trying to recreate a public user))
-        throw new BadRequestException('emailInUse');
+        throw new ConflictException('emailInUse');
       }
     }
 

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -119,7 +119,7 @@
   "authentication.createAccount.errors.tokenMissing": "Wrong token provided.",
   "authentication.createAccount.firstName": "First Name",
   "authentication.createAccount.lastName": "Last Name",
-  "errors.alert.emailConflict": "That email is already in use",
+  "errors.alert.emailConflict": "This email is already in use. Please contact your housing department if you're still experiencing issues",
   "errors.maxLessThanMinOccupancyError": "Max Occupancy must be greater than or equal to Minimum Occupancy",
   "errors.minGreaterThanMaxOccupancyError": "Minimum Occupancy must be less than or equal to Max Occupancy",
   "errors.partialAddress": "Cannot enter a partial address",


### PR DESCRIPTION
This PR addresses [#770](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/770)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Returns 409 instead of 400 error for email in use (frontend already checks for 409 error code, and displays different message)

## How Can This Be Tested/Reviewed?

In http://localhost:3001/users create user with already existing email (for example: `admin@example.com`). Error should display expected message

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
