### PR TITLE
feat: new opt in language for partners

### DIFF
--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -263,6 +263,8 @@
   "listings.lotteryDateQuestion": "When will the lottery be run?",
   "listings.lotteryEndTime": "Lottery End Time",
   "listings.lotteryOptInQuestion": "Will the lottery be run in the partner portal?",
+  "listings.lotteryOptInPartnerYes": "Your lottery will be run in the Partners Portal. If you want to make alternative arrangements, please contact staff.",
+  "listings.lotteryOptInPartnerNo": "This lottery will not be run in the Partners Portal because you have requested to use an alternative process. If this is an error, please contact staff.",
   "listings.lotteryPreferenceSubtitle": "Sort preferences to establish the order in which questions will appear in the application. This is how ranked buckets will appear in the lottery export file.",
   "listings.lotteryStartTime": "Lottery Start Time",
   "listings.lotteryTitle": "Lottery",

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -367,7 +367,10 @@ const ListingForm = ({ listing, editMode }: ListingFormProps) => {
                           </div>
                         </Tabs.TabPanel>
                         <Tabs.TabPanel>
-                          <RankingsAndResults listing={listing} />
+                          <RankingsAndResults
+                            listing={listing}
+                            isAdmin={profile?.userRoles.isAdmin}
+                          />
                           <LeasingAgent />
                           <ApplicationTypes listing={listing} />
                           <ApplicationAddress listing={listing} />

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -16,9 +16,10 @@ import SectionWithGrid from "../../../shared/SectionWithGrid"
 
 type RankingsAndResultsProps = {
   listing?: FormListing
+  isAdmin?: boolean
 }
 
-const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
+const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
   const formMethods = useFormContext()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -120,31 +121,48 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
         {reviewOrder === "reviewOrderLottery" && (
           <>
             {process.env.showLottery && (
-              <Grid.Row columns={2} className={"flex items-center"}>
-                <Grid.Cell>
-                  <p className={`field-label m-4 ml-0`}>{t("listings.lotteryOptInQuestion")}</p>
-                  <FieldGroup
-                    name="lotteryOptInQuestion"
-                    type="radio"
-                    register={register}
-                    fields={[
-                      {
-                        ...yesNoRadioOptions[0],
-                        id: "lotteryOptInYes",
-                        defaultChecked:
-                          !listing || listing.lotteryOptIn === true || !listing.lotteryOptIn,
-                      },
+              <>
+                {isAdmin ? (
+                  <Grid.Row columns={2} className={"flex items-center"}>
+                    <Grid.Cell>
+                      <p className={`field-label m-4 ml-0`}>{t("listings.lotteryOptInQuestion")}</p>
+                      <FieldGroup
+                        name="lotteryOptInQuestion"
+                        type="radio"
+                        register={register}
+                        fields={[
+                          {
+                            ...yesNoRadioOptions[0],
+                            id: "lotteryOptInYes",
+                            defaultChecked:
+                              !listing ||
+                              listing.lotteryOptIn === true ||
+                              listing.lotteryOptIn === null,
+                          },
 
-                      {
-                        ...yesNoRadioOptions[1],
-                        id: "lotteryOptInNo",
-                        defaultChecked: listing && listing.lotteryOptIn === false,
-                      },
-                    ]}
-                  />
-                </Grid.Cell>
-              </Grid.Row>
+                          {
+                            ...yesNoRadioOptions[1],
+                            id: "lotteryOptInNo",
+                            defaultChecked: listing && listing.lotteryOptIn === false,
+                          },
+                        ]}
+                      />
+                    </Grid.Cell>
+                  </Grid.Row>
+                ) : (
+                  <Grid.Row columns={2}>
+                    <Grid.Cell>
+                      <p className={"field-note -mt-6"}>
+                        {!listing || listing.lotteryOptIn === true || listing.lotteryOptIn === null
+                          ? t("listings.lotteryOptInPartnerYes")
+                          : t("listings.lotteryOptInPartnerNo")}
+                      </p>
+                    </Grid.Cell>
+                  </Grid.Row>
+                )}
+              </>
             )}
+
             <Grid.Row columns={3}>
               <Grid.Cell>
                 <DateField

--- a/sites/partners/src/lib/listings/AdditionalMetadataFormatter.ts
+++ b/sites/partners/src/lib/listings/AdditionalMetadataFormatter.ts
@@ -63,6 +63,8 @@ export default class AdditionalMetadataFormatter extends Formatter {
 
     if (this.data.reviewOrderType !== ReviewOrderTypeEnum.lottery) {
       this.data.lotteryOptIn = null
+    } else {
+      if (this.data.lotteryOptIn === null) delete this.data.lotteryOptIn
     }
 
     if (this.data.listingAvailabilityQuestion === "openWaitlist") {


### PR DESCRIPTION
This PR addresses #4221

- [x] Addresses the issue in full

## Description

Only admins can now opt in / out of the system lottery. A partner will just see explanatory text that they are opted in / out.

## How Can This Be Tested/Reviewed?

As an admin, create a listing that opts in to the lottery and view the listing as a partner to see the opt in text. Do the same for opting out. Save changes in both states as a partner to ensure the partner user is not able to update the value.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes (https://github.com/bloom-housing/bloom/issues/4206)
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
