### PR TITLE
fix: add back missing import

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   HttpException,
   Inject,
   Injectable,


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Unused import was removed in [saving listing with uploaded lottery](https://github.com/bloom-housing/bloom/pull/4277/files#diff-079326447730b9addbac740f4bcf63427c1f2c0c79be780bc72edcd7706580e4L2) but used in [listing duplication endpoint](https://github.com/bloom-housing/bloom/pull/4307/files#diff-079326447730b9addbac740f4bcf63427c1f2c0c79be780bc72edcd7706580e4R979). Merging missed to re-include import statement.

## How Can This Be Tested/Reviewed?

Run api locally and verify not import error occurs.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
