### PR TITLE
fix: lottery history log filtering

### DIFF
--- a/api/src/controllers/lottery.controller.ts
+++ b/api/src/controllers/lottery.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Header,
   Param,
+  ParseUUIDPipe,
   Put,
   Query,
   Request,
@@ -100,15 +101,16 @@ export class LotteryController {
     );
   }
 
-  @Get('lotteryActivityLog')
+  @Get('lotteryActivityLog/:id')
   @ApiOkResponse({ type: LotteryActivityLogItem, isArray: true })
   @ApiOperation({
     summary: 'Get a lottery activity log',
     operationId: 'lotteryActivityLog',
   })
+  @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
   async lotteryActivityLog(
     @Request() req: ExpressRequest,
-    @Param('id') id: string,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
   ): Promise<LotteryActivityLogItem[]> {
     return await this.lotteryService.lotteryActivityLog(
       id,

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2187,7 +2187,7 @@ export class LotteryService {
     options: IRequestOptions = {}
   ): Promise<LotteryActivityLogItem[]> {
     return new Promise((resolve, reject) => {
-      let url = basePath + "/lottery/lotteryActivityLog"
+      let url = basePath + "/lottery/lotteryActivityLog/{id}"
       url = url.replace("{id}", params["id"] + "")
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -45,9 +45,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { findByText } = render(<Lottery listing={undefined} />)
@@ -69,9 +72,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getAllByText, findByText } = render(<Lottery listing={closedListing} />)
@@ -95,9 +101,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getAllByText, findByText } = render(<Lottery listing={closedListing} />)
@@ -127,9 +136,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getAllByText, findByText } = render(<Lottery listing={closedListing} />)
@@ -159,9 +171,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { queryAllByText, queryByText } = render(<Lottery listing={closedListing} />)
@@ -189,9 +204,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getByText, findByText } = render(<Lottery listing={closedListing} />)
@@ -225,9 +243,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getByText, findByText } = render(
@@ -269,9 +290,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getByText, findByText } = render(
@@ -310,9 +334,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getByText, findByText } = render(
@@ -355,9 +382,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const lotteryLastRan = new Date()
@@ -404,9 +434,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getByText, findByText } = render(
@@ -449,9 +482,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 0 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getByText, findByText } = render(<Lottery listing={closedListing} />)
@@ -484,9 +520,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const { getByText, findByText } = render(<Lottery listing={closedListing} />)
@@ -518,9 +557,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const updatedListing = {
@@ -567,9 +609,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const updatedListing = {
@@ -620,9 +665,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const updatedListing = {
@@ -670,9 +718,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const updatedListing = {
@@ -709,9 +760,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const updatedListing = {
@@ -753,9 +807,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const updatedListing = {
@@ -790,9 +847,12 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(ctx.json([]))
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
     )
 
     const updatedListing = {
@@ -832,35 +892,42 @@ describe("lottery", () => {
       rest.get("http://localhost/api/adapter/applicationFlaggedSets/meta", (_req, res, ctx) => {
         return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
       }),
-      rest.get("http://localhost/api/adapter/lottery/lotteryActivityLog", (_req, res, ctx) => {
-        return res(
-          ctx.json([
-            { status: "closed", name: null, logDate: new Date("September 6, 2025 8:15:00") },
-            { status: "ran", name: "Admin One", logDate: new Date("September 6, 2025 9:00:00") },
-            { status: "rerun", name: "Admin Two", logDate: new Date("September 6, 2025 9:30:00") },
-            {
-              status: "releasedToPartners",
-              name: "Admin Three",
-              logDate: new Date("September 7, 2025 13:00:00"),
-            },
-            {
-              status: "retracted",
-              name: "Admin Four",
-              logDate: new Date("September 7, 2025 14:00:00"),
-            },
-            {
-              status: "releasedToPartners",
-              name: "Admin Five",
-              logDate: new Date("September 7, 2025 15:00:00"),
-            },
-            {
-              status: "publishedToPublic",
-              name: "Partner One",
-              logDate: new Date("September 8, 2025 9:00:00"),
-            },
-          ])
-        )
-      })
+      rest.get(
+        "http://localhost/api/adapter/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(
+            ctx.json([
+              { status: "closed", name: null, logDate: new Date("September 6, 2025 8:15:00") },
+              { status: "ran", name: "Admin One", logDate: new Date("September 6, 2025 9:00:00") },
+              {
+                status: "rerun",
+                name: "Admin Two",
+                logDate: new Date("September 6, 2025 9:30:00"),
+              },
+              {
+                status: "releasedToPartners",
+                name: "Admin Three",
+                logDate: new Date("September 7, 2025 13:00:00"),
+              },
+              {
+                status: "retracted",
+                name: "Admin Four",
+                logDate: new Date("September 7, 2025 14:00:00"),
+              },
+              {
+                status: "releasedToPartners",
+                name: "Admin Five",
+                logDate: new Date("September 7, 2025 15:00:00"),
+              },
+              {
+                status: "publishedToPublic",
+                name: "Partner One",
+                logDate: new Date("September 8, 2025 9:00:00"),
+              },
+            ])
+          )
+        }
+      )
     )
 
     const updatedListing = {

--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -619,9 +619,9 @@ export function useMapLayersList(jurisdictionId?: string) {
 
 export function useLotteryActivityLog(listingId: string) {
   const { lotteryService } = useContext(AuthContext)
-  const fetcher = () => lotteryService.lotteryActivityLog({ id: listingId })
+  const fetcher = () => listingId && lotteryService.lotteryActivityLog({ id: listingId })
 
-  const { data, error } = useSWR(`/api/adapter/lottery/lotteryActivityLog`, fetcher)
+  const { data, error } = useSWR(`/api/adapter/lottery/lotteryActivityLog/${listingId}`, fetcher)
 
   return {
     lotteryActivityLogData: data,


### PR DESCRIPTION
This PR addresses #4253

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Lottery history logs are not currently filtering by ID. The issue was that the listing ID wasn't actually getting passed through to the endpoint and was coming in as undefined.

## How Can This Be Tested/Reviewed?

Create two listings and take lottery actions on each of them. Ensure their history logs only reflect the actions that were taken on that listing.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
