### PR TITLE
fix: correctly bind publish job

### DIFF
--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -96,7 +96,7 @@ export class LotteryService {
       this.prisma,
       LOTTERY_PUBLISH_CRON_JOB_NAME,
       process.env.LOTTERY_PUBLISH_PROCESSING_CRON_STRING,
-      this.expireLotteries.bind(this),
+      this.autoPublishResults.bind(this),
       this.logger,
       this.schedulerRegistry,
     );


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Lottery auto publish cron job was incorrectly binded and thus not running. Now correctly binded.

## How Can This Be Tested/Reviewed?

Set the `LOTTERY_PUBLISH_PROCESSING_CRON_STRING` env var to something in the next few minutes and run the api. Verify "WARN autoPublishLotteryResults job running" and "WARN Changed the status of ${number} lotteries" both appear in the console.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
