### PR TITLE
test: lottery cypress test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,8 @@ executors:
       GOOGLE_API_ID: "secret-key"
       GOOGLE_API_KEY: "secret-key"
       GOOGLE_CLOUD_PROJECT_ID: "secret-key"
+      SHOW_LOTTERY: "TRUE"
+      THROTTLE_LIMIT: 1000
 
   standard-node:
     docker:

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -76,6 +76,16 @@ export const stagingSeed = async (
       acceptedTerms: true,
     }),
   });
+  // create a partner
+  await prismaClient.userAccounts.create({
+    data: await userFactory({
+      roles: { isPartner: true },
+      email: 'partner@example.com',
+      confirmedAt: new Date(),
+      jurisdictionIds: [jurisdiction.id],
+      acceptedTerms: true,
+    }),
+  });
   await prismaClient.userAccounts.create({
     data: await userFactory({
       roles: { isAdmin: true },

--- a/sites/partners/cypress/e2e/default/09-lottery.spec.ts
+++ b/sites/partners/cypress/e2e/default/09-lottery.spec.ts
@@ -1,0 +1,155 @@
+describe("Lottery Tests", () => {
+  before(() => {
+    cy.login()
+  })
+
+  after(() => {
+    cy.signOut()
+  })
+
+  it("can run through every lottery action", () => {
+    const uniqueListingName = Date.now().toString()
+
+    cy.visit("/")
+
+    // Create and publish minimal lottery listing
+    cy.getByID("addListingButton").contains("Add Listing").click()
+    cy.contains("New Listing")
+    cy.fixture("minimalListing").then((listing) => {
+      cy.getByID("jurisdictions.id").select("Bloomington")
+      cy.getByID("jurisdictions.id-error").should("have.length", 0)
+      cy.getByID("name").type(uniqueListingName)
+      cy.getByID("developer").type(listing["developer"])
+      cy.getByID("add-photos-button").contains("Add Photo").click()
+      cy.getByTestId("dropzone-input").attachFile(
+        "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96.jpeg",
+        {
+          subjectType: "drag-n-drop",
+        }
+      )
+      cy.getByTestId("drawer-photos-table")
+        .find("img")
+        .should("have.attr", "src")
+        .should("include", "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96")
+      cy.getByID("listing-photo-uploaded").contains("Save").click()
+      cy.getByID("listingsBuildingAddress.street").type(listing["buildingAddress.street"])
+      cy.getByID("neighborhood").type(listing["neighborhood"])
+      cy.getByID("listingsBuildingAddress.city").type(listing["buildingAddress.city"])
+      cy.getByID("listingsBuildingAddress.state").select(listing["buildingAddress.state"])
+      cy.getByID("listingsBuildingAddress.zipCode").type(listing["buildingAddress.zipCode"])
+      cy.getByID("addUnitsButton").contains("Add Unit").click()
+      cy.getByID("number").type(listing["number"])
+      cy.getByID("unitTypes.id").select(listing["unitType.id"])
+      cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
+      cy.getByID("amiChart.id").select(1).trigger("change")
+      cy.getByID("amiPercentage").select(1)
+      cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
+      cy.get("button").contains("Application Process").click()
+      cy.getByID("reviewOrderLottery").check()
+      cy.getByTestId("lottery-start-date-month").type("12")
+      cy.getByTestId("lottery-start-date-day").type("17")
+      cy.getByTestId("lottery-start-date-year").type("2026")
+      cy.getByTestId("lottery-start-time-hours").type("10")
+      cy.getByTestId("lottery-start-time-minutes").type("00")
+      cy.getByTestId("lottery-start-time-period").select("AM")
+      cy.getByTestId("lottery-end-time-hours").type("11")
+      cy.getByTestId("lottery-end-time-minutes").type("00")
+      cy.getByTestId("lottery-end-time-period").select("AM")
+      cy.getByID("leasingAgentName").type(listing["leasingAgentName"])
+      cy.getByID("leasingAgentEmail").type(listing["leasingAgentEmail"])
+      cy.getByID("leasingAgentPhone").type(listing["leasingAgentPhone"])
+      cy.getByID("digitalApplicationChoiceYes").check()
+      cy.getByID("commonDigitalApplicationChoiceYes").check()
+      cy.getByID("paperApplicationNo").check()
+      cy.getByID("referralOpportunityNo").check()
+    })
+    cy.getByID("publishButton").contains("Publish").click()
+    cy.getByID("publishButtonConfirm").contains("Publish").click()
+    cy.get("[data-testid=page-header]").should("be.visible")
+    cy.getByTestId("page-header").should("have.text", uniqueListingName)
+
+    // Submit one application
+    cy.visit("/")
+    cy.getByTestId(`listing-status-cell-${uniqueListingName}`).click()
+    cy.getByID("addApplicationButton").contains("Add Application").click()
+    cy.fixture("applicantOnlyData").then((application) => {
+      cy.fillPrimaryApplicant(application, [
+        "application.additionalPhoneNumber",
+        "application.additionalPhoneNumberType",
+        "application.applicant.address.street2",
+      ])
+    })
+    cy.getByID("submitApplicationButton").click()
+
+    // Close the listing and view lottery tab
+    cy.visit("/")
+    cy.getByTestId("ag-search-input").type(uniqueListingName)
+    cy.getByTestId(uniqueListingName).first().click()
+    cy.getByID("listingEditButton").contains("Edit").click()
+    cy.getByID("closeButton").contains("Close").click()
+    cy.getByID("close-listing-modal-button").contains("Close").click()
+    cy.get(`[role="tab"]`).eq(2).click()
+    cy.get(`[role="tab"]`).eq(2).click()
+    cy.get("h2").contains("No lottery data")
+
+    // Run lottery
+    cy.getByID("lottery-run-button").click()
+    cy.getByID("lottery-run-modal-button").click()
+    cy.get("h2").contains("Export lottery data")
+
+    // Re-run lottery
+    cy.getByID("lottery-rerun-button").click()
+    cy.getByID("lottery-rerun-modal-button").click()
+    cy.get("h2").contains("Export lottery data")
+
+    // Release lottery
+    cy.getByID("lottery-release-button").click()
+    cy.getByID("lottery-release-modal-button").click()
+    cy.get("h2").contains("Export lottery data")
+
+    // Add partner to this listing
+    cy.visit("/")
+    cy.getByTestId("Users-1").click()
+    cy.getByTestId("ag-search-input").type("partner-user@example.com")
+    cy.getByID("user-link-partner@example.com").first().click()
+    cy.getByTestId("listings-all-Bloomington").check()
+    cy.getByID("save-user").click()
+
+    // Login as partner and view lottery tab
+    cy.signOut()
+    cy.login("partnerUser")
+    cy.visit("/")
+    cy.getByTestId("ag-search-input").type(uniqueListingName)
+    cy.getByTestId(uniqueListingName).first().click()
+    cy.get(`[role="tab"]`).eq(2).click()
+    cy.get("h2").contains("Publish lottery data")
+
+    // Publish the lottery
+    cy.getByID("lottery-publish-button").click()
+    cy.getByID("lottery-publish-modal-button").click()
+    cy.get("h2").contains("Export lottery data")
+
+    // Login as admin and view lottery tab
+    cy.signOut()
+    cy.login()
+    cy.visit("/")
+    cy.getByTestId("ag-search-input").type(uniqueListingName)
+    cy.getByTestId(uniqueListingName).first().click()
+    cy.get(`[role="tab"]`).eq(2).click()
+    cy.get("h2").contains("Export lottery data")
+
+    // Retract lottery
+    cy.getByID("lottery-retract-button").click()
+    cy.getByID("lottery-retract-modal-button").click()
+    cy.get("h2").contains("Export lottery data")
+
+    // Login as partner and view lottery tab, ensure no data
+    cy.signOut()
+    cy.login("partnerUser")
+    cy.visit("/")
+    cy.getByTestId("ag-search-input").type(uniqueListingName)
+    cy.getByTestId(uniqueListingName).first().click()
+    cy.get(`[role="tab"]`).eq(2).click()
+    cy.get("h2").contains("No lottery data")
+  })
+})

--- a/sites/partners/cypress/e2e/default/09-lottery.spec.ts
+++ b/sites/partners/cypress/e2e/default/09-lottery.spec.ts
@@ -11,75 +11,8 @@ describe("Lottery Tests", () => {
     const uniqueListingName = Date.now().toString()
 
     cy.visit("/")
-
-    // Create and publish minimal lottery listing
-    cy.getByID("addListingButton").contains("Add Listing").click()
-    cy.contains("New Listing")
-    cy.fixture("minimalListing").then((listing) => {
-      cy.getByID("jurisdictions.id").select("Bloomington")
-      cy.getByID("jurisdictions.id-error").should("have.length", 0)
-      cy.getByID("name").type(uniqueListingName)
-      cy.getByID("developer").type(listing["developer"])
-      cy.getByID("add-photos-button").contains("Add Photo").click()
-      cy.getByTestId("dropzone-input").attachFile(
-        "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96.jpeg",
-        {
-          subjectType: "drag-n-drop",
-        }
-      )
-      cy.getByTestId("drawer-photos-table")
-        .find("img")
-        .should("have.attr", "src")
-        .should("include", "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96")
-      cy.getByID("listing-photo-uploaded").contains("Save").click()
-      cy.getByID("listingsBuildingAddress.street").type(listing["buildingAddress.street"])
-      cy.getByID("neighborhood").type(listing["neighborhood"])
-      cy.getByID("listingsBuildingAddress.city").type(listing["buildingAddress.city"])
-      cy.getByID("listingsBuildingAddress.state").select(listing["buildingAddress.state"])
-      cy.getByID("listingsBuildingAddress.zipCode").type(listing["buildingAddress.zipCode"])
-      cy.getByID("addUnitsButton").contains("Add Unit").click()
-      cy.getByID("number").type(listing["number"])
-      cy.getByID("unitTypes.id").select(listing["unitType.id"])
-      cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
-      cy.getByID("amiChart.id").select(1).trigger("change")
-      cy.getByID("amiPercentage").select(1)
-      cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
-      cy.get("button").contains("Application Process").click()
-      cy.getByID("reviewOrderLottery").check()
-      cy.getByTestId("lottery-start-date-month").type("12")
-      cy.getByTestId("lottery-start-date-day").type("17")
-      cy.getByTestId("lottery-start-date-year").type("2026")
-      cy.getByTestId("lottery-start-time-hours").type("10")
-      cy.getByTestId("lottery-start-time-minutes").type("00")
-      cy.getByTestId("lottery-start-time-period").select("AM")
-      cy.getByTestId("lottery-end-time-hours").type("11")
-      cy.getByTestId("lottery-end-time-minutes").type("00")
-      cy.getByTestId("lottery-end-time-period").select("AM")
-      cy.getByID("leasingAgentName").type(listing["leasingAgentName"])
-      cy.getByID("leasingAgentEmail").type(listing["leasingAgentEmail"])
-      cy.getByID("leasingAgentPhone").type(listing["leasingAgentPhone"])
-      cy.getByID("digitalApplicationChoiceYes").check()
-      cy.getByID("commonDigitalApplicationChoiceYes").check()
-      cy.getByID("paperApplicationNo").check()
-      cy.getByID("referralOpportunityNo").check()
-    })
-    cy.getByID("publishButton").contains("Publish").click()
-    cy.getByID("publishButtonConfirm").contains("Publish").click()
-    cy.get("[data-testid=page-header]").should("be.visible")
-    cy.getByTestId("page-header").should("have.text", uniqueListingName)
-
-    // Submit one application
-    cy.visit("/")
-    cy.getByTestId(`listing-status-cell-${uniqueListingName}`).click()
-    cy.getByID("addApplicationButton").contains("Add Application").click()
-    cy.fixture("applicantOnlyData").then((application) => {
-      cy.fillPrimaryApplicant(application, [
-        "application.additionalPhoneNumber",
-        "application.additionalPhoneNumberType",
-        "application.applicant.address.street2",
-      ])
-    })
-    cy.getByID("submitApplicationButton").click()
+    cy.addMinimalListing(uniqueListingName, true, false)
+    cy.addMinimalApplication(uniqueListingName)
 
     // Close the listing and view lottery tab
     cy.visit("/")

--- a/sites/partners/cypress/e2e/default/09-lottery.spec.ts
+++ b/sites/partners/cypress/e2e/default/09-lottery.spec.ts
@@ -11,7 +11,7 @@ describe("Lottery Tests", () => {
     const uniqueListingName = Date.now().toString()
 
     cy.visit("/")
-    cy.addMinimalListing(uniqueListingName, true, false)
+    cy.addMinimalListing(uniqueListingName, true, false, true)
     cy.addMinimalApplication(uniqueListingName)
 
     // Close the listing and view lottery tab
@@ -43,6 +43,7 @@ describe("Lottery Tests", () => {
     // Add partner to this listing
     cy.visit("/")
     cy.getByTestId("Users-1").click()
+    cy.contains("Users")
     cy.getByTestId("ag-search-input").type("partner-user@example.com")
     cy.getByID("user-link-partner@example.com").first().click()
     cy.getByTestId("listings-all-Bloomington").check()

--- a/sites/partners/cypress/e2e/listings-approval/listings-approval.spec.ts
+++ b/sites/partners/cypress/e2e/listings-approval/listings-approval.spec.ts
@@ -6,7 +6,7 @@ describe("Listings approval feature", () => {
     cy.login("jurisdictionalAdminUser")
     cy.visit("/")
 
-    cy.addMinimalListing(uniqueListingName, false, true)
+    cy.addMinimalListing(uniqueListingName, false, true, false)
     cy.getByID("listing-status-pending-review").should("be.visible")
     cy.signOut()
 

--- a/sites/partners/cypress/e2e/listings-approval/listings-approval.spec.ts
+++ b/sites/partners/cypress/e2e/listings-approval/listings-approval.spec.ts
@@ -5,11 +5,8 @@ describe("Listings approval feature", () => {
     // Partner: Submit a listing for approval
     cy.login("jurisdictionalAdminUser")
     cy.visit("/")
-    cy.getByID("addListingButton").contains("Add Listing").click()
-    cy.contains("New Listing")
-    cy.fixture("minimalListing").then((listing) => {
-      fillOutMinimalListing(cy, listing)
-    })
+
+    cy.addMinimalListing(uniqueListingName, false, true)
     cy.getByID("listing-status-pending-review").should("be.visible")
     cy.signOut()
 
@@ -51,53 +48,5 @@ describe("Listings approval feature", () => {
   function searchAndOpenListing(cy: Cypress.cy, name: string): void {
     cy.getByTestId("ag-search-input").type(name)
     cy.getByTestId(name).click()
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  function fillOutMinimalListing(cy: Cypress.cy, listing: any): void {
-    cy.getByID("name").type(uniqueListingName)
-    cy.getByID("developer").type(listing["developer"])
-    // Test photo upload
-    cy.getByID("add-photos-button").contains("Add Photo").click()
-    cy.getByTestId("dropzone-input").attachFile(
-      "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96.jpeg",
-      {
-        subjectType: "drag-n-drop",
-      }
-    )
-    cy.getByTestId("drawer-photos-table")
-      .find("img")
-      .should("have.attr", "src")
-      .should("include", "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96")
-    cy.getByID("listing-photo-uploaded").contains("Save").click()
-
-    cy.getByID("listingsBuildingAddress.street").type(listing["buildingAddress.street"])
-    cy.getByID("neighborhood").type(listing["neighborhood"])
-    cy.getByID("listingsBuildingAddress.city").type(listing["buildingAddress.city"])
-    cy.getByID("listingsBuildingAddress.state").select(listing["buildingAddress.state"])
-    cy.getByID("listingsBuildingAddress.zipCode").type(listing["buildingAddress.zipCode"])
-
-    cy.getByID("addUnitsButton").contains("Add Unit").click()
-    cy.getByID("number").type(listing["number"])
-    cy.getByID("unitTypes.id").select(listing["unitType.id"])
-    cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
-    cy.getByID("amiChart.id").select(1).trigger("change")
-    cy.getByID("amiPercentage").select(1)
-    cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
-    cy.get("button").contains("Application Process").click()
-
-    cy.getByID("leasingAgentName").type(listing["leasingAgentName"])
-    cy.getByID("leasingAgentEmail").type(listing["leasingAgentEmail"])
-    cy.getByID("leasingAgentPhone").type(listing["leasingAgentPhone"])
-    cy.getByID("digitalApplicationChoiceYes").check()
-    cy.getByID("commonDigitalApplicationChoiceYes").check()
-    cy.getByID("paperApplicationNo").check()
-    cy.getByID("referralOpportunityNo").check()
-
-    cy.getByID("submitButton").contains("Submit").click()
-
-    cy.getByID("submitListingForApprovalButtonConfirm").contains("Submit").click()
-    cy.getByTestId("page-header").should("be.visible")
-    cy.getByTestId("page-header").should("have.text", uniqueListingName)
   }
 })

--- a/sites/partners/cypress/fixtures/partnerUser.json
+++ b/sites/partners/cypress/fixtures/partnerUser.json
@@ -1,0 +1,4 @@
+{
+  "email": "partner@example.com",
+  "password": "Abcdef12345!"
+}

--- a/sites/partners/cypress/support/commands.js
+++ b/sites/partners/cypress/support/commands.js
@@ -392,13 +392,15 @@ Cypress.Commands.add("verifyTerms", (application) => {
   cy.getByTestId("signatureOnTerms").contains(application["acceptedTerms"])
 })
 
-Cypress.Commands.add("addMinimalListing", (listingName, isLottery, isApproval) => {
+Cypress.Commands.add("addMinimalListing", (listingName, isLottery, isApproval, jurisdiction) => {
   // Create and publish minimal lottery listing
   cy.getByID("addListingButton").contains("Add Listing").click()
   cy.contains("New Listing")
   cy.fixture("minimalListing").then((listing) => {
-    cy.getByID("jurisdictions.id").select("Bloomington")
-    cy.getByID("jurisdictions.id-error").should("have.length", 0)
+    if (jurisdiction) {
+      cy.getByID("jurisdictions.id").select("Bloomington")
+      cy.getByID("jurisdictions.id-error").should("have.length", 0)
+    }
     cy.getByID("name").type(listingName)
     cy.getByID("developer").type(listing["developer"])
     cy.getByID("add-photos-button").contains("Add Photo").click()

--- a/sites/partners/cypress/support/commands.js
+++ b/sites/partners/cypress/support/commands.js
@@ -391,3 +391,85 @@ Cypress.Commands.add("verifyHouseholdIncome", (application, fieldsToSkip = []) =
 Cypress.Commands.add("verifyTerms", (application) => {
   cy.getByTestId("signatureOnTerms").contains(application["acceptedTerms"])
 })
+
+Cypress.Commands.add("addMinimalListing", (listingName, isLottery, isApproval) => {
+  // Create and publish minimal lottery listing
+  cy.getByID("addListingButton").contains("Add Listing").click()
+  cy.contains("New Listing")
+  cy.fixture("minimalListing").then((listing) => {
+    cy.getByID("jurisdictions.id").select("Bloomington")
+    cy.getByID("jurisdictions.id-error").should("have.length", 0)
+    cy.getByID("name").type(listingName)
+    cy.getByID("developer").type(listing["developer"])
+    cy.getByID("add-photos-button").contains("Add Photo").click()
+    cy.getByTestId("dropzone-input").attachFile(
+      "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96.jpeg",
+      {
+        subjectType: "drag-n-drop",
+      }
+    )
+    cy.getByTestId("drawer-photos-table")
+      .find("img")
+      .should("have.attr", "src")
+      .should("include", "cypress-automated-image-upload-071e2ab9-5a52-4f34-85f0-e41f696f4b96")
+    cy.getByID("listing-photo-uploaded").contains("Save").click()
+    cy.getByID("listingsBuildingAddress.street").type(listing["buildingAddress.street"])
+    cy.getByID("neighborhood").type(listing["neighborhood"])
+    cy.getByID("listingsBuildingAddress.city").type(listing["buildingAddress.city"])
+    cy.getByID("listingsBuildingAddress.state").select(listing["buildingAddress.state"])
+    cy.getByID("listingsBuildingAddress.zipCode").type(listing["buildingAddress.zipCode"])
+    cy.getByID("addUnitsButton").contains("Add Unit").click()
+    cy.getByID("number").type(listing["number"])
+    cy.getByID("unitTypes.id").select(listing["unitType.id"])
+    cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
+    cy.getByID("amiChart.id").select(1).trigger("change")
+    cy.getByID("amiPercentage").select(1)
+    cy.getByID("unitFormSaveAndExitButton").contains("Save & Exit").click()
+    cy.get("button").contains("Application Process").click()
+    if (isLottery) {
+      cy.getByID("reviewOrderLottery").check()
+      cy.getByTestId("lottery-start-date-month").type("12")
+      cy.getByTestId("lottery-start-date-day").type("17")
+      cy.getByTestId("lottery-start-date-year").type("2026")
+      cy.getByTestId("lottery-start-time-hours").type("10")
+      cy.getByTestId("lottery-start-time-minutes").type("00")
+      cy.getByTestId("lottery-start-time-period").select("AM")
+      cy.getByTestId("lottery-end-time-hours").type("11")
+      cy.getByTestId("lottery-end-time-minutes").type("00")
+      cy.getByTestId("lottery-end-time-period").select("AM")
+    }
+    cy.getByID("leasingAgentName").type(listing["leasingAgentName"])
+    cy.getByID("leasingAgentEmail").type(listing["leasingAgentEmail"])
+    cy.getByID("leasingAgentPhone").type(listing["leasingAgentPhone"])
+    cy.getByID("digitalApplicationChoiceYes").check()
+    cy.getByID("commonDigitalApplicationChoiceYes").check()
+    cy.getByID("paperApplicationNo").check()
+    cy.getByID("referralOpportunityNo").check()
+  })
+
+  if (isApproval) {
+    cy.getByID("submitButton").contains("Submit").click()
+    cy.getByID("submitListingForApprovalButtonConfirm").contains("Submit").click()
+    cy.getByTestId("page-header").should("be.visible")
+    cy.getByTestId("page-header").should("have.text", listingName)
+  } else {
+    cy.getByID("publishButton").contains("Publish").click()
+    cy.getByID("publishButtonConfirm").contains("Publish").click()
+    cy.get("[data-testid=page-header]").should("be.visible")
+    cy.getByTestId("page-header").should("have.text", listingName)
+  }
+})
+
+Cypress.Commands.add("addMinimalApplication", (listingName) => {
+  cy.visit("/")
+  cy.getByTestId(`listing-status-cell-${listingName}`).click()
+  cy.getByID("addApplicationButton").contains("Add Application").click()
+  cy.fixture("applicantOnlyData").then((application) => {
+    cy.fillPrimaryApplicant(application, [
+      "application.additionalPhoneNumber",
+      "application.additionalPhoneNumberType",
+      "application.applicant.address.street2",
+    ])
+  })
+  cy.getByID("submitApplicationButton").click()
+})

--- a/sites/partners/cypress/support/index.d.ts
+++ b/sites/partners/cypress/support/index.d.ts
@@ -41,7 +41,12 @@ declare namespace Cypress {
       fieldsToClick: fieldObj[],
       fieldsToSkip: string[]
     ): Chainable
-    addMinimalListing(listingName: string, isLottery: boolean, isApproval: boolean): Chainable
+    addMinimalListing(
+      listingName: string,
+      isLottery: boolean,
+      isApproval: boolean,
+      jurisdiction: boolean
+    ): Chainable
     addMinimalApplication(listingName: string): Chainable
   }
 }

--- a/sites/partners/cypress/support/index.d.ts
+++ b/sites/partners/cypress/support/index.d.ts
@@ -41,6 +41,8 @@ declare namespace Cypress {
       fieldsToClick: fieldObj[],
       fieldsToSkip: string[]
     ): Chainable
+    addMinimalListing(listingName: string, isLottery: boolean, isApproval: boolean): Chainable
+    addMinimalApplication(listingName: string): Chainable
   }
 }
 /* eslint-enable @typescript-eslint/no-unused-vars */

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -157,6 +157,7 @@ const ListingFormActions = ({
           variant="primary-outlined"
           className="w-full"
           onClick={() => showCloseListingModal && showCloseListingModal()}
+          id={"closeButton"}
         >
           {t("listings.actions.close")}
         </Button>

--- a/sites/partners/src/components/listings/PaperListingForm/dialogs/CloseListingDialog.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/dialogs/CloseListingDialog.tsx
@@ -33,6 +33,7 @@ const CloseListingDialog = ({ isOpen, setOpen, submitFormWithStatus }: CloseList
             submitFormWithStatus("redirect", ListingsStatusEnum.closed)
           }}
           size="sm"
+          id={"close-listing-modal-button"}
         >
           {t("listings.actions.close")}
         </Button>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -172,6 +172,7 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
                             : null,
                         }
                   }
+                  dataTestId={"lottery-start-date"}
                 />
               </Grid.Cell>
               <Grid.Cell>
@@ -201,6 +202,7 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
                           period: new Date(lotteryEvent?.startTime).getHours() >= 12 ? "pm" : "am",
                         }
                   }
+                  dataTestId={"lottery-start-time"}
                 />
               </Grid.Cell>
               <Grid.Cell>
@@ -230,6 +232,7 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
                           period: new Date(lotteryEvent?.endTime).getHours() >= 12 ? "pm" : "am",
                         }
                   }
+                  dataTestId={"lottery-end-time"}
                 />
               </Grid.Cell>
             </Grid.Row>

--- a/sites/partners/src/components/users/FormUserManage.tsx
+++ b/sites/partners/src/components/users/FormUserManage.tsx
@@ -412,6 +412,7 @@ const FormUserManage = ({
               onClick={() => onSave()}
               variant="primary"
               loadingMessage={isUpdateUserLoading && t("t.formSubmitted")}
+              id={"save-user"}
             >
               {t("t.save")}
             </Button>

--- a/sites/partners/src/components/users/JurisdictionAndListingSelection.tsx
+++ b/sites/partners/src/components/users/JurisdictionAndListingSelection.tsx
@@ -87,6 +87,7 @@ const JurisdictionAndListingSelection = ({ jurisdictionOptions, listingsOptions 
                       onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                         updateAllCheckboxes(e, key),
                     }}
+                    dataTestId={`listings-all-${jurisdictionLabel}`}
                   />
 
                   <FieldGroup

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -139,7 +139,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
         <Icon size="xl">
           <Download />
         </Icon>
-        <Heading priority={2} size={"2xl"}>
+        <Heading priority={2} size={"2xl"} id={"lottery-heading"}>
           {t("listings.lottery.export")}
         </Heading>
         <div className={styles["card-description"]}>
@@ -185,6 +185,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                   setRunModal(true)
                 }}
                 disabled={loading || exportLoading}
+                id={"lottery-run-button"}
               >
                 {t("listings.lottery.runLottery")}
               </Button>
@@ -221,6 +222,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 onClick={() => {
                   setPublishModal(true)
                 }}
+                id={"lottery-publish-button"}
               >
                 {t("listings.actions.publish")}
               </Button>
@@ -284,6 +286,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 className={styles["action"]}
                 onClick={() => setReRunModal(true)}
                 variant={"primary-outlined"}
+                id={"lottery-rerun-button"}
               >
                 {t("listings.lottery.reRun")}
               </Button>
@@ -299,6 +302,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                   }
                 }}
                 variant={"primary-outlined"}
+                id={"lottery-release-button"}
               >
                 {t("listings.lottery.release")}
               </Button>
@@ -309,6 +313,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 className={styles["action"]}
                 onClick={() => setRetractModal(true)}
                 variant={"alert-outlined"}
+                id={"lottery-retract-button"}
               >
                 {t("listings.lottery.retract")}
               </Button>
@@ -445,6 +450,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 }}
                 size="sm"
                 loadingMessage={loading || exportLoading ? t("t.loading") : undefined}
+                id={"lottery-run-modal-button"}
               >
                 {duplicatesExist
                   ? t("listings.lottery.runLotteryDuplicates")
@@ -512,6 +518,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 }}
                 size="sm"
                 loadingMessage={loading ? t("t.loading") : null}
+                id={"lottery-rerun-modal-button"}
               >
                 {t("listings.lottery.reRunUnderstand")}
               </Button>
@@ -561,6 +568,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 }}
                 loadingMessage={loading ? t("t.loading") : null}
                 size="sm"
+                id={"lottery-release-modal-button"}
               >
                 {t("listings.lottery.releaseButton")}
               </Button>
@@ -640,6 +648,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 }}
                 loadingMessage={loading ? t("t.loading") : null}
                 size="sm"
+                id={"lottery-retract-modal-button"}
               >
                 {t("listings.lottery.retract")}
               </Button>
@@ -796,6 +805,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 }}
                 loadingMessage={loading ? t("t.loading") : null}
                 size="sm"
+                id={"lottery-publish-modal-button"}
               >
                 {t("listings.lottery.publishLottery")}
               </Button>

--- a/sites/partners/src/pages/users/index.tsx
+++ b/sites/partners/src/pages/users/index.tsx
@@ -44,6 +44,7 @@ const Users = () => {
             <button
               className="text-blue-700 underline"
               onClick={() => setUserDrawer({ type: "edit", user })}
+              id={`user-link-${user.email}`}
             >
               {params.value}
             </button>


### PR DESCRIPTION
This PR addresses #4206

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds a Cypress test for the partners lottery flow happy path (flow described in ticket). It is a longer test (took 54 seconds), and the partners Cypress suite is our longest suite, so this would increase time-to-green by one minute. I think we have space to reduce our other partners Cypress tests that are less effective or should be unit tests (added this to the workshop agenda).

## How Can This Be Tested/Reviewed?

Check out the test if you'd like!

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
