### PR TITLE
fix: update retract modal copy

### DIFF
--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -277,7 +277,7 @@
   "listings.lottery.reRunUnderstand": "I understand, re-run lottery",
   "listings.lottery.retract": "Retract lottery",
   "listings.lottery.retractContent": "Retracting the lottery will revoke Partner users’ access to the lottery data, including their ability to publish results to applicants.",
-  "listings.lottery.retractContentRemoval": "If a lottery has already been published, it will also remove any lottery results from applicant accounts and the listing status will be marked as 'Lottery retracted'.",
+  "listings.lottery.retractContentRemoval": "If a lottery has already been published, it will also remove any lottery results from applicant accounts and the listing status will revert to \"applications closed\"",
   "listings.lottery.runLottery": "Run lottery",
   "listings.lottery.runLotteryContent": "Make sure to add all paper applications before running the lottery.",
   "listings.lottery.runLotteryDuplicates": "Run lottery without resolving duplicates",


### PR DESCRIPTION
This PR addresses #4446 
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Changes copy of retract lottery modal

## How Can This Be Tested/Reviewed?

On partners site in lottery tab confirmation modal after clicking retract should have new copy

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
