### PR TITLE
fix: include comparison in next config

### DIFF
--- a/sites/partners/next.config.js
+++ b/sites/partners/next.config.js
@@ -49,7 +49,7 @@ module.exports = withBundleAnalyzer(
       mapBoxToken: MAPBOX_TOKEN,
       featureListingsApproval: process.env.FEATURE_LISTINGS_APPROVAL,
       reCaptchaKey: process.env.RECAPTCHA_KEY,
-      showLottery: process.env.SHOW_LOTTERY,
+      showLottery: process.env.SHOW_LOTTERY === "TRUE",
       lotteryDaysTillExpiry: process.env.LOTTERY_DAYS_TILL_EXPIRY,
     },
     i18n: {


### PR DESCRIPTION
This PR addresses #4273 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds comparison to next config

## How Can This Be Tested/Reviewed?

Test locally with show_lottery="TRUE", show_lottery="FALSE" and without show_lottery ever defined. The second two cases should hide the features.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
