### PR TITLE
fix: partial character date formatting

### DIFF
--- a/sites/partners/__tests__/lib/helpers.test.ts
+++ b/sites/partners/__tests__/lib/helpers.test.ts
@@ -27,6 +27,12 @@ describe("helpers", () => {
     it("should create dates with variable numbers of characters", () => {
       expect(createDate({ year: "2025", month: "12", day: "10" })).toEqual(new Date(2025, 11, 10))
       expect(createDate({ year: "2025", month: "1", day: "5" })).toEqual(new Date(2025, 0, 5))
+      expect(createDate({ year: "2025", month: "01", day: "05" })).toEqual(new Date(2025, 0, 5))
+    })
+    it("should fail with invalid input", () => {
+      expect(createDate({ year: "202", month: "12", day: "10" })).toBeFalsy()
+      expect(createDate({ year: "2025", month: "13", day: "10" })).toBeFalsy()
+      expect(createDate({ year: "2025", month: "13", day: "35" })).toBeFalsy()
     })
   })
 })

--- a/sites/partners/__tests__/lib/helpers.test.ts
+++ b/sites/partners/__tests__/lib/helpers.test.ts
@@ -1,5 +1,5 @@
 import { Application } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { mergeApplicationNames } from "../../src/lib/helpers"
+import { createDate, mergeApplicationNames } from "../../src/lib/helpers"
 
 describe("helpers", () => {
   describe("mergeApplicationNames", () => {
@@ -21,6 +21,12 @@ describe("helpers", () => {
     })
     it("should merge names for no application", () => {
       expect(mergeApplicationNames([])).toEqual("")
+    })
+  })
+  describe("createDate", () => {
+    it("should create dates with variable numbers of characters", () => {
+      expect(createDate({ year: "2025", month: "12", day: "10" })).toEqual(new Date(2025, 11, 10))
+      expect(createDate({ year: "2025", month: "1", day: "5" })).toEqual(new Date(2025, 0, 5))
     })
   })
 })

--- a/sites/partners/cypress/support/commands.js
+++ b/sites/partners/cypress/support/commands.js
@@ -430,13 +430,13 @@ Cypress.Commands.add("addMinimalListing", (listingName, isLottery, isApproval, j
     cy.get("button").contains("Application Process").click()
     if (isLottery) {
       cy.getByID("reviewOrderLottery").check()
-      cy.getByTestId("lottery-start-date-month").type("12")
+      cy.getByTestId("lottery-start-date-month").type("1")
       cy.getByTestId("lottery-start-date-day").type("17")
       cy.getByTestId("lottery-start-date-year").type("2026")
-      cy.getByTestId("lottery-start-time-hours").type("10")
+      cy.getByTestId("lottery-start-time-hours").type("9")
       cy.getByTestId("lottery-start-time-minutes").type("00")
       cy.getByTestId("lottery-start-time-period").select("AM")
-      cy.getByTestId("lottery-end-time-hours").type("11")
+      cy.getByTestId("lottery-end-time-hours").type("10")
       cy.getByTestId("lottery-end-time-minutes").type("00")
       cy.getByTestId("lottery-end-time-period").select("AM")
     }

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -156,7 +156,7 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
                         }
                       : null
                   }
-                  errorMessage={t("errors.requiredFieldError")}
+                  errorMessage={t("errors.dateError")}
                   defaultDate={
                     errors?.lotteryDate
                       ? null
@@ -184,7 +184,7 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
                   watch={watch}
                   error={errors?.lotteryDate ? true : false}
                   strings={{
-                    timeError: errors?.lotteryDate ? t("errors.requiredFieldError") : null,
+                    timeError: errors?.lotteryDate ? t("errors.dateError") : null,
                   }}
                   defaultValues={
                     errors?.lotteryDate
@@ -214,7 +214,7 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
                   watch={watch}
                   error={errors?.lotteryDate ? true : false}
                   strings={{
-                    timeError: errors?.lotteryDate ? t("errors.requiredFieldError") : null,
+                    timeError: errors?.lotteryDate ? t("errors.dateError") : null,
                   }}
                   defaultValues={
                     errors?.lotteryDate

--- a/sites/partners/src/lib/helpers.ts
+++ b/sites/partners/src/lib/helpers.ts
@@ -145,15 +145,18 @@ export const createTime = (
  * Create Date object depending on DateField component
  */
 export const createDate = (formDate: { year: string; month: string; day: string }) => {
-  if (!formDate || !formDate?.year || !formDate?.month || !formDate?.day) return null
+  const year = formDate?.year
+  let month = formDate?.month
+  let day = formDate?.day
+  if (!formDate || !year || !month || !day || year.length !== 4) return null
 
-  const createdDate = new Date(
-    parseInt(formDate.year),
-    parseInt(formDate.month) - 1,
-    parseInt(formDate.day)
-  )
+  if (day.length === 1) day = `0${day}`
+  if (month.length === 1) month = `0${month}`
 
-  return createdDate
+  const date = dayjs(`${year}-${month}-${day}`, "YYYY-MM-DD", true)
+  if (!date.isValid()) return null
+
+  return date.toDate()
 }
 
 interface FileUploaderParams {

--- a/sites/partners/src/lib/helpers.ts
+++ b/sites/partners/src/lib/helpers.ts
@@ -147,7 +147,13 @@ export const createTime = (
 export const createDate = (formDate: { year: string; month: string; day: string }) => {
   if (!formDate || !formDate?.year || !formDate?.month || !formDate?.day) return null
 
-  return dayjs(`${formDate.year}-${formDate.month}-${formDate.day}`, "YYYY-MM-DD").toDate()
+  const createdDate = new Date(
+    parseInt(formDate.year),
+    parseInt(formDate.month) - 1,
+    parseInt(formDate.day)
+  )
+
+  return createdDate
 }
 
 interface FileUploaderParams {


### PR DESCRIPTION
This PR addresses #4292

- [x] Addresses the issue in full

## Description

Allows you to enter partial dates in the partners listing form (i.e. `9/6/1994` instead of requiring `09/06/1994`)

## How Can This Be Tested/Reviewed?

Attempt to save a listing with a lottery date that has a partial month and day and ensure you don't receive an error.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
