### PR TITLE
fix: lottery translations script bug

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -94,6 +94,21 @@ export class ScirptRunnerController {
     return await this.scriptRunnerService.addLotteryTranslations(req);
   }
 
+  @Put('lotteryTranslationsCreateIfEmpty')
+  @ApiOperation({
+    summary:
+      'A script that adds lottery translations to the db and creates them if it does not exist',
+    operationId: 'lotteryTranslations',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async lotteryTranslationsCreateIfEmpty(
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.addLotteryTranslationsCreateIfEmpty(
+      req,
+    );
+  }
+
   @Put('optOutExistingLotteries')
   @ApiOperation({
     summary: 'A script that opts out existing lottery listings',

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -204,8 +204,6 @@ export class ScriptRunnerService {
   }
 
   private async addLotteryTranslationsHelper(req: ExpressRequest) {
-    const requestingUser = mapTo(User, req['user']);
-
     const updateForLanguage = async (
       language: LanguagesEnum,
       translationKeys: Record<string, Record<string, string>>,
@@ -344,10 +342,6 @@ export class ScriptRunnerService {
     await updateForLanguage(LanguagesEnum.tl, tlKeys);
     await updateForLanguage(LanguagesEnum.vi, viKeys);
     await updateForLanguage(LanguagesEnum.zh, zhKeys);
-
-    await this.markScriptAsComplete('add lottery translations', requestingUser);
-
-    return { success: true };
   }
 
   /**
@@ -360,7 +354,10 @@ export class ScriptRunnerService {
   async addLotteryTranslations(req: ExpressRequest): Promise<SuccessDTO> {
     const requestingUser = mapTo(User, req['user']);
     await this.markScriptAsRunStart('add lottery translations', requestingUser);
-    return this.addLotteryTranslationsHelper(req);
+    this.addLotteryTranslationsHelper(req);
+    await this.markScriptAsComplete('add lottery translations', requestingUser);
+
+    return { success: true };
   }
 
   /**
@@ -378,7 +375,13 @@ export class ScriptRunnerService {
       'add lottery translations create if empty',
       requestingUser,
     );
-    return this.addLotteryTranslationsHelper(req);
+    this.addLotteryTranslationsHelper(req);
+    await this.markScriptAsComplete(
+      'add lottery translations create if empty',
+      requestingUser,
+    );
+
+    return { success: true };
   }
 
   /**

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -126,7 +126,7 @@ describe('Testing script runner service', () => {
     });
   });
 
-  fit('should add lottery translations and create if empty', async () => {
+  it('should add lottery translations and create if empty', async () => {
     prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
     prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
     prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1,5 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { PrismaClient, ReviewOrderTypeEnum } from '@prisma/client';
+import {
+  LanguagesEnum,
+  PrismaClient,
+  ReviewOrderTypeEnum,
+} from '@prisma/client';
 import { randomUUID } from 'crypto';
 import { Request as ExpressRequest } from 'express';
 import { mockDeep } from 'jest-mock-extended';
@@ -120,6 +124,53 @@ describe('Testing script runner service', () => {
         scriptName,
       },
     });
+  });
+
+  fit('should add lottery translations and create if empty', async () => {
+    prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
+    prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+    prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
+    prisma.translations.findFirst = jest.fn().mockResolvedValue(undefined);
+    prisma.translations.update = jest.fn().mockResolvedValue(null);
+    prisma.translations.create = jest.fn().mockReturnValue({
+      language: LanguagesEnum.en,
+      translations: {},
+      jurisdictions: undefined,
+    });
+
+    const id = randomUUID();
+    const scriptName = 'add lottery translations create if empty';
+
+    const res = await service.addLotteryTranslationsCreateIfEmpty({
+      user: {
+        id,
+      } as unknown as User,
+    } as unknown as ExpressRequest);
+
+    expect(res.success).toBe(true);
+
+    expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
+      where: {
+        scriptName,
+      },
+    });
+    expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
+      data: {
+        scriptName,
+        triggeringUser: id,
+      },
+    });
+    expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
+      data: {
+        didScriptRun: true,
+        triggeringUser: id,
+      },
+      where: {
+        scriptName,
+      },
+    });
+
+    expect(prisma.translations.create).toHaveBeenCalled();
   });
 
   it('should bulk resend application confirmations', async () => {

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2124,6 +2124,22 @@ export class ScriptRunnerService {
     })
   }
   /**
+   * A script that adds lottery translations to the db and creates them if it does not exist
+   */
+  lotteryTranslations1(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/lotteryTranslationsCreateIfEmpty"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
    * A script that opts out existing lottery listings
    */
   optOutExistingLotteries(options: IRequestOptions = {}): Promise<SuccessDTO> {


### PR DESCRIPTION
This PR addresses #4272

- [x] Addresses the issue in full

## Description

This fixes a bug that was causing the lottery translations script to fail. We are using the default translations, i.e. not tied to a jurisdictional ID, and not all jurisdictions had existing default translations across all languages.

## How Can This Be Tested/Reviewed?

Start the app, and via swagger log-in and run the new script. Ensure it succeeds and that the translations are in the database.

If you want to test the user flow, you can also submit an application in a foreign language while signed in to one of your own emails, and then run and publish that lottery to get the email (screenshot below).
<img width="657" alt="Screenshot 2024-08-28 at 1 07 25 PM" src="https://github.com/user-attachments/assets/5b7c5e04-23fe-4d47-8bbd-03738c2420e2">

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
