### PR TITLE
fix: dont send lottery emails to duplicate applications

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -278,53 +278,6 @@ export class ListingService implements OnModuleInit {
     return { emails: userEmails, publicUrl };
   }
 
-  public async getPublicUserEmailInfo(
-    listingId?: string,
-  ): Promise<{ [key: string]: string[] }> {
-    const userResults = await this.prisma.applications.findMany({
-      select: {
-        userAccounts: {
-          select: {
-            email: true,
-          },
-        },
-        language: true,
-      },
-      where: {
-        listingId,
-        markedAsDuplicate: {
-          not: true,
-        },
-      },
-    });
-
-    const emailUsers = userResults.filter((user) => !!user.userAccounts?.email);
-
-    const result = {};
-    Object.keys(LanguagesEnum).forEach((languageKey) => {
-      const applications = emailUsers
-        .filter((user) => user.language === languageKey)
-        .map((userObj) => userObj.userAccounts.email);
-      if (applications.length) {
-        result[languageKey] = applications;
-      }
-    });
-
-    const noLanguageIndicated = emailUsers
-      .filter((user) => !user.language)
-      .map((userObj) => userObj.userAccounts.email);
-
-    if (!result[LanguagesEnum.en])
-      result[LanguagesEnum.en] = noLanguageIndicated;
-    else
-      result[LanguagesEnum.en] = [
-        ...result[LanguagesEnum.en],
-        ...noLanguageIndicated,
-      ];
-
-    return result;
-  }
-
   public async listingApprovalNotify(params: {
     user: User;
     listingInfo: IdDTO;

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -283,39 +283,36 @@ export class ListingService implements OnModuleInit {
   ): Promise<{ [key: string]: string[] }> {
     const userResults = await this.prisma.applications.findMany({
       select: {
-        language: true,
-        applicant: {
+        userAccounts: {
           select: {
-            emailAddress: true,
+            email: true,
           },
         },
+        language: true,
       },
       where: {
         listingId,
-        applicant: {
-          emailAddress: {
-            not: null,
-          },
-        },
         markedAsDuplicate: {
           not: true,
         },
       },
     });
 
+    const emailUsers = userResults.filter((user) => !!user.userAccounts?.email);
+
     const result = {};
     Object.keys(LanguagesEnum).forEach((languageKey) => {
-      const applications = userResults
+      const applications = emailUsers
         .filter((user) => user.language === languageKey)
-        .map((userObj) => userObj.applicant.emailAddress);
+        .map((userObj) => userObj.userAccounts.email);
       if (applications.length) {
         result[languageKey] = applications;
       }
     });
 
-    const noLanguageIndicated = userResults
+    const noLanguageIndicated = emailUsers
       .filter((user) => !user.language)
-      .map((userObj) => userObj.applicant.emailAddress);
+      .map((userObj) => userObj.userAccounts.email);
 
     if (!result[LanguagesEnum.en])
       result[LanguagesEnum.en] = noLanguageIndicated;

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -297,6 +297,9 @@ export class ListingService implements OnModuleInit {
             not: null,
           },
         },
+        markedAsDuplicate: {
+          not: true,
+        },
       },
     });
 

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -9,7 +9,7 @@ import {
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import {
-  ApplicationLotteryTotal,
+  LanguagesEnum,
   ListingEventsTypeEnum,
   ListingsStatusEnum,
   LotteryStatusEnum,
@@ -343,6 +343,53 @@ export class LotteryService {
     };
   }
 
+  public async getPublicUserEmailInfo(
+    listingId?: string,
+  ): Promise<{ [key: string]: string[] }> {
+    const userResults = await this.prisma.applications.findMany({
+      select: {
+        userAccounts: {
+          select: {
+            email: true,
+          },
+        },
+        language: true,
+      },
+      where: {
+        listingId,
+        markedAsDuplicate: {
+          not: true,
+        },
+      },
+    });
+
+    const emailUsers = userResults.filter((user) => !!user.userAccounts?.email);
+
+    const result = {};
+    Object.keys(LanguagesEnum).forEach((languageKey) => {
+      const applications = emailUsers
+        .filter((user) => user.language === languageKey)
+        .map((userObj) => userObj.userAccounts.email);
+      if (applications.length) {
+        result[languageKey] = applications;
+      }
+    });
+
+    const noLanguageIndicated = emailUsers
+      .filter((user) => !user.language)
+      .map((userObj) => userObj.userAccounts.email);
+
+    if (!result[LanguagesEnum.en])
+      result[LanguagesEnum.en] = noLanguageIndicated;
+    else
+      result[LanguagesEnum.en] = [
+        ...result[LanguagesEnum.en],
+        ...noLanguageIndicated,
+      ];
+
+    return result;
+  }
+
   async publishLottery(listing: Listing): Promise<SuccessDTO> {
     const partnerUserEmailInfo = await this.listingService.getUserEmailInfo(
       [
@@ -354,8 +401,7 @@ export class LotteryService {
       listing.jurisdictions?.id,
     );
 
-    const publicUserEmailInfo =
-      await this.listingService.getPublicUserEmailInfo(listing.id);
+    const publicUserEmailInfo = await this.getPublicUserEmailInfo(listing.id);
 
     await this.updateLotteryStatus(
       listing.id,

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -1032,9 +1032,12 @@ describe('Lottery Controller Tests', () => {
             confirmationCode: 'ABCD1234',
             submissionType: ApplicationSubmissionTypeEnum.electronical,
             language: LanguagesEnum.en,
-            applicant: {
+            userAccounts: {
               create: {
-                emailAddress: 'applicant@email.com',
+                email: 'applicant@email.com',
+                firstName: 'first',
+                lastName: 'last',
+                passwordHash: 'abcd1234',
               },
             },
           },
@@ -1044,9 +1047,12 @@ describe('Lottery Controller Tests', () => {
             confirmationCode: 'EFGH5678',
             submissionType: ApplicationSubmissionTypeEnum.electronical,
             language: LanguagesEnum.es,
-            applicant: {
+            userAccounts: {
               create: {
-                emailAddress: 'applicant2@email.com',
+                email: 'applicant2@email.com',
+                firstName: 'first',
+                lastName: 'last',
+                passwordHash: 'abcd1234',
               },
             },
           },
@@ -1056,9 +1062,24 @@ describe('Lottery Controller Tests', () => {
             confirmationCode: 'IJKL9012',
             submissionType: ApplicationSubmissionTypeEnum.electronical,
             language: null,
+            userAccounts: {
+              create: {
+                email: 'applicant3@email.com',
+                firstName: 'first',
+                lastName: 'last',
+                passwordHash: 'abcd1234',
+              },
+            },
+          },
+          {
+            preferences: [],
+            status: ApplicationStatusEnum.submitted,
+            confirmationCode: 'MNOP3456',
+            submissionType: ApplicationSubmissionTypeEnum.electronical,
+            language: null,
             applicant: {
               create: {
-                emailAddress: 'applicant3@email.com',
+                emailAddress: 'applicant4@email.com',
               },
             },
           },

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -615,11 +615,9 @@ describe('Testing lottery service', () => {
         emails: ['admin@email.com', 'partner@email.com'],
       });
 
-      jest
-        .spyOn(listingService, 'getPublicUserEmailInfo')
-        .mockResolvedValueOnce({
-          en: ['applicant@email.com'],
-        });
+      jest.spyOn(service, 'getPublicUserEmailInfo').mockResolvedValueOnce({
+        en: ['applicant@email.com'],
+      });
 
       await service.lotteryStatus(
         {
@@ -671,11 +669,9 @@ describe('Testing lottery service', () => {
       jest.spyOn(listingService, 'getUserEmailInfo').mockResolvedValueOnce({
         emails: ['admin@email.com', 'partner@email.com'],
       });
-      jest
-        .spyOn(listingService, 'getPublicUserEmailInfo')
-        .mockResolvedValueOnce({
-          en: ['applicant@email.com'],
-        });
+      jest.spyOn(service, 'getPublicUserEmailInfo').mockResolvedValueOnce({
+        en: ['applicant@email.com'],
+      });
 
       await expect(
         async () =>
@@ -716,11 +712,9 @@ describe('Testing lottery service', () => {
       jest.spyOn(listingService, 'getUserEmailInfo').mockResolvedValueOnce({
         emails: ['admin@email.com', 'partner@email.com'],
       });
-      jest
-        .spyOn(listingService, 'getPublicUserEmailInfo')
-        .mockResolvedValueOnce({
-          en: ['applicant@email.com'],
-        });
+      jest.spyOn(service, 'getPublicUserEmailInfo').mockResolvedValueOnce({
+        en: ['applicant@email.com'],
+      });
 
       await service.lotteryStatus(
         {
@@ -828,11 +822,9 @@ describe('Testing lottery service', () => {
         lotteryStatus: LotteryStatusEnum.ran,
       });
       prisma.jurisdictions.findFirst = jest.fn().mockResolvedValue(null);
-      jest
-        .spyOn(listingService, 'getPublicUserEmailInfo')
-        .mockResolvedValueOnce({
-          en: ['applicant@email.com'],
-        });
+      jest.spyOn(service, 'getPublicUserEmailInfo').mockResolvedValueOnce({
+        en: ['applicant@email.com'],
+      });
 
       jest.spyOn(listingService, 'getUserEmailInfo').mockResolvedValueOnce({
         emails: ['admin@email.com', 'partner@email.com'],


### PR DESCRIPTION
This PR addresses #4312 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

A change to not send lottery published emails to applications that have been marked as a duplicate. Also changes the email we are sending the lottery results to to the email associated with the account that applied, as opposed to the email field on the application, since the account email has been verified. Chatted with Sarah about what this means for HBA and lottery without them having mandated accounts - before we would release lottery in HBA we may have to consider turning mandated accounts on for the public side experience of receiving results - and that we should still use the account email here so folks know when they receive an email they need to login with that email to see the results.

## How Can This Be Tested/Reviewed?

Submit two applications while logged in under different email accounts, but use same name / dob, as a partner mark one as a duplicate, and after publishing the lottery ensure only the valid email received a notification.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
