### PR TITLE
fix: update checks to use boolean

### DIFF
--- a/sites/partners/src/components/shared/NavigationHeader.tsx
+++ b/sites/partners/src/components/shared/NavigationHeader.tsx
@@ -66,7 +66,7 @@ const NavigationHeader = ({
       },
     ]
 
-    if (process.env.showLottery === "TRUE" && tabs?.lotteryLabel) {
+    if (process.env.showLottery && tabs?.lotteryLabel) {
       elements.push({
         label: tabs.lotteryLabel,
         path: `/listings/${listingId}/lottery`,

--- a/sites/partners/src/pages/listings/[id]/applications/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/index.tsx
@@ -185,7 +185,7 @@ const ApplicationsList = () => {
                     <Button
                       onClick={() => {
                         if (
-                          process.env.showLottery === "TRUE" &&
+                          process.env.showLottery &&
                           (listingDto.lotteryStatus === LotteryStatusEnum.ran ||
                             listingDto.lotteryStatus === LotteryStatusEnum.releasedToPartners ||
                             listingDto.lotteryStatus === LotteryStatusEnum.publishedToPublic)


### PR DESCRIPTION
This PR addresses #4273
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR updates the use of the show lottery variable so that it reflects the updated next.config

## How Can This Be Tested/Reviewed?

Turn show lottery on and ensure the tab is present on the applications and listing tab when viewing a closed lottery listing.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
