### PR TITLE
fix: update zip length requirement and error messaging

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -516,7 +516,7 @@
   "errors.householdTooBig": "El número de miembros de su hogar es demasiado alto.",
   "errors.householdTooSmall": "El número de miembros de su hogar es demasiado bajo.",
   "errors.lastNameError": "Por favor ingrese un apellido",
-  "errors.maxLength": "No debe tener más de 64 caracteres.",
+  "errors.maxLength": "No debe tener más de %{length} caracteres.",
   "errors.notFound.message": "Me temo que no podemos encontrar la página que está buscando. Intente regresar a la página anterior o haga clic abajo para ver listados.",
   "errors.notFound.title": "No se encontró la página",
   "errors.numberError": "Por favor ingrese un número válido mayor a 0.",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -507,7 +507,7 @@
   "errors.householdTooBig": "Your household size is too big.",
   "errors.householdTooSmall": "Your household size is too small.",
   "errors.lastNameError": "Please enter a Last Name",
-  "errors.maxLength": "Must not be more than 64 characters.",
+  "errors.maxLength": "Must not be more than %{length} characters.",
   "errors.notFound.message": "Uh oh, we can’t seem to find the page you’re looking for. Try going back to the previous page or click below to browse listings.",
   "errors.notFound.title": "Page Not Found",
   "errors.numberError": "Please enter a valid number greater than 0.",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -516,7 +516,7 @@
   "errors.householdTooBig": "Napakalaki ng iyong sambahayan.",
   "errors.householdTooSmall": "Napakaliit ng iyong sambahayan.",
   "errors.lastNameError": "Pakilagay ang  Apelyido",
-  "errors.maxLength": "Hindi dapat higit sa 64 na character.",
+  "errors.maxLength": "Hindi dapat higit sa %{length} na character.",
   "errors.notFound.message": "Sori, mukhang hindi namin makita ang page na hinahanap mo. Pakisubukang bumalik sa dating page o mag-click sa ibaba para mag-browse ng mga listahan.",
   "errors.notFound.title": "Hindi Nahanap ang Page",
   "errors.numberError": "Pakilagay ang tamang numero na mas malaki sa 0.",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -516,7 +516,7 @@
   "errors.householdTooBig": "Quy mô hộ gia đình của quý vị quá lớn.",
   "errors.householdTooSmall": "Quy mô hộ gia đình của quý vị quá nhỏ.",
   "errors.lastNameError": "Vui lòng nhập Họ",
-  "errors.maxLength": "Không được nhiều hơn 64 ký tự.",
+  "errors.maxLength": "Không được nhiều hơn %{length} ký tự.",
   "errors.notFound.message": "Rất tiếc, chúng tôi dường như không thể tìm thấy trang quý vị đang tìm kiếm. Hãy thử quay lại trang trước hoặc nhấp vào bên dưới để duyệt các danh sách nhà.",
   "errors.notFound.title": "Không Tìm thấy Trang",
   "errors.numberError": "Vui lòng nhập một số hợp lệ lớn hơn 0.",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -516,7 +516,7 @@
   "errors.householdTooBig": "您的家庭人數過多。",
   "errors.householdTooSmall": "您的家庭人數過少。",
   "errors.lastNameError": "請輸入姓氏",
-  "errors.maxLength": "不得超过 64 个字符",
+  "errors.maxLength": "不得超过 %{length} 个字符",
   "errors.notFound.message": "嗯，我們似乎找不到您要的網頁。請嘗試返回上一頁，或點擊下面以瀏覽上市名單。",
   "errors.notFound.title": "找不到網頁",
   "errors.numberError": "請輸入一個大於 0 的有效數字。",

--- a/shared-helpers/src/views/address/FormAddressAlternate.tsx
+++ b/shared-helpers/src/views/address/FormAddressAlternate.tsx
@@ -31,7 +31,7 @@ export const FormAddressAlternate = ({
         validation={{ required: true, maxLength: 64 }}
         errorMessage={
           resolveObject(`${dataKey}.street`, errors)?.type === "maxLength"
-            ? t("errors.maxLength")
+            ? t("errors.maxLength", { length: 64 })
             : t("errors.streetError")
         }
         error={!!resolveObject(`${dataKey}.street`, errors)}
@@ -46,7 +46,7 @@ export const FormAddressAlternate = ({
         register={register}
         error={!!resolveObject(`${dataKey}.street2`, errors)}
         validation={{ maxLength: 64 }}
-        errorMessage={t("errors.maxLength")}
+        errorMessage={t("errors.maxLength", { length: 64 })}
       />
 
       <div className="flex">
@@ -59,7 +59,7 @@ export const FormAddressAlternate = ({
           error={!!resolveObject(`${dataKey}.city`, errors)}
           errorMessage={
             resolveObject(`${dataKey}.city`, errors)?.type === "maxLength"
-              ? t("errors.maxLength")
+              ? t("errors.maxLength", { length: 64 })
               : t("errors.cityError")
           }
           dataTestId="address-city"
@@ -73,7 +73,7 @@ export const FormAddressAlternate = ({
           error={!!resolveObject(`${dataKey}.state`, errors)}
           errorMessage={
             resolveObject(`${dataKey}.state`, errors)?.type === "maxLength"
-              ? t("errors.maxLength")
+              ? t("errors.maxLength", { length: 64 })
               : t("errors.stateError")
           }
           register={register}
@@ -88,11 +88,11 @@ export const FormAddressAlternate = ({
         name={`${dataKey}.zipCode`}
         label={t("application.contact.zip")}
         register={register}
-        validation={{ required, maxLength: 64 }}
+        validation={{ required, maxLength: 10 }}
         error={!!resolveObject(`${dataKey}.zipCode`, errors)}
         errorMessage={
           resolveObject(`${dataKey}.zipCode`, errors)?.type === "maxLength"
-            ? t("errors.maxLength")
+            ? t("errors.maxLength", { length: 10 })
             : t("errors.zipCodeError")
         }
         dataTestId="address-zipcode"

--- a/shared-helpers/src/views/multiselectQuestions.tsx
+++ b/shared-helpers/src/views/multiselectQuestions.tsx
@@ -258,7 +258,7 @@ export const multiselectOptionWrapper = (
           error={!!resolveObject(`${optionFieldName}-${AddressHolder.Name}`, errors)}
           errorMessage={
             resolveObject(`${optionFieldName}-${AddressHolder.Name}`, errors)?.type === "maxLength"
-              ? t("errors.maxLength")
+              ? t("errors.maxLength", { length: 64 })
               : t("errors.requiredFieldError")
           }
           dataTestId="addressHolder-name"
@@ -275,7 +275,7 @@ export const multiselectOptionWrapper = (
           errorMessage={
             resolveObject(`${optionFieldName}-${AddressHolder.Relationship}`, errors)?.type ===
             "maxLength"
-              ? t("errors.maxLength")
+              ? t("errors.maxLength", { length: 64 })
               : t("errors.requiredFieldError")
           }
           dataTestId="addressHolder-relationship"

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -111,7 +111,7 @@ const FormMultiselectQuestions = ({
             errorMessage={
               resolveObject(`${optionFieldName}-${AddressHolder.Name}`, errors)?.type ===
               "maxLength"
-                ? t("errors.maxLength")
+                ? t("errors.maxLength", { length: 64 })
                 : t("errors.requiredFieldError")
             }
           />
@@ -127,7 +127,7 @@ const FormMultiselectQuestions = ({
             errorMessage={
               resolveObject(`${optionFieldName}-${AddressHolder.Relationship}`, errors)?.type ===
               "maxLength"
-                ? t("errors.maxLength")
+                ? t("errors.maxLength", { length: 64 })
                 : t("errors.requiredFieldError")
             }
           />

--- a/sites/public/src/pages/account/edit.tsx
+++ b/sites/public/src/pages/account/edit.tsx
@@ -249,7 +249,7 @@ const Edit = () => {
                     validation={{ maxLength: 64 }}
                     errorMessage={
                       nameErrors.firstName?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.firstNameError")
                     }
                     register={nameRegister}
@@ -265,7 +265,7 @@ const Edit = () => {
                     label={t("application.name.middleNameOptional")}
                     error={nameErrors.middleName}
                     validation={{ maxLength: 64 }}
-                    errorMessage={t("errors.maxLength")}
+                    errorMessage={t("errors.maxLength", { length: 64 })}
                     dataTestId={"account-middle-name"}
                   />
 
@@ -280,7 +280,7 @@ const Edit = () => {
                     validation={{ maxLength: 64 }}
                     errorMessage={
                       nameErrors.lastName?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.lastNameError")
                     }
                     dataTestId={"account-last-name"}

--- a/sites/public/src/pages/applications/contact/address.tsx
+++ b/sites/public/src/pages/applications/contact/address.tsx
@@ -302,7 +302,7 @@ const ApplicationAddress = () => {
                   validation={{ required: true, maxLength: 64 }}
                   errorMessage={
                     errors.applicant?.address?.street?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 64 })
                       : t("errors.streetError")
                   }
                   error={errors.applicant?.applicantAddress?.street}
@@ -319,7 +319,7 @@ const ApplicationAddress = () => {
                   dataTestId={"app-primary-address-street2"}
                   error={errors.applicant?.applicantAddress?.street2}
                   validation={{ maxLength: 64 }}
-                  errorMessage={t("errors.maxLength")}
+                  errorMessage={t("errors.maxLength", { length: 64 })}
                 />
 
                 <div className="flex max-w-2xl">
@@ -331,7 +331,7 @@ const ApplicationAddress = () => {
                     validation={{ required: true, maxLength: 64 }}
                     errorMessage={
                       errors.applicant?.address?.city?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.cityError")
                     }
                     error={errors.applicant?.applicantAddress?.city}
@@ -347,7 +347,7 @@ const ApplicationAddress = () => {
                     error={errors.applicant?.applicantAddress?.state}
                     errorMessage={
                       errors.applicant?.applicantAddress?.state?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.stateError")
                     }
                     register={register}
@@ -362,10 +362,10 @@ const ApplicationAddress = () => {
                   name="applicant.applicantAddress.zipCode"
                   label={t("application.contact.zip")}
                   defaultValue={application.applicant.applicantAddress.zipCode}
-                  validation={{ required: true, maxLength: 64 }}
+                  validation={{ required: true, maxLength: 10 }}
                   errorMessage={
                     errors.applicant?.applicantAddress?.zipCode?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 10 })
                       : t("errors.zipCodeError")
                   }
                   error={errors.applicant?.applicantAddress?.zipCode}
@@ -407,7 +407,7 @@ const ApplicationAddress = () => {
                     error={errors.applicationsMailingAddress?.street}
                     errorMessage={
                       errors.applicationsMailingAddress?.street?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.streetError")
                     }
                     register={register}
@@ -423,7 +423,7 @@ const ApplicationAddress = () => {
                     dataTestId={"app-primary-mailing-address-street2"}
                     validation={{ maxLength: 64 }}
                     error={errors.applicationsMailingAddress?.street2}
-                    errorMessage={t("errors.maxLength")}
+                    errorMessage={t("errors.maxLength", { length: 64 })}
                   />
 
                   <div className="flex max-w-2xl">
@@ -436,7 +436,7 @@ const ApplicationAddress = () => {
                       error={errors.applicationsMailingAddress?.city}
                       errorMessage={
                         errors.applicationsMailingAddress?.city?.type === "maxLength"
-                          ? t("errors.maxLength")
+                          ? t("errors.maxLength", { length: 64 })
                           : t("errors.cityError")
                       }
                       register={register}
@@ -451,7 +451,7 @@ const ApplicationAddress = () => {
                       validation={{ required: true, maxLength: 64 }}
                       errorMessage={
                         errors.applicationsMailingAddress?.state?.type === "maxLength"
-                          ? t("errors.maxLength")
+                          ? t("errors.maxLength", { length: 64 })
                           : t("errors.stateError")
                       }
                       error={errors.applicationsMailingAddress?.state}
@@ -468,11 +468,11 @@ const ApplicationAddress = () => {
                     name="applicationsMailingAddress.zipCode"
                     label={t("application.contact.zip")}
                     defaultValue={application.applicationsMailingAddress.zipCode}
-                    validation={{ required: true, maxLength: 64 }}
+                    validation={{ required: true, maxLength: 10 }}
                     error={errors.applicationsMailingAddress?.zipCode}
                     errorMessage={
                       errors.applicationsMailingAddress?.zipCode?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 10 })
                         : t("errors.zipCodeError")
                     }
                     register={register}
@@ -571,7 +571,7 @@ const ApplicationAddress = () => {
                       error={errors.applicant?.applicantWorkAddress?.street}
                       errorMessage={
                         errors.applicant?.applicantWorkAddress?.street?.type === "maxLength"
-                          ? t("errors.maxLength")
+                          ? t("errors.maxLength", { length: 64 })
                           : t("errors.streetError")
                       }
                       register={register}
@@ -601,7 +601,7 @@ const ApplicationAddress = () => {
                         error={errors.applicant?.applicantWorkAddress?.city}
                         errorMessage={
                           errors.applicant?.applicantWorkAddress?.city?.type === "maxLength"
-                            ? t("errors.maxLength")
+                            ? t("errors.maxLength", { length: 64 })
                             : t("errors.cityError")
                         }
                         register={register}
@@ -617,7 +617,7 @@ const ApplicationAddress = () => {
                         error={errors.applicant?.applicantWorkAddress?.state}
                         errorMessage={
                           errors.applicant?.applicantWorkAddress?.state?.type === "maxLength"
-                            ? t("errors.maxLength")
+                            ? t("errors.maxLength", { length: 64 })
                             : t("errors.stateError")
                         }
                         register={register}
@@ -633,11 +633,11 @@ const ApplicationAddress = () => {
                       name="applicant.applicantWorkAddress.zipCode"
                       label={t("application.contact.zip")}
                       defaultValue={application.applicant.applicantWorkAddress.zipCode}
-                      validation={{ required: true, maxLength: 64 }}
+                      validation={{ required: true, maxLength: 10 }}
                       error={errors.applicant?.applicantWorkAddress?.zipCode}
                       errorMessage={
                         errors.applicant?.applicantWorkAddress?.zipCode?.type === "maxLength"
-                          ? t("errors.maxLength")
+                          ? t("errors.maxLength", { length: 10 })
                           : t("errors.zipCodeError")
                       }
                       register={register}

--- a/sites/public/src/pages/applications/contact/alternate-contact-contact.tsx
+++ b/sites/public/src/pages/applications/contact/alternate-contact-contact.tsx
@@ -136,7 +136,7 @@ const ApplicationAlternateContactContact = () => {
                 dataTestId={"app-alternate-mailing-address-street"}
                 error={errors.mailingAddress?.street}
                 validation={{ maxLength: 64 }}
-                errorMessage={t("errors.maxLength")}
+                errorMessage={t("errors.maxLength", { length: 64 })}
               />
               <Field
                 id="mailingAddress.street2"
@@ -147,7 +147,7 @@ const ApplicationAlternateContactContact = () => {
                 defaultValue={application.alternateContact.address.street2}
                 error={errors.mailingAddress?.street2}
                 validation={{ maxLength: 64 }}
-                errorMessage={t("errors.maxLength")}
+                errorMessage={t("errors.maxLength", { length: 64 })}
               />
               <div className="flex max-w-2xl">
                 <Field
@@ -159,7 +159,7 @@ const ApplicationAlternateContactContact = () => {
                   dataTestId={"app-alternate-mailing-address-city"}
                   error={errors.mailingAddress?.city}
                   validation={{ maxLength: 64 }}
-                  errorMessage={t("errors.maxLength")}
+                  errorMessage={t("errors.maxLength", { length: 64 })}
                 />
 
                 <Select
@@ -174,7 +174,7 @@ const ApplicationAlternateContactContact = () => {
                   dataTestId={"app-alternate-mailing-address-state"}
                   error={errors.mailingAddress?.state}
                   validation={{ maxLength: 64 }}
-                  errorMessage={t("errors.maxLength")}
+                  errorMessage={t("errors.maxLength", { length: 64 })}
                 />
               </div>
               <Field
@@ -185,8 +185,8 @@ const ApplicationAlternateContactContact = () => {
                 register={register}
                 dataTestId={"app-alternate-mailing-address-zip"}
                 error={errors.mailingAddress?.zipCode}
-                validation={{ maxLength: 64 }}
-                errorMessage={t("errors.maxLength")}
+                validation={{ maxLength: 10 }}
+                errorMessage={t("errors.maxLength", { length: 10 })}
               />
             </fieldset>
           </CardSection>

--- a/sites/public/src/pages/applications/contact/alternate-contact-name.tsx
+++ b/sites/public/src/pages/applications/contact/alternate-contact-name.tsx
@@ -81,7 +81,7 @@ const ApplicationAlternateContactName = () => {
                 validation={{ required: true, maxLength: 64 }}
                 errorMessage={
                   errors.firstName?.type === "maxLength"
-                    ? t("errors.maxLength")
+                    ? t("errors.maxLength", { length: 64 })
                     : t("errors.givenNameError")
                 }
                 error={errors.firstName}
@@ -97,7 +97,7 @@ const ApplicationAlternateContactName = () => {
                 error={errors.lastName}
                 errorMessage={
                   errors.lastName?.type === "maxLength"
-                    ? t("errors.maxLength")
+                    ? t("errors.maxLength", { length: 64 })
                     : t("errors.familyNameError")
                 }
                 register={register}

--- a/sites/public/src/pages/applications/contact/alternate-contact-type.tsx
+++ b/sites/public/src/pages/applications/contact/alternate-contact-type.tsx
@@ -115,7 +115,7 @@ const ApplicationAlternateContactType = () => {
                         error={errors.otherType}
                         errorMessage={
                           errors.otherType?.type === "maxLength"
-                            ? t("errors.maxLength")
+                            ? t("errors.maxLength", { length: 64 })
                             : t("application.alternateContact.type.otherTypeValidationErrorMessage")
                         }
                         register={register}

--- a/sites/public/src/pages/applications/contact/name.tsx
+++ b/sites/public/src/pages/applications/contact/name.tsx
@@ -113,7 +113,7 @@ const ApplicationName = () => {
                   error={errors.applicant?.firstName}
                   errorMessage={
                     errors.applicant?.firstName?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 64 })
                       : t("errors.givenNameError")
                   }
                   register={register}
@@ -129,7 +129,7 @@ const ApplicationName = () => {
                   dataTestId={"app-primary-middle-name"}
                   validation={{ maxLength: 64 }}
                   error={errors.applicant?.middleName}
-                  errorMessage={t("errors.maxLength")}
+                  errorMessage={t("errors.maxLength", { length: 64 })}
                 />
 
                 <Field
@@ -141,7 +141,7 @@ const ApplicationName = () => {
                   error={errors.applicant?.lastName}
                   errorMessage={
                     errors.applicant?.lastName?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 64 })
                       : t("errors.familyNameError")
                   }
                   register={register}

--- a/sites/public/src/pages/applications/household/member.tsx
+++ b/sites/public/src/pages/applications/household/member.tsx
@@ -208,7 +208,7 @@ const ApplicationMember = () => {
                 error={errors.firstName}
                 errorMessage={
                   errors.firstName?.type === "maxLength"
-                    ? t("errors.maxLength")
+                    ? t("errors.maxLength", { length: 64 })
                     : t("errors.givenNameError")
                 }
                 register={register}
@@ -222,7 +222,7 @@ const ApplicationMember = () => {
                 defaultValue={member.middleName}
                 validation={{ maxLength: 64 }}
                 error={errors.middleName}
-                errorMessage={t("errors.maxLength")}
+                errorMessage={t("errors.maxLength", { length: 64 })}
                 register={register}
                 dataTestId={"app-household-member-middle-name"}
               />
@@ -236,7 +236,7 @@ const ApplicationMember = () => {
                 error={errors.lastName}
                 errorMessage={
                   errors.lastName?.type === "maxLength"
-                    ? t("errors.maxLength")
+                    ? t("errors.maxLength", { length: 64 })
                     : t("errors.familyNameError")
                 }
                 register={register}
@@ -291,7 +291,7 @@ const ApplicationMember = () => {
                   validation={{ required: true, maxLength: 64 }}
                   errorMessage={
                     errors.householdMemberAddress?.street?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 64 })
                       : t("errors.streetError")
                   }
                   error={errors.householdMemberAddress?.street}
@@ -307,7 +307,7 @@ const ApplicationMember = () => {
                   defaultValue={member.householdMemberAddress.street2}
                   error={errors.householdMemberAddress?.street2}
                   validation={{ maxLength: 64 }}
-                  errorMessage={t("errors.maxLength")}
+                  errorMessage={t("errors.maxLength", { length: 64 })}
                   register={register}
                   dataTestId={"app-household-member-address-street2"}
                 />
@@ -321,7 +321,7 @@ const ApplicationMember = () => {
                     validation={{ required: true, maxLength: 64 }}
                     errorMessage={
                       errors.householdMemberAddress?.city?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.cityError")
                     }
                     error={errors.householdMemberAddress?.city}
@@ -338,7 +338,7 @@ const ApplicationMember = () => {
                     error={errors.householdMemberAddress?.state}
                     errorMessage={
                       errors.householdMemberAddress?.state?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.stateError")
                     }
                     register={register}
@@ -354,11 +354,11 @@ const ApplicationMember = () => {
                   name="householdMemberAddress.zipCode"
                   label={t("application.contact.zip")}
                   defaultValue={member.householdMemberAddress.zipCode}
-                  validation={{ required: true, maxLength: 64 }}
+                  validation={{ required: true, maxLength: 10 }}
                   error={errors.householdMemberAddress?.zipCode}
                   errorMessage={
                     errors.address?.householdMemberAddress?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 10 })
                       : t("errors.zipCodeError")
                   }
                   register={register}
@@ -403,7 +403,7 @@ const ApplicationMember = () => {
                   error={errors.householdMemberWorkAddress?.street}
                   errorMessage={
                     errors.householdMemberWorkAddress?.street?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 64 })
                       : t("errors.streetError")
                   }
                   register={register}
@@ -416,7 +416,7 @@ const ApplicationMember = () => {
                   label={t("application.contact.apt")}
                   defaultValue={member.householdMemberWorkAddress.street2}
                   error={errors.householdMemberWorkAddress?.street2}
-                  errorMessage={t("errors.maxLength")}
+                  errorMessage={t("errors.maxLength", { length: 64 })}
                   validation={{ maxLength: 64 }}
                   register={register}
                   dataTestId={"app-household-member-work-address-street2"}
@@ -432,7 +432,7 @@ const ApplicationMember = () => {
                     error={errors.householdMemberWorkAddress?.city}
                     errorMessage={
                       errors.householdMemberWorkAddress?.city?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.cityError")
                     }
                     register={register}
@@ -448,7 +448,7 @@ const ApplicationMember = () => {
                     error={errors.householdMemberWorkAddress?.state}
                     errorMessage={
                       errors.householdMemberWorkAddress?.state?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.stateError")
                     }
                     register={register}
@@ -464,11 +464,11 @@ const ApplicationMember = () => {
                   name="householdMemberWorkAddress.zipCode"
                   label={t("application.contact.zip")}
                   defaultValue={member.householdMemberWorkAddress.zipCode}
-                  validation={{ required: true, maxLength: 64 }}
+                  validation={{ required: true, maxLength: 10 }}
                   error={errors.householdMemberWorkAddress?.zipCode}
                   errorMessage={
                     errors.householdMemberWorkAddress?.zipCode?.type === "maxLength"
-                      ? t("errors.maxLength")
+                      ? t("errors.maxLength", { length: 10 })
                       : t("errors.zipCodeError")
                   }
                   register={register}

--- a/sites/public/src/pages/create-account.tsx
+++ b/sites/public/src/pages/create-account.tsx
@@ -129,7 +129,7 @@ export default () => {
                     error={errors.givenName}
                     errorMessage={
                       errors.givenName?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.firstNameError")
                     }
                     register={register}
@@ -143,7 +143,7 @@ export default () => {
                     register={register}
                     error={errors.middleName}
                     validation={{ maxLength: 64 }}
-                    errorMessage={t("errors.maxLength")}
+                    errorMessage={t("errors.maxLength", { length: 64 })}
                     controlClassName={styles["create-account-input"]}
                   />
 
@@ -157,7 +157,7 @@ export default () => {
                     register={register}
                     errorMessage={
                       errors.lastName?.type === "maxLength"
-                        ? t("errors.maxLength")
+                        ? t("errors.maxLength", { length: 64 })
                         : t("errors.lastNameError")
                     }
                     controlClassName={styles["create-account-input"]}


### PR DESCRIPTION
This PR addresses #4260 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the length validation on Zip Code fields to be 10 which matches the verify endpoint length. This also updates the error message be take in the length rather than hardcoding 64 characters.

## How Can This Be Tested/Reviewed?

This can be tested by attempting to fill out the application and zip code field with more than 10 characters and seeing the appropriate error message.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
