### PR TITLE
feat: require lottery date time fields

### DIFF
--- a/api/src/dtos/listings/listing-update.dto.ts
+++ b/api/src/dtos/listings/listing-update.dto.ts
@@ -14,7 +14,7 @@ import { AddressCreate } from '../addresses/address-create.dto';
 import { ListingEventCreate } from './listing-event-create.dto';
 import { ListingFeatures } from './listing-feature.dto';
 import { ListingUtilities } from './listing-utility.dto';
-import { LotteryDateParamValidator } from 'src/utilities/lottery-date-validator';
+import { LotteryDateParamValidator } from '../../utilities/lottery-date-validator';
 
 export class ListingUpdate extends OmitType(Listing, [
   // fields get their type changed

--- a/api/src/dtos/listings/listing-update.dto.ts
+++ b/api/src/dtos/listings/listing-update.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
-import { IsDefined, ValidateNested } from 'class-validator';
+import { IsDefined, Validate, ValidateNested } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 import { IdDTO } from '../shared/id.dto';
@@ -14,6 +14,7 @@ import { AddressCreate } from '../addresses/address-create.dto';
 import { ListingEventCreate } from './listing-event-create.dto';
 import { ListingFeatures } from './listing-feature.dto';
 import { ListingUtilities } from './listing-utility.dto';
+import { LotteryDateParamValidator } from 'src/utilities/lottery-date-validator';
 
 export class ListingUpdate extends OmitType(Listing, [
   // fields get their type changed
@@ -129,6 +130,9 @@ export class ListingUpdate extends OmitType(Listing, [
   listingsResult?: AssetCreate;
 
   @Expose()
+  @Validate(LotteryDateParamValidator, {
+    groups: [ValidationsGroupsEnum.default],
+  })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => ListingEventCreate)
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -38,7 +38,7 @@ import { IdDTO } from '../shared/id.dto';
 import { listingUrlSlug } from '../../utilities/listing-url-slug';
 import { User } from '../users/user.dto';
 import { requestedChangesUserMapper } from '../../utilities/requested-changes-user';
-import { LotteryDateParamValidator } from 'src/utilities/lottery-date-validator';
+import { LotteryDateParamValidator } from '../../utilities/lottery-date-validator';
 
 class Listing extends AbstractDTO {
   @Expose()

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -9,6 +9,7 @@ import {
   IsString,
   IsUrl,
   MaxLength,
+  Validate,
   ValidateNested,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -37,6 +38,7 @@ import { IdDTO } from '../shared/id.dto';
 import { listingUrlSlug } from '../../utilities/listing-url-slug';
 import { User } from '../users/user.dto';
 import { requestedChangesUserMapper } from '../../utilities/requested-changes-user';
+import { LotteryDateParamValidator } from 'src/utilities/lottery-date-validator';
 
 class Listing extends AbstractDTO {
   @Expose()
@@ -460,6 +462,9 @@ class Listing extends AbstractDTO {
   assets: Asset[];
 
   @Expose()
+  @Validate(LotteryDateParamValidator, {
+    groups: [ValidationsGroupsEnum.default],
+  })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => ListingEvent)
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/utilities/lottery-date-validator.ts
+++ b/api/src/utilities/lottery-date-validator.ts
@@ -1,0 +1,38 @@
+import {
+  ListingEventsTypeEnum,
+  ReviewOrderTypeEnum,
+  YesNoEnum,
+} from '@prisma/client';
+import {
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+} from 'class-validator';
+import { ListingEvent } from '../dtos/listings/listing-event.dto';
+
+/*
+    This is a custom validator to make sure lottery startDate is set when reviewOrder is set to lottery
+  */
+@ValidatorConstraint({ name: 'lotteryDate', async: false })
+export class LotteryDateParamValidator implements ValidatorConstraintInterface {
+  validate(
+    listingEvents: ListingEvent[] | undefined,
+    args: ValidationArguments,
+  ) {
+    const { reviewOrderType, lotteryOptIn } = args.object as {
+      reviewOrderType: string;
+      lotteryOptIn: boolean;
+    };
+    if (reviewOrderType === ReviewOrderTypeEnum.lottery && lotteryOptIn) {
+      return !!listingEvents.find(
+        (event: ListingEvent) =>
+          event.type === ListingEventsTypeEnum.publicLottery && event.startDate,
+      );
+    }
+    return true;
+  }
+
+  defaultMessage() {
+    return 'lotteryDate run date must be set';
+  }
+}

--- a/api/src/utilities/lottery-date-validator.ts
+++ b/api/src/utilities/lottery-date-validator.ts
@@ -26,7 +26,10 @@ export class LotteryDateParamValidator implements ValidatorConstraintInterface {
     if (reviewOrderType === ReviewOrderTypeEnum.lottery && lotteryOptIn) {
       return !!listingEvents.find(
         (event: ListingEvent) =>
-          event.type === ListingEventsTypeEnum.publicLottery && event.startDate,
+          event.type === ListingEventsTypeEnum.publicLottery &&
+          event.startDate &&
+          event.startTime &&
+          event.endTime,
       );
     }
     return true;

--- a/api/test/unit/utilities/lottery-date-validator.spec.ts
+++ b/api/test/unit/utilities/lottery-date-validator.spec.ts
@@ -54,7 +54,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startDate', () => {
+  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startDate', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -83,7 +83,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startTime', () => {
+  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startTime', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -112,7 +112,7 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without endTime', () => {
+  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without endTime', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(
@@ -148,6 +148,44 @@ describe('Testing OrderQueryParamValidator', () => {
         [
           {
             type: ListingEventsTypeEnum.publicLottery,
+            startDate: new Date(),
+            startTime: new Date(),
+            endTime: new Date(),
+            id: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        ],
+        {
+          property: 'listingEvents',
+          object: {
+            reviewOrderType: ReviewOrderTypeEnum.lottery,
+            lotteryOptIn: true,
+          },
+          value: undefined,
+          constraints: [],
+          targetName: '',
+        },
+      ),
+    ).toBeTruthy();
+  });
+
+  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has full publicLottery event and other events', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate(
+        [
+          {
+            type: ListingEventsTypeEnum.publicLottery,
+            startDate: new Date(),
+            startTime: new Date(),
+            endTime: new Date(),
+            id: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+          {
+            type: ListingEventsTypeEnum.openHouse,
             startDate: new Date(),
             startTime: new Date(),
             endTime: new Date(),

--- a/api/test/unit/utilities/lottery-date-validator.spec.ts
+++ b/api/test/unit/utilities/lottery-date-validator.spec.ts
@@ -54,7 +54,94 @@ describe('Testing OrderQueryParamValidator', () => {
     ).toBeFalsy();
   });
 
-  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery and startDate', () => {
+  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startDate', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate(
+        [
+          {
+            type: ListingEventsTypeEnum.publicLottery,
+            startDate: null,
+            startTime: new Date(),
+            endTime: new Date(),
+            id: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        ],
+        {
+          property: 'listingEvents',
+          object: {
+            reviewOrderType: ReviewOrderTypeEnum.lottery,
+            lotteryOptIn: true,
+          },
+          value: undefined,
+          constraints: [],
+          targetName: '',
+        },
+      ),
+    ).toBeFalsy();
+  });
+
+  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without startTime', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate(
+        [
+          {
+            type: ListingEventsTypeEnum.publicLottery,
+            startDate: new Date(),
+            startTime: null,
+            endTime: new Date(),
+            id: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        ],
+        {
+          property: 'listingEvents',
+          object: {
+            reviewOrderType: ReviewOrderTypeEnum.lottery,
+            lotteryOptIn: true,
+          },
+          value: undefined,
+          constraints: [],
+          targetName: '',
+        },
+      ),
+    ).toBeFalsy();
+  });
+
+  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery without endTime', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate(
+        [
+          {
+            type: ListingEventsTypeEnum.publicLottery,
+            startDate: new Date(),
+            startTime: new Date(),
+            endTime: null,
+            id: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        ],
+        {
+          property: 'listingEvents',
+          object: {
+            reviewOrderType: ReviewOrderTypeEnum.lottery,
+            lotteryOptIn: true,
+          },
+          value: undefined,
+          constraints: [],
+          targetName: '',
+        },
+      ),
+    ).toBeFalsy();
+  });
+
+  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has full publicLottery event', () => {
     const lotteryDateParamValidator = new LotteryDateParamValidator();
     expect(
       lotteryDateParamValidator.validate(

--- a/api/test/unit/utilities/lottery-date-validator.spec.ts
+++ b/api/test/unit/utilities/lottery-date-validator.spec.ts
@@ -1,0 +1,85 @@
+import {
+  ListingEventsTypeEnum,
+  ReviewOrderTypeEnum,
+  YesNoEnum,
+} from '@prisma/client';
+import { LotteryDateParamValidator } from '../../../src/utilities/lottery-date-validator';
+
+describe('Testing OrderQueryParamValidator', () => {
+  it('should return true if reviewOrderType is not lottery and lotteryOptIn is null', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate([], {
+        property: 'listingEvents',
+        object: {
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          lotteryOptIn: null,
+        },
+        value: undefined,
+        constraints: [],
+        targetName: '',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('should return true if reviewOrderType is lottery and lotteryOptIn is no', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate([], {
+        property: 'listingEvents',
+        object: {
+          reviewOrderType: ReviewOrderTypeEnum.lottery,
+          lotteryOptIn: false,
+        },
+        value: undefined,
+        constraints: [],
+        targetName: '',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('should return false if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents is empty', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate([], {
+        property: 'listingEvents',
+        object: {
+          reviewOrderType: ReviewOrderTypeEnum.lottery,
+          lotteryOptIn: true,
+        },
+        value: undefined,
+        constraints: [],
+        targetName: '',
+      }),
+    ).toBeFalsy();
+  });
+
+  it('should return true if reviewOrderType is lottery and lotteryOptIn is yes and listingEvents has publicLottery and startDate', () => {
+    const lotteryDateParamValidator = new LotteryDateParamValidator();
+    expect(
+      lotteryDateParamValidator.validate(
+        [
+          {
+            type: ListingEventsTypeEnum.publicLottery,
+            startDate: new Date(),
+            startTime: new Date(),
+            endTime: new Date(),
+            id: null,
+            createdAt: null,
+            updatedAt: null,
+          },
+        ],
+        {
+          property: 'listingEvents',
+          object: {
+            reviewOrderType: ReviewOrderTypeEnum.lottery,
+            lotteryOptIn: true,
+          },
+          value: undefined,
+          constraints: [],
+          targetName: '',
+        },
+      ),
+    ).toBeTruthy();
+  });
+});

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -43,13 +43,17 @@ const DetailRankingsAndResults = () => {
         <>
           <Grid.Row>
             <FieldValue id="lotteryEvent.startTime.date" label={t("listings.lotteryDateQuestion")}>
-              {dayjs(new Date(lotteryEvent?.startTime)).utc().format("MM/DD/YYYY")}
+              {dayjs(new Date(lotteryEvent?.startDate)).utc().format("MM/DD/YYYY")}
             </FieldValue>
             <FieldValue id="lotteryEvent.startTime.time" label={t("listings.lotteryStartTime")}>
-              {dayjs(new Date(lotteryEvent?.startTime)).format("hh:mm A")}
+              {lotteryEvent?.startTime
+                ? dayjs(new Date(lotteryEvent?.startTime)).format("hh:mm A")
+                : null}
             </FieldValue>
             <FieldValue id="lotteryEvent.lotteryEndTime.time" label={t("listings.lotteryEndTime")}>
-              {dayjs(new Date(lotteryEvent?.endTime)).format("hh:mm A")}
+              {lotteryEvent?.endTime
+                ? dayjs(new Date(lotteryEvent?.endTime)).format("hh:mm A")
+                : null}
             </FieldValue>
           </Grid.Row>
           <Grid.Row>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -163,17 +163,21 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
                       : null
                   }
                   errorMessage={t("errors.requiredFieldError")}
-                  defaultDate={{
-                    month: lotteryEvent?.startDate
-                      ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("MM")
-                      : null,
-                    day: lotteryEvent?.startDate
-                      ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("DD")
-                      : null,
-                    year: lotteryEvent?.startDate
-                      ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("YYYY")
-                      : null,
-                  }}
+                  defaultDate={
+                    errors?.lotteryDate
+                      ? null
+                      : {
+                          month: lotteryEvent?.startDate
+                            ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("MM")
+                            : null,
+                          day: lotteryEvent?.startDate
+                            ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("DD")
+                            : null,
+                          year: lotteryEvent?.startDate
+                            ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("YYYY")
+                            : null,
+                        }
+                  }
                 />
               </Grid.Cell>
               <Grid.Cell>
@@ -183,18 +187,26 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
                   id={"lotteryStartTime"}
                   register={register}
                   watch={watch}
-                  defaultValues={{
-                    hours: lotteryEvent?.startTime
-                      ? dayjs(new Date(lotteryEvent?.startTime)).format("hh")
-                      : null,
-                    minutes: lotteryEvent?.startTime
-                      ? dayjs(new Date(lotteryEvent?.startTime)).format("mm")
-                      : null,
-                    seconds: lotteryEvent?.startTime
-                      ? dayjs(new Date(lotteryEvent?.startTime)).format("ss")
-                      : null,
-                    period: new Date(lotteryEvent?.startTime).getHours() >= 12 ? "pm" : "am",
+                  error={errors?.lotteryDate ? true : false}
+                  strings={{
+                    timeError: errors?.lotteryDate ? t("errors.requiredFieldError") : null,
                   }}
+                  defaultValues={
+                    errors?.lotteryDate
+                      ? null
+                      : {
+                          hours: lotteryEvent?.startTime
+                            ? dayjs(new Date(lotteryEvent?.startTime)).format("hh")
+                            : null,
+                          minutes: lotteryEvent?.startTime
+                            ? dayjs(new Date(lotteryEvent?.startTime)).format("mm")
+                            : null,
+                          seconds: lotteryEvent?.startTime
+                            ? dayjs(new Date(lotteryEvent?.startTime)).format("ss")
+                            : null,
+                          period: new Date(lotteryEvent?.startTime).getHours() >= 12 ? "pm" : "am",
+                        }
+                  }
                 />
               </Grid.Cell>
               <Grid.Cell>
@@ -204,18 +216,26 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
                   id={"lotteryEndTime"}
                   register={register}
                   watch={watch}
-                  defaultValues={{
-                    hours: lotteryEvent?.endTime
-                      ? dayjs(new Date(lotteryEvent?.endTime)).format("hh")
-                      : null,
-                    minutes: lotteryEvent?.endTime
-                      ? dayjs(new Date(lotteryEvent?.endTime)).format("mm")
-                      : null,
-                    seconds: lotteryEvent?.endTime
-                      ? dayjs(new Date(lotteryEvent?.endTime)).format("ss")
-                      : null,
-                    period: new Date(lotteryEvent?.endTime).getHours() >= 12 ? "pm" : "am",
+                  error={errors?.lotteryDate ? true : false}
+                  strings={{
+                    timeError: errors?.lotteryDate ? t("errors.requiredFieldError") : null,
                   }}
+                  defaultValues={
+                    errors?.lotteryDate
+                      ? null
+                      : {
+                          hours: lotteryEvent?.endTime
+                            ? dayjs(new Date(lotteryEvent?.endTime)).format("hh")
+                            : null,
+                          minutes: lotteryEvent?.endTime
+                            ? dayjs(new Date(lotteryEvent?.endTime)).format("mm")
+                            : null,
+                          seconds: lotteryEvent?.endTime
+                            ? dayjs(new Date(lotteryEvent?.endTime)).format("ss")
+                            : null,
+                          period: new Date(lotteryEvent?.endTime).getHours() >= 12 ? "pm" : "am",
+                        }
+                  }
                 />
               </Grid.Cell>
             </Grid.Row>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -22,7 +22,7 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
   const formMethods = useFormContext()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, watch, control } = formMethods
+  const { register, watch, control, errors } = formMethods
 
   const lotteryEvent = getLotteryEvent(listing as unknown as Listing)
 
@@ -153,6 +153,16 @@ const RankingsAndResults = ({ listing }: RankingsAndResultsProps) => {
                   id={"lotteryDate"}
                   register={register}
                   watch={watch}
+                  error={
+                    errors?.lotteryDate
+                      ? {
+                          month: errors?.lotteryDate,
+                          day: errors?.lotteryDate,
+                          year: errors?.lotteryDate,
+                        }
+                      : null
+                  }
+                  errorMessage={t("errors.requiredFieldError")}
                   defaultDate={{
                     month: lotteryEvent?.startDate
                       ? dayjs(new Date(lotteryEvent?.startDate)).utc().format("MM")


### PR DESCRIPTION
This PR addresses [#(4212)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/4212)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When a listing has lottery selected and has opted in to our lottery system, the lottery start date, start time and end time fields should be required. When any of the 3 fields are not filled out, an error will appear on save and all 3 fields will be highlighted. 

## How Can This Be Tested/Reviewed?

Create or edit a listing in the partners portal.
Save with First Come First Serve selected. No errors should appear.
Edit and save with Lottery selected and No selected for optin. No errors should appear.
Edit and select Yes for optin. Do not fill out start date, start time and end time fields. Error should appear and fields should be highlighted. Cancel edit.
Edit and select Yes for optin. Fill out some but not all of the fields. Error should appear and fields should be highlighted. Cancel edit.
Edit and select Yes for optin. Fill out all of the fields. Save and no errors should appear.
Edit and remove one of the lottery date fields. Error should appear and fields should be highlighted. Cancel edit.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
