### PR TITLE
feat: public lottery view, totals data

### DIFF
--- a/api/prisma/migrations/16_lottery_total/migration.sql
+++ b/api/prisma/migrations/16_lottery_total/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "application_lottery_totals" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "total" INTEGER NOT NULL,
+    "listing_id" UUID NOT NULL,
+    "multiselect_question_id" UUID,
+
+    CONSTRAINT "application_lottery_totals_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "application_lottery_totals_listing_id_idx" ON "application_lottery_totals"("listing_id");
+
+-- AddForeignKey
+ALTER TABLE "application_lottery_totals" ADD CONSTRAINT "application_lottery_totals_listing_id_fkey" FOREIGN KEY ("listing_id") REFERENCES "listings"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "application_lottery_totals" ADD CONSTRAINT "application_lottery_totals_multiselect_question_id_fkey" FOREIGN KEY ("multiselect_question_id") REFERENCES "multiselect_questions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -440,6 +440,18 @@ model ApplicationLotteryPositions {
   @@map("application_lottery_positions")
 }
 
+model ApplicationLotteryTotal {
+  id                    String                @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  total                 Int
+  listingId             String                @map("listing_id") @db.Uuid
+  listings              Listings              @relation(fields: [listingId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  multiselectQuestionId String?               @map("multiselect_question_id") @db.Uuid
+  multiselectQuestions  MultiselectQuestions? @relation(fields: [multiselectQuestionId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@index([listingId])
+  @@map("application_lottery_totals")
+}
+
 model ListingUtilities {
   id          String    @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamp(6)
@@ -591,7 +603,7 @@ model Listings {
   requestedChangesUserId                String?                       @map("requested_changes_user_id") @db.Uuid
   requestedChangesUser                  UserAccounts?                 @relation("requested_changes_user", fields: [requestedChangesUserId], references: [id], onDelete: NoAction, onUpdate: NoAction)
   applicationLotteryPositions           ApplicationLotteryPositions[]
-
+  applicationLotteryTotals              ApplicationLotteryTotal[]
   @@index([jurisdictionId])
   @@map("listings")
 }
@@ -631,6 +643,7 @@ model MultiselectQuestions {
   jurisdictions               Jurisdictions[]
   listings                    ListingMultiselectQuestions[]
   applicationLotteryPositions ApplicationLotteryPositions[]
+  applicationLotteryTotals    ApplicationLotteryTotal[]
 
   @@map("multiselect_questions")
 }

--- a/api/src/controllers/lottery.controller.ts
+++ b/api/src/controllers/lottery.controller.ts
@@ -36,6 +36,7 @@ import { PermissionAction } from '../../src/decorators/permission-action.decorat
 import { permissionActions } from '../../src/enums/permissions/permission-actions-enum';
 import { AdminOrJurisdictionalAdminGuard } from '../../src/guards/admin-or-jurisdiction-admin.guard';
 import { PublicLotteryResult } from '../../src/dtos/lottery/lottery-public-result.dto';
+import { ApplicationLotteryTotal } from '../../src/dtos/applications/application-lottery-total.dto';
 
 @Controller('lottery')
 @ApiTags('lottery')
@@ -162,5 +163,21 @@ export class LotteryController {
       id,
       mapTo(User, req['user']),
     );
+  }
+
+  @Get(`lotteryTotals/:id`)
+  @ApiOkResponse({
+    type: ApplicationLotteryTotal,
+    isArray: true,
+  })
+  @ApiOperation({
+    summary: 'Get lottery totals by listing id',
+    operationId: 'lotteryTotals',
+  })
+  async lotteryTotals(
+    @Request() req: ExpressRequest,
+    @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
+  ): Promise<ApplicationLotteryTotal[]> {
+    return this.lotteryService.lotteryTotals(id, mapTo(User, req['user']));
   }
 }

--- a/api/src/controllers/lottery.controller.ts
+++ b/api/src/controllers/lottery.controller.ts
@@ -36,8 +36,7 @@ import { PermissionAction } from '../../src/decorators/permission-action.decorat
 import { permissionActions } from '../../src/enums/permissions/permission-actions-enum';
 import { AdminOrJurisdictionalAdminGuard } from '../../src/guards/admin-or-jurisdiction-admin.guard';
 import { PublicLotteryResult } from '../../src/dtos/lottery/lottery-public-result.dto';
-import { ApplicationLotteryTotal } from '../../src/dtos/applications/application-lottery-total.dto';
-import { PublicLotteryTotal } from 'src/dtos/lottery/lottery-public-total.dto';
+import { PublicLotteryTotal } from '../../src/dtos/lottery/lottery-public-total.dto';
 
 @Controller('lottery')
 @ApiTags('lottery')

--- a/api/src/controllers/lottery.controller.ts
+++ b/api/src/controllers/lottery.controller.ts
@@ -37,6 +37,7 @@ import { permissionActions } from '../../src/enums/permissions/permission-action
 import { AdminOrJurisdictionalAdminGuard } from '../../src/guards/admin-or-jurisdiction-admin.guard';
 import { PublicLotteryResult } from '../../src/dtos/lottery/lottery-public-result.dto';
 import { ApplicationLotteryTotal } from '../../src/dtos/applications/application-lottery-total.dto';
+import { PublicLotteryTotal } from 'src/dtos/lottery/lottery-public-total.dto';
 
 @Controller('lottery')
 @ApiTags('lottery')
@@ -167,7 +168,7 @@ export class LotteryController {
 
   @Get(`lotteryTotals/:id`)
   @ApiOkResponse({
-    type: ApplicationLotteryTotal,
+    type: PublicLotteryTotal,
     isArray: true,
   })
   @ApiOperation({
@@ -177,7 +178,7 @@ export class LotteryController {
   async lotteryTotals(
     @Request() req: ExpressRequest,
     @Param('id', new ParseUUIDPipe({ version: '4' })) id: string,
-  ): Promise<ApplicationLotteryTotal[]> {
+  ): Promise<PublicLotteryTotal[]> {
     return this.lotteryService.lotteryTotals(id, mapTo(User, req['user']));
   }
 }

--- a/api/src/dtos/applications/application-lottery-position.dto.ts
+++ b/api/src/dtos/applications/application-lottery-position.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsDefined, IsNumber, IsString, IsUUID } from 'class-validator';
+import {
+  IsDefined,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 
 export class ApplicationLotteryPosition {
@@ -21,9 +27,9 @@ export class ApplicationLotteryPosition {
   @Expose()
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
-  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @ApiProperty()
-  multiselectQuestionId: string;
+  multiselectQuestionId?: string;
 
   @Expose()
   @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })

--- a/api/src/dtos/applications/application-lottery-total.dto.ts
+++ b/api/src/dtos/applications/application-lottery-total.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import {
   IsDefined,
@@ -21,7 +21,7 @@ export class ApplicationLotteryTotal {
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
-  @ApiProperty()
+  @ApiPropertyOptional()
   multiselectQuestionId?: string;
 
   @Expose()

--- a/api/src/dtos/applications/application-lottery-total.dto.ts
+++ b/api/src/dtos/applications/application-lottery-total.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsDefined, IsNumber, IsString, IsUUID } from 'class-validator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class ApplicationLotteryTotal {
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  listingId: string;
+
+  @Expose()
+  @IsString({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  multiselectQuestionId: string;
+
+  @Expose()
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  total: number;
+}

--- a/api/src/dtos/applications/application-lottery-total.dto.ts
+++ b/api/src/dtos/applications/application-lottery-total.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsDefined, IsNumber, IsString, IsUUID } from 'class-validator';
+import {
+  IsDefined,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 
 export class ApplicationLotteryTotal {
@@ -14,9 +20,9 @@ export class ApplicationLotteryTotal {
   @Expose()
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
-  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @ApiProperty()
-  multiselectQuestionId: string;
+  multiselectQuestionId?: string;
 
   @Expose()
   @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })

--- a/api/src/dtos/listings/listing-update.dto.ts
+++ b/api/src/dtos/listings/listing-update.dto.ts
@@ -47,6 +47,7 @@ export class ListingUpdate extends OmitType(Listing, [
   'afsLastRunAt',
   'urlSlug',
   'applicationConfig',
+  'applicationLotteryTotals',
 ]) {
   @Expose()
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -1,5 +1,6 @@
 import { Expose, Transform, TransformFnParams, Type } from 'class-transformer';
 import {
+  IsArray,
   IsBoolean,
   IsDate,
   IsDefined,
@@ -39,6 +40,7 @@ import { listingUrlSlug } from '../../utilities/listing-url-slug';
 import { User } from '../users/user.dto';
 import { requestedChangesUserMapper } from '../../utilities/requested-changes-user';
 import { LotteryDateParamValidator } from '../../utilities/lottery-date-validator';
+import { ApplicationLotteryTotal } from '../applications/application-lottery-total.dto';
 
 class Listing extends AbstractDTO {
   @Expose()
@@ -597,6 +599,14 @@ class Listing extends AbstractDTO {
   @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional()
   lotteryOptIn?: boolean;
+
+  @Expose()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
+  @Type(() => ApplicationLotteryTotal)
+  @ApiProperty({ type: ApplicationLotteryTotal, isArray: true })
+  applicationLotteryTotals: ApplicationLotteryTotal[];
 }
 
 export { Listing as default, Listing };

--- a/api/src/dtos/lottery/lottery-public-result.dto.ts
+++ b/api/src/dtos/lottery/lottery-public-result.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsDefined, IsNumber, IsOptional, IsUUID } from 'class-validator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
@@ -11,7 +11,7 @@ export class PublicLotteryResult {
   ordinal: number;
 
   @Expose()
-  @ApiProperty()
+  @ApiPropertyOptional()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
   multiselectQuestionId?: string;

--- a/api/src/dtos/lottery/lottery-public-total.dto.ts
+++ b/api/src/dtos/lottery/lottery-public-total.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsDefined, IsNumber, IsOptional, IsUUID } from 'class-validator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
@@ -11,7 +11,7 @@ export class PublicLotteryTotal {
   total: number;
 
   @Expose()
-  @ApiProperty()
+  @ApiPropertyOptional()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
   multiselectQuestionId?: string;

--- a/api/src/dtos/lottery/lottery-public-total.dto.ts
+++ b/api/src/dtos/lottery/lottery-public-total.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsDefined, IsNumber, IsOptional, IsUUID } from 'class-validator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+
+export class PublicLotteryTotal {
+  @Expose()
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @ApiProperty()
+  @IsDefined({ groups: [ValidationsGroupsEnum.default] })
+  total: number;
+
+  @Expose()
+  @ApiProperty()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default] })
+  multiselectQuestionId?: string;
+}

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -49,6 +49,7 @@ import { ListingViews } from '../../src/enums/listings/view-enum';
 import { startCronJob } from '../utilities/cron-job-starter';
 import { EmailService } from './email.service';
 import { PublicLotteryResult } from '../../src/dtos/lottery/lottery-public-result.dto';
+import { PublicLotteryTotal } from '../../src/dtos/lottery/lottery-public-total.dto';
 
 view.csv = {
   ...view.details,
@@ -1178,7 +1179,7 @@ export class LotteryService {
   public async lotteryTotals(
     listingId: string,
     user: User,
-  ): Promise<ApplicationLotteryTotal[]> {
+  ): Promise<PublicLotteryTotal[]> {
     if (!user) {
       throw new ForbiddenException();
     }
@@ -1199,10 +1200,8 @@ export class LotteryService {
 
     const results = await this.prisma.applicationLotteryTotal.findMany({
       select: {
-        id: true,
         total: true,
         multiselectQuestionId: true,
-        listingId: true,
       },
       where: {
         listingId,

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -1129,6 +1129,8 @@ describe('Lottery Controller Tests', () => {
       const jurisdiction = await prisma.jurisdictions.create({
         data: jurisdictionFactory(),
       });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+
       const listing1 = await listingFactory(jurisdiction.id, prisma, {
         status: ListingsStatusEnum.closed,
       });
@@ -1167,6 +1169,106 @@ describe('Lottery Controller Tests', () => {
         .expect(200);
 
       expect(res.body).toEqual([{ ordinal: 1, multiselectQuestionId: null }]);
+    });
+  });
+  describe('lotteryTotals', () => {
+    fit('should return totals', async () => {
+      const unitTypeA = await unitTypeFactorySingle(
+        prisma,
+        UnitTypeEnum.oneBdrm,
+      );
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+
+      const preferenceA = await multiselectQuestionFactory(jurisdiction.id, {
+        multiselectQuestion: {
+          text: 'City Employees',
+          description: 'Employees of the local city.',
+          applicationSection:
+            MultiselectQuestionsApplicationSectionEnum.preferences,
+          options: [
+            {
+              text: 'At least one member of my household is a city employee',
+              collectAddress: false,
+              ordinal: 0,
+            },
+          ],
+        },
+      });
+
+      const preferenceACreated = await prisma.multiselectQuestions.create({
+        data: preferenceA,
+      });
+
+      const listing1 = await listingFactory(jurisdiction.id, prisma, {
+        status: ListingsStatusEnum.closed,
+        multiselectQuestions: [preferenceACreated],
+      });
+
+      const listing1Created = await prisma.listings.create({
+        data: listing1,
+      });
+
+      const appA = await applicationFactory({
+        listingId: listing1Created.id,
+        unitTypeId: unitTypeA.id,
+        multiselectQuestions: [preferenceACreated],
+      });
+
+      await prisma.applications.create({
+        data: appA,
+        include: {
+          applicant: true,
+        },
+      });
+
+      const appB = await applicationFactory({
+        listingId: listing1Created.id,
+        unitTypeId: unitTypeA.id,
+      });
+
+      await prisma.applications.create({
+        data: appB,
+        include: {
+          applicant: true,
+        },
+      });
+
+      await lotteryService.lotteryGenerate(
+        {
+          user: {
+            id: randomUUID(),
+            userRoles: {
+              isAdmin: true,
+            },
+          },
+        } as unknown as ExpressRequest,
+        {} as Response,
+        { id: listing1Created.id },
+      );
+
+      const res = await request(app.getHttpServer())
+        .get(`/lottery/lotteryTotals/${listing1Created.id}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', adminAccessToken)
+        .expect(200);
+
+      expect(res.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            listingId: listing1Created.id,
+            multiselectQuestionId: null,
+            total: 2,
+          }),
+          expect.objectContaining({
+            listingId: listing1Created.id,
+            multiselectQuestionId: preferenceACreated.id,
+            total: 1,
+          }),
+        ]),
+      );
     });
   });
 });

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -1258,12 +1258,10 @@ describe('Lottery Controller Tests', () => {
       expect(res.body).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            listingId: listing1Created.id,
             multiselectQuestionId: null,
             total: 2,
           }),
           expect.objectContaining({
-            listingId: listing1Created.id,
             multiselectQuestionId: preferenceACreated.id,
             total: 1,
           }),

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -1172,7 +1172,7 @@ describe('Lottery Controller Tests', () => {
     });
   });
   describe('lotteryTotals', () => {
-    fit('should return totals', async () => {
+    it('should return totals', async () => {
       const unitTypeA = await unitTypeFactorySingle(
         prisma,
         UnitTypeEnum.oneBdrm,

--- a/api/test/unit/services/google-translate.service.spec.ts
+++ b/api/test/unit/services/google-translate.service.spec.ts
@@ -1,0 +1,49 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LanguagesEnum } from '@prisma/client';
+import { Translate } from '@google-cloud/translate/build/src/v2';
+import { GoogleTranslateService } from '../../../src/services/google-translate.service';
+import { PrismaService } from '../../../src/services/prisma.service';
+jest.mock('@google-cloud/translate/build/src/v2');
+
+describe('GoogleTranslateService', () => {
+  let service: GoogleTranslateService;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PrismaService, GoogleTranslateService],
+    }).compile();
+
+    service = module.get<GoogleTranslateService>(GoogleTranslateService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  describe('isConfigured', () => {
+    it('should return true if all variables are present', () => {
+      process.env.GOOGLE_API_ID = 'api-id';
+      process.env.GOOGLE_API_EMAIL = 'api-email';
+      process.env.GOOGLE_API_KEY = 'api-key';
+      expect(service.isConfigured()).toBe(true);
+    });
+    it('should return false if variables are not present', () => {
+      delete process.env.GOOGLE_API_ID;
+      delete process.env.GOOGLE_API_EMAIL;
+      delete process.env.GOOGLE_API_KEY;
+      expect(service.isConfigured()).toBe(false);
+    });
+  });
+  describe('fetch', () => {
+    it('should make the translate service', () => {
+      process.env.GOOGLE_API_ID = 'api-id';
+      process.env.GOOGLE_API_EMAIL = 'api-email';
+      process.env.GOOGLE_API_KEY = 'api-key';
+
+      service.fetch(
+        ['listing.petPolicy', 'listing.unitAmenities'],
+        LanguagesEnum.es,
+      );
+
+      expect(Translate).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -128,9 +128,16 @@ describe('Testing lottery service', () => {
         .fn()
         .mockResolvedValue({ id: randomUUID() });
 
+      prisma.applicationLotteryTotal.create = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
       await service.lotteryRandomizer(listingId, applications, []);
 
-      expect(prisma.applicationLotteryPositions.createMany).toHaveBeenCalled();
+      expect(
+        prisma.applicationLotteryPositions.createMany,
+      ).toHaveBeenCalledTimes(1);
+      expect(prisma.applicationLotteryTotal.create).toHaveBeenCalledTimes(1);
 
       const args = (prisma.applicationLotteryPositions.createMany as any).mock
         .calls[0][0].data;
@@ -173,6 +180,10 @@ describe('Testing lottery service', () => {
         .fn()
         .mockResolvedValue({ id: randomUUID() });
 
+      prisma.applicationLotteryTotal.create = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
       await service.lotteryRandomizer(listingId, applications, preferences);
 
       const args = (prisma.applicationLotteryPositions.createMany as any).mock
@@ -188,6 +199,7 @@ describe('Testing lottery service', () => {
       }
 
       expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(1);
+      expect(prisma.applicationLotteryTotal.create).toBeCalledTimes(1);
     });
 
     it('should store randomized ordinals and preference specific ordinals', async () => {
@@ -213,6 +225,10 @@ describe('Testing lottery service', () => {
       }
 
       prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.applicationLotteryTotal.create = jest
         .fn()
         .mockResolvedValue({ id: randomUUID() });
 
@@ -248,6 +264,7 @@ describe('Testing lottery service', () => {
       );
 
       expect(prisma.applicationLotteryPositions.createMany).toBeCalledTimes(2);
+      expect(prisma.applicationLotteryTotal.create).toBeCalledTimes(2);
     });
   });
 
@@ -295,6 +312,10 @@ describe('Testing lottery service', () => {
       ]);
 
       prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.applicationLotteryTotal.createMany = jest
         .fn()
         .mockResolvedValue({ id: randomUUID() });
 
@@ -351,6 +372,8 @@ describe('Testing lottery service', () => {
       });
 
       expect(prisma.applicationLotteryPositions.createMany).toHaveBeenCalled();
+      expect(prisma.applicationLotteryTotal.create).toHaveBeenCalled();
+
       expect(prisma.listings.update).toHaveBeenCalledWith({
         data: {
           lotteryLastRunAt: expect.anything(),
@@ -409,6 +432,11 @@ describe('Testing lottery service', () => {
         .fn()
         .mockResolvedValue({ id: randomUUID() });
 
+      prisma.applicationLotteryTotal.deleteMany = jest.fn();
+      prisma.applicationLotteryTotal.create = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
       prisma.listings.update = jest.fn().mockResolvedValue({
         id: listingId,
         lotteryLastRunAt: null,
@@ -435,9 +463,14 @@ describe('Testing lottery service', () => {
       expect(
         prisma.applicationLotteryPositions.deleteMany,
       ).toHaveBeenCalledWith({ where: { listingId: listingId } });
+      expect(prisma.applicationLotteryTotal.deleteMany).toHaveBeenCalledWith({
+        where: { listingId: listingId },
+      });
       expect(prisma.applications.findMany).toHaveBeenCalled();
 
       expect(prisma.applicationLotteryPositions.createMany).toHaveBeenCalled();
+      expect(prisma.applicationLotteryTotal.create).toHaveBeenCalled();
+
       expect(prisma.listings.update).toHaveBeenCalled();
     });
   });
@@ -1155,6 +1188,7 @@ describe('Testing lottery service', () => {
     const applicationId = randomUUID();
     const publicUser = {
       id: 'public id',
+      userRoles: {},
     } as User;
 
     it('should query for lottery positions', async () => {

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -269,6 +269,30 @@ describe('Testing lottery service', () => {
   });
 
   describe('Testing lotteryGenerate()', () => {
+    it('should error if not an admin', async () => {
+      const listingId = randomUUID();
+      const requestingUser = {
+        firstName: 'requesting fName',
+        lastName: 'requesting lName',
+        email: 'requestingUser@email.com',
+        jurisdictions: [{ id: 'juris id' }],
+        userRoles: { isAdmin: false },
+      } as unknown as User;
+
+      prisma.listings.findUnique = jest.fn();
+
+      await expect(
+        async () =>
+          await service.lotteryGenerate(
+            { user: requestingUser } as unknown as ExpressRequest,
+            {} as unknown as Response,
+            { id: listingId },
+          ),
+      ).rejects.toThrowError();
+
+      expect(prisma.listings.findUnique).not.toHaveBeenCalled();
+    });
+
     it('should build lottery when no prior lottery has been ran', async () => {
       const listingId = randomUUID();
       const requestingUser = {

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1258,10 +1258,8 @@ describe('Testing lottery service', () => {
 
       expect(prisma.applicationLotteryTotal.findMany).toHaveBeenCalledWith({
         select: {
-          id: true,
           total: true,
           multiselectQuestionId: true,
-          listingId: true,
         },
         where: {
           listingId,

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1214,4 +1214,49 @@ describe('Testing lottery service', () => {
       });
     });
   });
+
+  describe('Testing lotteryTotals()', () => {
+    const listingId = randomUUID();
+    const publicUser = {
+      id: 'public id',
+      userRoles: {},
+    } as User;
+
+    it('should query for lottery totals', async () => {
+      prisma.applications.findFirstOrThrow = jest
+        .fn()
+        .mockResolvedValue({ userId: publicUser.id });
+      prisma.applicationLotteryTotal.findMany = jest.fn().mockResolvedValue([
+        { total: 10, multiselectQuestionId: null, listingId },
+        { total: 5, multiselectQuestionId: 'preference id', listingId },
+      ]);
+      await service.lotteryTotals(listingId, publicUser);
+
+      expect(prisma.applicationLotteryTotal.findMany).toHaveBeenCalledWith({
+        select: {
+          id: true,
+          total: true,
+          multiselectQuestionId: true,
+          listingId: true,
+        },
+        where: {
+          listingId,
+        },
+      });
+    });
+
+    it('should fail for no user', async () => {
+      prisma.applications.findFirstOrThrow = jest
+        .fn()
+        .mockResolvedValue({ userId: publicUser.id });
+      prisma.applicationLotteryTotal.findMany = jest.fn().mockResolvedValue([
+        { total: 10, multiselectQuestionId: null, listingId },
+        { total: 5, multiselectQuestionId: 'preference id', listingId },
+      ]);
+
+      await expect(
+        async () => await service.lotteryTotals(listingId, null),
+      ).rejects.toThrowError();
+    });
+  });
 });

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1216,7 +1216,7 @@ describe('Testing lottery service', () => {
     } as User;
 
     it('should query for lottery positions', async () => {
-      prisma.applications.findFirstOrThrow = jest
+      prisma.applications.findFirst = jest
         .fn()
         .mockResolvedValue({ userId: publicUser.id });
       prisma.applicationLotteryPositions.findMany = jest
@@ -1247,7 +1247,7 @@ describe('Testing lottery service', () => {
     } as User;
 
     it('should query for lottery totals', async () => {
-      prisma.applications.findFirstOrThrow = jest
+      prisma.applications.findFirst = jest
         .fn()
         .mockResolvedValue({ userId: publicUser.id });
       prisma.applicationLotteryTotal.findMany = jest.fn().mockResolvedValue([

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2298,7 +2298,7 @@ export class LotteryService {
       id: string
     } = {} as any,
     options: IRequestOptions = {}
-  ): Promise<ApplicationLotteryTotal[]> {
+  ): Promise<PublicLotteryTotal[]> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/lottery/lotteryTotals/{id}"
       url = url.replace("{id}", params["id"] + "")
@@ -5753,6 +5753,14 @@ export interface LotteryActivityLogItem {
 export interface PublicLotteryResult {
   /**  */
   ordinal: number
+
+  /**  */
+  multiselectQuestionId: string
+}
+
+export interface PublicLotteryTotal {
+  /**  */
+  total: number
 
   /**  */
   multiselectQuestionId: string

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2289,6 +2289,27 @@ export class LotteryService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * Get lottery totals by listing id
+   */
+  lotteryTotals(
+    params: {
+      /**  */
+      id: string
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<ApplicationLotteryTotal[]> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/lottery/lotteryTotals/{id}"
+      url = url.replace("{id}", params["id"] + "")
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+
+      /** 适配ios13，get请求不允许带body */
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export interface SuccessDTO {
@@ -2979,6 +3000,17 @@ export interface UnitsSummary {
   totalAvailable?: number
 }
 
+export interface ApplicationLotteryTotal {
+  /**  */
+  listingId: string
+
+  /**  */
+  multiselectQuestionId: string
+
+  /**  */
+  total: number
+}
+
 export interface Listing {
   /**  */
   id: string
@@ -3267,6 +3299,9 @@ export interface Listing {
 
   /**  */
   lotteryOptIn?: boolean
+
+  /**  */
+  applicationLotteryTotals: ApplicationLotteryTotal[]
 }
 
 export interface PaginationMeta {

--- a/sites/partners/src/lib/listings/formTypes.ts
+++ b/sites/partners/src/lib/listings/formTypes.ts
@@ -167,6 +167,7 @@ export const formDefaults: FormListing = {
   //     rows: [],
   //   },
   // },
+  applicationLotteryTotals: [],
 }
 
 export type TempUnit = Unit & {

--- a/sites/partners/src/lib/listings/formTypes.ts
+++ b/sites/partners/src/lib/listings/formTypes.ts
@@ -155,18 +155,6 @@ export const formDefaults: FormListing = {
   // showWaitlist: false,
   reviewOrderType: null,
   unitsSummary: [],
-  // unitsSummarized: {
-  //   unitTypes: [],
-  //   priorityTypes: [],
-  //   amiPercentages: [],
-  //   byUnitTypeAndRent: [],
-  //   byUnitType: [],
-  //   byAMI: [],
-  //   hmi: {
-  //     columns: [],
-  //     rows: [],
-  //   },
-  // },
   applicationLotteryTotals: [],
 }
 

--- a/sites/public/src/pages/account/application/[id]/lottery-results.tsx
+++ b/sites/public/src/pages/account/application/[id]/lottery-results.tsx
@@ -4,6 +4,7 @@ import { t } from "@bloom-housing/ui-components"
 import { AuthContext, BloomCard, CustomIconMap, RequireLogin } from "@bloom-housing/shared-helpers"
 import {
   Application,
+  ApplicationLotteryTotal,
   Listing,
   MultiselectQuestionsApplicationSectionEnum,
   PublicLotteryResult,
@@ -22,6 +23,7 @@ export default () => {
   const { applicationsService, listingsService, profile, lotteryService } = useContext(AuthContext)
   const [application, setApplication] = useState<Application>()
   const [results, setResults] = useState<PublicLotteryResult[]>()
+  const [totals, setTotals] = useState<ApplicationLotteryTotal[]>()
   const [listing, setListing] = useState<Listing>()
   const [unauthorized, setUnauthorized] = useState(false)
   const [noApplication, setNoApplication] = useState(false)
@@ -39,6 +41,14 @@ export default () => {
                 .publicLotteryResults({ id: applicationId })
                 .then((results) => {
                   setResults(results)
+                  lotteryService
+                    .lotteryTotals({ id: retrievedListing.id })
+                    .then((totals) => {
+                      setTotals(totals)
+                    })
+                    .catch((err) => {
+                      console.error(`Error fetching lottery totals: ${err}`)
+                    })
                 })
                 .catch((err) => {
                   console.error(`Error fetching lottery results: ${err}`)
@@ -108,7 +118,7 @@ export default () => {
                           listing?.unitsAvailable !== 1 ? "Plural" : ""
                         }`,
                         {
-                          applications: 2500, // TODO: Plug in BE data
+                          applications: totals?.find((total) => !total.multiselectQuestionId).total,
                           units: listing?.unitsAvailable,
                         }
                       )}
@@ -181,7 +191,14 @@ export default () => {
                           result.multiselectQuestionId === question.multiselectQuestions.id
                       )
                       return result
-                        ? preferenceRank(result.ordinal, question.multiselectQuestions.text, 2500) // TODO: Plug in BE data
+                        ? preferenceRank(
+                            result.ordinal,
+                            question.multiselectQuestions.text,
+                            totals?.find(
+                              (total) =>
+                                total.multiselectQuestionId === question.multiselectQuestions.id
+                            )?.total
+                          )
                         : null
                     })}
                   <Card.Section divider={"flush"} className={"border-none"}>

--- a/sites/public/src/pages/account/application/[id]/lottery-results.tsx
+++ b/sites/public/src/pages/account/application/[id]/lottery-results.tsx
@@ -4,7 +4,7 @@ import { t } from "@bloom-housing/ui-components"
 import { AuthContext, BloomCard, CustomIconMap, RequireLogin } from "@bloom-housing/shared-helpers"
 import {
   Application,
-  ApplicationLotteryTotal,
+  PublicLotteryTotal,
   Listing,
   MultiselectQuestionsApplicationSectionEnum,
   PublicLotteryResult,
@@ -23,7 +23,7 @@ export default () => {
   const { applicationsService, listingsService, profile, lotteryService } = useContext(AuthContext)
   const [application, setApplication] = useState<Application>()
   const [results, setResults] = useState<PublicLotteryResult[]>()
-  const [totals, setTotals] = useState<ApplicationLotteryTotal[]>()
+  const [totals, setTotals] = useState<PublicLotteryTotal[]>()
   const [listing, setListing] = useState<Listing>()
   const [unauthorized, setUnauthorized] = useState(false)
   const [noApplication, setNoApplication] = useState(false)


### PR DESCRIPTION
Related to merge of: https://github.com/bloom-housing/bloom/pull/4275

This PR addresses #4224

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds in the total number of applicants and number of applicants per preference into the public site lottery results page.

I created a new table that stores the totals in a very similar way to how we store lottery positions. I had performance concerns over querying the lottery positions table every time a user needs to see their results page as it will have 1000s of rows after just one lottery is run.

There's also some misc. test coverage.

## How Can This Be Tested/Reviewed?

Submit an application to a listing and claim a preference. Run and release the lottery. Ensure that the total number of applications and number of applications that claimed that preference are correct.

Handling listings without preferences or a user who doesn't claim any is a separate ticket.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
