### PR TITLE
fix: remove db dependency from unit tests

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "~29.6.2",
     "jest-environment-jsdom": "~29.6.2",
+    "jest-mock-extended": "2.0.4",
     "prettier": "^2.3.2",
     "source-map-support": "~0.5.20",
     "supertest": "^6.1.3",

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -35,19 +35,22 @@ export class ScriptRunnerService {
   async dataTransfer(
     req: ExpressRequest,
     dataTransferDTO: DataTransferDTO,
+    prisma?: PrismaClient,
   ): Promise<SuccessDTO> {
     // script runner standard start up
     const requestingUser = mapTo(User, req['user']);
     await this.markScriptAsRunStart('data transfer', requestingUser);
 
     // connect to foreign db based on incoming connection string
-    const client = new PrismaClient({
-      datasources: {
-        db: {
-          url: dataTransferDTO.connectionString,
+    const client =
+      prisma ||
+      new PrismaClient({
+        datasources: {
+          db: {
+            url: dataTransferDTO.connectionString,
+          },
         },
-      },
-    });
+      });
     await client.$connect();
 
     // get data

--- a/api/test/unit/services/application.service.spec.ts
+++ b/api/test/unit/services/application.service.spec.ts
@@ -695,6 +695,7 @@ describe('Testing application service', () => {
     prisma.applications.findFirst = jest.fn().mockResolvedValue({
       id: 'example id',
     });
+    prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
 
     const params: ApplicationQueryParams = {
       orderBy: ApplicationOrderByKeys.createdAt,
@@ -775,8 +776,11 @@ describe('Testing application service', () => {
       jurisdictions: [{ id: 'juris id' }],
     } as unknown as User;
     const date = new Date();
-    const mockedValue = mockApplication(3, date);
+    const mockedValue = mockApplication({ date: date, position: 3 });
     prisma.applications.findUnique = jest.fn().mockResolvedValue(mockedValue);
+    prisma.jurisdictions.findFirst = jest
+      .fn()
+      .mockResolvedValue({ id: randomUUID() });
 
     expect(
       await service.findOne('example Id', {
@@ -1693,6 +1697,10 @@ describe('Testing application service', () => {
     prisma.jurisdictions.findFirst = jest
       .fn()
       .mockResolvedValue({ id: randomUUID() });
+    prisma.listings.findFirst = jest
+      .fn()
+      .mockResolvedValue({ id: randomUUID() });
+    prisma.householdMember.deleteMany = jest.fn().mockResolvedValue(null);
 
     await service.update(dto, {
       id: 'requestingUser id',

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -2260,6 +2260,7 @@ describe('Testing listing service', () => {
       prisma.$transaction = jest
         .fn()
         .mockResolvedValue([{ id: 'example id', name: 'example name' }]);
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
 
       await service.update(
         {
@@ -2406,6 +2407,8 @@ describe('Testing listing service', () => {
         ]);
 
       const val = constructFullListingData(randomUUID());
+      prisma.assets.create = jest.fn().mockResolvedValue({ id: randomUUID() });
+      prisma.address.create = jest.fn().mockResolvedValue({ id: randomUUID() });
       val.reservedCommunityTypes = null;
 
       await service.update(val as ListingUpdate, user);

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -302,6 +302,7 @@ describe('Testing lottery service', () => {
         lotteryLastRunAt: null,
         lotteryStatus: null,
       });
+      prisma.userAccounts.findMany = jest.fn().mockResolvedValue([]);
 
       await service.lotteryGenerate(
         { user: requestingUser } as unknown as ExpressRequest,
@@ -412,6 +413,7 @@ describe('Testing lottery service', () => {
         lotteryLastRunAt: null,
         lotteryStatus: null,
       });
+      prisma.userAccounts.findMany = jest.fn().mockResolvedValue([]);
 
       await service.lotteryGenerate(
         { user: requestingUser } as unknown as ExpressRequest,
@@ -703,6 +705,7 @@ describe('Testing lottery service', () => {
         lotteryStatus: LotteryStatusEnum.ran,
       });
       prisma.listings.update = jest.fn().mockResolvedValue(null);
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
 
       await expect(
         async () =>
@@ -772,6 +775,7 @@ describe('Testing lottery service', () => {
         status: ListingsStatusEnum.closed,
         lotteryStatus: LotteryStatusEnum.ran,
       });
+      prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
       jest
         .spyOn(listingService, 'getPublicUserEmailInfo')
         .mockResolvedValueOnce({

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1,11 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaClient } from '@prisma/client';
 import { randomUUID } from 'crypto';
 import { Request as ExpressRequest } from 'express';
+import { mockDeep } from 'jest-mock-extended';
 import { ScriptRunnerService } from '../../../src/services/script-runner.service';
 import { PrismaService } from '../../../src/services/prisma.service';
 import { User } from '../../../src/dtos/users/user.dto';
 import { EmailService } from '../../../src/services/email.service';
 import { AmiChartService } from '../../../src/services/ami-chart.service';
+
+const externalPrismaClient = mockDeep<PrismaClient>();
 
 describe('Testing script runner service', () => {
   let service: ScriptRunnerService;
@@ -49,6 +53,7 @@ describe('Testing script runner service', () => {
       {
         connectionString: process.env.TEST_CONNECTION_STRING,
       },
+      externalPrismaClient,
     );
 
     expect(res.success).toBe(true);

--- a/api/test/unit/services/translation.service.spec.ts
+++ b/api/test/unit/services/translation.service.spec.ts
@@ -221,6 +221,9 @@ describe('Testing translations service', () => {
     prisma.generatedListingTranslations.findFirst = jest
       .fn()
       .mockResolvedValue(null);
+    prisma.generatedListingTranslations.create = jest
+      .fn()
+      .mockResolvedValue(null);
 
     const result = await service.translateListing(
       mockListing() as Listing,
@@ -230,6 +233,7 @@ describe('Testing translations service', () => {
     expect(prisma.generatedListingTranslations.findFirst).toHaveBeenCalledTimes(
       1,
     );
+    expect(prisma.generatedListingTranslations.create).toHaveBeenCalledTimes(1);
     validateTranslatedFields(result);
   });
 
@@ -243,6 +247,9 @@ describe('Testing translations service', () => {
         translations: [translatedStrings],
       });
     prisma.generatedListingTranslations.delete = jest
+      .fn()
+      .mockResolvedValue(null);
+    prisma.generatedListingTranslations.create = jest
       .fn()
       .mockResolvedValue(null);
 

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -5122,6 +5122,13 @@ jest-message-util@^29.6.3:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock-extended@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/jest-mock-extended/-/jest-mock-extended-2.0.4.tgz#2bb430ba0adb9e10ea6a68d08731f2129330c8fe"
+  integrity sha512-MgL3B3GjURQFjjPGqbCANydA5BFNPygv0mYp4Tjfxohh9MWwxxX8Eq2p6ncCt/Vt+RAnaLlDaI7gwrDRD7Pt9A==
+  dependencies:
+    ts-essentials "^7.0.3"
+
 jest-mock@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.6.3.tgz#433f3fd528c8ec5a76860177484940628bdf5e0a"
@@ -7469,6 +7476,11 @@ tree-kill@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
+ts-essentials@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
 
 ts-jest@~29.1.1:
   version "29.1.1"


### PR DESCRIPTION
There are several backend unit tests that happen to be working because we have a database running while the tests are running. If this were to not be the case these tests would start failing and there is even a failing test semi-related to this issue.

This PR mocks out all db calls that are needed in tests that are not already mocked out. 

To test:
- These are already passing in circleci, but to test it locally to make sure all are caught you can change your .env file to point to a non-existent DB. I did this by changing the port on the DB url