### PR TITLE
fix: allows uploading lottery result update

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
@@ -42,7 +42,10 @@ const LotteryResults = (props: LotteryResultsProps) => {
 
   useEffect(() => {
     if (uploadedPDF) {
-      setCloudinaryData({ url: cloudinaryUrlFromId(uploadedPDF.file?.fileId), id: uploadedPDF.id })
+      setCloudinaryData({
+        url: cloudinaryUrlFromId(uploadedPDF.file?.fileId || uploadedPDF?.assets?.fileId),
+        id: uploadedPDF.id,
+      })
       // Don't allow a new one to be uploaded if one already exists so setting progress to 100%
       setProgressValue(100)
     }

--- a/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/LotteryResults.tsx
@@ -43,7 +43,7 @@ const LotteryResults = (props: LotteryResultsProps) => {
   useEffect(() => {
     if (uploadedPDF) {
       setCloudinaryData({
-        url: cloudinaryUrlFromId(uploadedPDF.file?.fileId || uploadedPDF?.assets?.fileId),
+        url: cloudinaryUrlFromId(uploadedPDF.file?.fileId || uploadedPDF.assets?.fileId),
         id: uploadedPDF.id,
       })
       // Don't allow a new one to be uploaded if one already exists so setting progress to 100%


### PR DESCRIPTION
This PR addresses #4243 

- [x] Addresses the issue in full

## Description
It seems like one of the other commits in to main fixes the issue of the drawer not opening, and this fixes the preview in the table so you can see the preview of the table before its changed

## How Can This Be Tested/Reviewed?
Create or edit a listing such that:
- the listing is closed, marked as running a lottery, marked as NOT running the lottery through the partner site

- upload lottery results

- go in to edit the listing and make sure you can edit the uploaded lottery results (delete results, switch to a different file, etc)

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
