### PR TITLE
fix: tighten the rules for which afs job

### DIFF
--- a/api/src/services/application-flagged-set.service.ts
+++ b/api/src/services/application-flagged-set.service.ts
@@ -513,7 +513,7 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
             OR: [
               // Only run this job on listings that were closed after the DUPLICATES_CLOSE_DATE
               { closedAt: { gte: duplicatesCloseDate.toDate() } },
-              { closedAt: null },
+              { status: { not: 'closed' } },
             ],
           },
           // Allow the ability to force process even if application flag set has run more recent than last application update
@@ -778,10 +778,6 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
         id: listingId,
         // If DUPLICATES_CLOSE_DATE is in the past only run this job on closed listings
         // from before DUPLICATES_CLOSE_DATE
-        closedAt:
-          duplicatesCloseDate && duplicatesCloseDate < dayjs(new Date())
-            ? { lte: duplicatesCloseDate.toDate() }
-            : undefined,
         AND: [
           {
             OR: [
@@ -797,6 +793,14 @@ export class ApplicationFlaggedSetService implements OnModuleInit {
               },
             ],
           },
+          duplicatesCloseDate && duplicatesCloseDate < dayjs(new Date())
+            ? {
+                AND: [
+                  { closedAt: { lte: duplicatesCloseDate.toDate() } },
+                  { status: { not: 'active' } },
+                ],
+              }
+            : undefined,
         ],
       },
     });

--- a/api/test/integration/application-flagged-set.e2e-spec.ts
+++ b/api/test/integration/application-flagged-set.e2e-spec.ts
@@ -2013,8 +2013,13 @@ describe('Application flagged set Controller Tests', () => {
       });
 
       expect(afs.length).toEqual(2);
-      expect(afs[0].applications).toHaveLength(6);
-      expect(afs[0].applications).toEqual([
+      const combinationAFS = afs.find(
+        (flagSet) =>
+          flagSet.ruleKey ===
+          `${listing}-email1@email.com-${listing}-firstname3-${listing}-lastname3-3-3-3-${listing}-firstname1-${listing}-lastname1-1-1-1`,
+      );
+      expect(combinationAFS.applications).toHaveLength(6);
+      expect(combinationAFS.applications).toEqual([
         { id: app2.id },
         { id: app3.id },
         { id: app4.id },
@@ -2022,13 +2027,19 @@ describe('Application flagged set Controller Tests', () => {
         { id: app7.id },
         { id: app8.id },
       ]);
-      expect(afs[0].ruleKey).toEqual(
+      expect(combinationAFS.rule).toEqual(RuleEnum.combination);
+      expect(combinationAFS.ruleKey).toEqual(
         `${listing}-email1@email.com-${listing}-firstname3-${listing}-lastname3-3-3-3-${listing}-firstname1-${listing}-lastname1-1-1-1`,
       );
-      expect(afs[0].rule).toEqual(RuleEnum.combination);
-      expect(afs[1].applications).toHaveLength(2);
-      expect(afs[1].applications).toEqual([{ id: app1.id }, { id: app5.id }]);
-      expect(afs[1].ruleKey).toEqual(`${listing}-email3@email.com`);
+      const emailAFS = afs.find(
+        (flagSet) => flagSet.ruleKey === `${listing}-email3@email.com`,
+      );
+      expect(emailAFS.applications).toHaveLength(2);
+      expect(emailAFS.applications).toEqual(
+        expect.arrayContaining([{ id: app1.id }, { id: app5.id }]),
+      );
+      expect(emailAFS.rule).toEqual(RuleEnum.email);
+      expect(emailAFS.ruleKey).toEqual(`${listing}-email3@email.com`);
     });
 
     it('should create a new flagged set if applications match on nameAndDOB case insensitive', async () => {

--- a/api/test/unit/services/application-flagged-set.service.spec.ts
+++ b/api/test/unit/services/application-flagged-set.service.spec.ts
@@ -2587,7 +2587,7 @@ describe('Testing application flagged set service', () => {
                   },
                 },
                 {
-                  closedAt: null,
+                  status: { not: 'closed' },
                 },
               ],
             },
@@ -2640,7 +2640,7 @@ describe('Testing application flagged set service', () => {
                   },
                 },
                 {
-                  closedAt: null,
+                  status: { not: 'closed' },
                 },
               ],
             },
@@ -2694,7 +2694,7 @@ describe('Testing application flagged set service', () => {
                   },
                 },
                 {
-                  closedAt: null,
+                  status: { not: 'closed' },
                 },
               ],
             },


### PR DESCRIPTION
This PR addresses #4208 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When the `DUPLICATES_CLOSE_DATE` and `DUPLICATES_PROCESSING_CRON_STRING` environment variables are set 
the new AFS cron job should run for all listings that meet either of the following scenarios:
- Listing is closed after `DUPLICATES_CLOSE_DATE`
- Listing is not yet closed

There is an issue with the second scenario for some listings because we currently don't remove the `closed_at` field when a listing is reopened. This means that the old job will still get triggered if the previously closed time was before the duplicate close date

## How Can This Be Tested/Reviewed?

1. Close a listing
2. Reopen the listing
3. Set `DUPLICATES_CLOSE_DATE` to now (or some time after the time stamp of when you first closed the listing) and restart backend
4. add applications. Preferably multiple and at least one duplication
5. Set both `AFS_PROCESSING_CRON_STRING` and `DUPLICATES_PROCESSING_CRON_STRING` with times that will happen in the next few minutes (makes it so you don't have to wait around forever). It's easier if they are at different times and  `AFS_PROCESSING_CRON_STRING` should be before `DUPLICATES_PROCESSING_CRON_STRING`
6. Restart backend and wait for the cron jobs to go off. Verify that the listing wasn't triggered for the old job, but was for the new one.

## Author Checklist:

- [n/a] Added QA notes to the issue with applicable URLs
- [n/a] Reviewed in a desktop view
- [n/a] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
