### PR TITLE
fix: return updated failed login attempts

### DIFF
--- a/api/src/passports/mfa.strategy.ts
+++ b/api/src/passports/mfa.strategy.ts
@@ -17,7 +17,7 @@ import { defaultValidationPipeOptions } from '../utilities/default-validation-pi
 import { Login } from '../dtos/auth/login.dto';
 import { MfaType } from '../enums/mfa/mfa-type-enum';
 import {
-  checkFailedLoginCount,
+  checkUserLockout,
   singleUseCodePresent,
   singleUseCodeInvalid,
 } from '../utilities/passport-validator-utilities';
@@ -58,7 +58,7 @@ export class MfaStrategy extends PassportStrategy(Strategy, 'mfa') {
       );
     }
     //check if user is locked out and update failed login attempts count
-    rawUser.failedLoginAttemptsCount = checkFailedLoginCount(
+    rawUser.failedLoginAttemptsCount = checkUserLockout(
       rawUser.lastLoginAt,
       rawUser.failedLoginAttemptsCount,
       Number(process.env.AUTH_LOCK_LOGIN_AFTER_FAILED_ATTEMPTS),

--- a/api/src/passports/mfa.strategy.ts
+++ b/api/src/passports/mfa.strategy.ts
@@ -17,7 +17,7 @@ import { defaultValidationPipeOptions } from '../utilities/default-validation-pi
 import { Login } from '../dtos/auth/login.dto';
 import { MfaType } from '../enums/mfa/mfa-type-enum';
 import {
-  isUserLockedOut,
+  checkFailedLoginCount,
   singleUseCodePresent,
   singleUseCodeInvalid,
 } from '../utilities/passport-validator-utilities';
@@ -57,7 +57,8 @@ export class MfaStrategy extends PassportStrategy(Strategy, 'mfa') {
         `user ${dto.email} attempted to log in, but does not exist`,
       );
     }
-    isUserLockedOut(
+    //check if user is locked out and update failed login attempts count
+    rawUser.failedLoginAttemptsCount = checkFailedLoginCount(
       rawUser.lastLoginAt,
       rawUser.failedLoginAttemptsCount,
       Number(process.env.AUTH_LOCK_LOGIN_AFTER_FAILED_ATTEMPTS),

--- a/api/src/passports/single-use-code.strategy.ts
+++ b/api/src/passports/single-use-code.strategy.ts
@@ -14,7 +14,7 @@ import { defaultValidationPipeOptions } from '../utilities/default-validation-pi
 import { LoginViaSingleUseCode } from '../dtos/auth/login-single-use-code.dto';
 import { OrderByEnum } from '../enums/shared/order-by-enum';
 import {
-  isUserLockedOut,
+  checkFailedLoginCount,
   singleUseCodePresent,
   singleUseCodeInvalid,
 } from '../utilities/passport-validator-utilities';
@@ -86,7 +86,7 @@ export class SingleUseCodeStrategy extends PassportStrategy(
       );
     }
 
-    isUserLockedOut(
+    rawUser.failedLoginAttemptsCount = checkFailedLoginCount(
       rawUser.lastLoginAt,
       rawUser.failedLoginAttemptsCount,
       Number(process.env.AUTH_LOCK_LOGIN_AFTER_FAILED_ATTEMPTS),

--- a/api/src/passports/single-use-code.strategy.ts
+++ b/api/src/passports/single-use-code.strategy.ts
@@ -14,7 +14,7 @@ import { defaultValidationPipeOptions } from '../utilities/default-validation-pi
 import { LoginViaSingleUseCode } from '../dtos/auth/login-single-use-code.dto';
 import { OrderByEnum } from '../enums/shared/order-by-enum';
 import {
-  checkFailedLoginCount,
+  checkUserLockout,
   singleUseCodePresent,
   singleUseCodeInvalid,
 } from '../utilities/passport-validator-utilities';
@@ -86,7 +86,7 @@ export class SingleUseCodeStrategy extends PassportStrategy(
       );
     }
 
-    rawUser.failedLoginAttemptsCount = checkFailedLoginCount(
+    rawUser.failedLoginAttemptsCount = checkUserLockout(
       rawUser.lastLoginAt,
       rawUser.failedLoginAttemptsCount,
       Number(process.env.AUTH_LOCK_LOGIN_AFTER_FAILED_ATTEMPTS),

--- a/api/src/utilities/passport-validator-utilities.ts
+++ b/api/src/utilities/passport-validator-utilities.ts
@@ -6,14 +6,14 @@ import { HttpException, HttpStatus } from '@nestjs/common';
  * @param failedLoginAttemptsCount the number of times the user failed to log in (stored in db)
  * @param maxAttempts the maximum number of attempts before user is considered locked out (env variable)
  *
- * @returns throws error if user is already locked out
+ * @returns updated value of failed login attempts
  */
-export function isUserLockedOut(
+export function checkFailedLoginCount(
   lastLoginAt: Date,
   failedLoginAttemptsCount: number,
   maxAttempts: number,
   cooldown: number,
-): void {
+): number {
   if (lastLoginAt && failedLoginAttemptsCount >= maxAttempts) {
     // if a user has logged in, but has since gone over their max failed login attempts
     const retryAfter = new Date(lastLoginAt.getTime() + cooldown);
@@ -33,6 +33,7 @@ export function isUserLockedOut(
       );
     }
   }
+  return failedLoginAttemptsCount;
 }
 
 /**

--- a/api/src/utilities/passport-validator-utilities.ts
+++ b/api/src/utilities/passport-validator-utilities.ts
@@ -8,7 +8,7 @@ import { HttpException, HttpStatus } from '@nestjs/common';
  *
  * @returns updated value of failed login attempts
  */
-export function checkFailedLoginCount(
+export function checkUserLockout(
   lastLoginAt: Date,
   failedLoginAttemptsCount: number,
   maxAttempts: number,

--- a/api/test/unit/passports/passport-validator-utilities.spec.ts
+++ b/api/test/unit/passports/passport-validator-utilities.spec.ts
@@ -1,12 +1,12 @@
-import { checkFailedLoginCount } from '../../../src/utilities/passport-validator-utilities';
+import { checkUserLockout } from '../../../src/utilities/passport-validator-utilities';
 
-describe('Testing checkFailedLoginCount', () => {
+describe('Testing checkUserLockout', () => {
   it('should return without erroring and set failedLoginAttemptsCount to be 0 if lockout expired', () => {
     const val = {
       lastLoginAt: new Date('01/01/2024'),
       failedLoginAttemptsCount: 5,
     };
-    const updatedFailedLoginCount = checkFailedLoginCount(
+    const updatedFailedLoginCount = checkUserLockout(
       val.lastLoginAt,
       val.failedLoginAttemptsCount,
       5,
@@ -20,7 +20,7 @@ describe('Testing checkFailedLoginCount', () => {
       lastLoginAt: new Date('01/01/2024'),
       failedLoginAttemptsCount: 2,
     };
-    const updatedFailedLoginCount = checkFailedLoginCount(
+    const updatedFailedLoginCount = checkUserLockout(
       val.lastLoginAt,
       val.failedLoginAttemptsCount,
       5,
@@ -35,12 +35,7 @@ describe('Testing checkFailedLoginCount', () => {
       failedLoginAttemptsCount: 5,
     };
     expect(
-      checkFailedLoginCount(
-        val.lastLoginAt,
-        val.failedLoginAttemptsCount,
-        5,
-        10,
-      ),
+      checkUserLockout(val.lastLoginAt, val.failedLoginAttemptsCount, 5, 10),
     ).rejects.toThrowError(`Failed login attempts exceeded.`);
   });
 });

--- a/api/test/unit/passports/passport-validator-utilities.spec.ts
+++ b/api/test/unit/passports/passport-validator-utilities.spec.ts
@@ -35,7 +35,13 @@ describe('Testing checkUserLockout', () => {
       failedLoginAttemptsCount: 5,
     };
     expect(
-      checkUserLockout(val.lastLoginAt, val.failedLoginAttemptsCount, 5, 10),
+      async () =>
+        await checkUserLockout(
+          val.lastLoginAt,
+          val.failedLoginAttemptsCount,
+          5,
+          10,
+        ),
     ).rejects.toThrowError(`Failed login attempts exceeded.`);
   });
 });

--- a/api/test/unit/passports/passport-validator-utilities.spec.ts
+++ b/api/test/unit/passports/passport-validator-utilities.spec.ts
@@ -1,0 +1,46 @@
+import { checkFailedLoginCount } from '../../../src/utilities/passport-validator-utilities';
+
+describe('Testing checkFailedLoginCount', () => {
+  it('should return without erroring and set failedLoginAttemptsCount to be 0 if lockout expired', () => {
+    const val = {
+      lastLoginAt: new Date('01/01/2024'),
+      failedLoginAttemptsCount: 5,
+    };
+    const updatedFailedLoginCount = checkFailedLoginCount(
+      val.lastLoginAt,
+      val.failedLoginAttemptsCount,
+      5,
+      10,
+    );
+    expect(updatedFailedLoginCount).toEqual(0);
+  });
+
+  it('should return without erroring and leave failed login count unchanged if user is and was not locked out', () => {
+    const val = {
+      lastLoginAt: new Date('01/01/2024'),
+      failedLoginAttemptsCount: 2,
+    };
+    const updatedFailedLoginCount = checkFailedLoginCount(
+      val.lastLoginAt,
+      val.failedLoginAttemptsCount,
+      5,
+      10,
+    );
+    expect(updatedFailedLoginCount).toEqual(2);
+  });
+
+  it('should error if user is still in lockout period', () => {
+    const val = {
+      lastLoginAt: new Date(),
+      failedLoginAttemptsCount: 5,
+    };
+    expect(
+      checkFailedLoginCount(
+        val.lastLoginAt,
+        val.failedLoginAttemptsCount,
+        5,
+        10,
+      ),
+    ).rejects.toThrowError(`Failed login attempts exceeded.`);
+  });
+});


### PR DESCRIPTION
This PR addresses #4473 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR changes the function isUserLockedOut to return the verified failedLoginAttempts count explicitly. Before, it was failing to reset after the lockout period was over because of an assumption that it was pass by reference rather than value.

## How Can This Be Tested/Reviewed?

Note that there is an existing bug in core: https://github.com/bloom-housing/bloom/issues/4284

This can be tested locally by locking out a public user via 5 failed password attempts (you'll have to verify in network tab). Then, go into the DB and set that user's last login at date to be last year. Lastly, try to log in again with an incorrect password and see that the count has been reset (via the network tab).


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
