### PR TITLE
fix: handle empty other race options

### DIFF
--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -542,12 +542,12 @@ export const getHouseholdCsvHeaders = (
 export const convertDemographicRaceToReadable = (type: string): string => {
   const [rootKey, customValue = ''] = type.split(':');
   //only show colon if user entered a custom value
-  const customAppendStr = customValue ? `: ${customValue}` : '';
+  const customValueFormatted = customValue ? `: ${customValue}` : '';
   const typeMap = {
     americanIndianAlaskanNative: 'American Indian / Alaskan Native',
     asian: 'Asian',
     'asian-asianIndian': 'Asian[Asian Indian]',
-    'asian-otherAsian': `Asian[Other Asian${customAppendStr}]`,
+    'asian-otherAsian': `Asian[Other Asian${customValueFormatted}]`,
     blackAfricanAmerican: 'Black / African American',
     'asian-chinese': 'Asian[Chinese]',
     declineToRespond: 'Decline to Respond',
@@ -560,8 +560,8 @@ export const convertDemographicRaceToReadable = (type: string): string => {
       'Native Hawaiian / Other Pacific Islander[Native Hawaiian]',
     nativeHawaiianOtherPacificIslander:
       'Native Hawaiian / Other Pacific Islander',
-    otherMultiracial: `Other / Multiracial${customAppendStr}`,
-    'nativeHawaiianOtherPacificIslander-otherPacificIslander': `Native Hawaiian / Other Pacific Islander[Other Pacific Islander:${customValue}]`,
+    otherMultiracial: `Other / Multiracial${customValueFormatted}`,
+    'nativeHawaiianOtherPacificIslander-otherPacificIslander': `Native Hawaiian / Other Pacific Islander[Other Pacific Islander${customValueFormatted}]`,
     'nativeHawaiianOtherPacificIslander-samoan':
       'Native Hawaiian / Other Pacific Islander[Samoan]',
     'asian-vietnamese': 'Asian[Vietnamese]',

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -541,11 +541,13 @@ export const getHouseholdCsvHeaders = (
  */
 export const convertDemographicRaceToReadable = (type: string): string => {
   const [rootKey, customValue = ''] = type.split(':');
+  //only show colon if user entered a custom value
+  const customAppendStr = customValue ? `: ${customValue}` : '';
   const typeMap = {
     americanIndianAlaskanNative: 'American Indian / Alaskan Native',
     asian: 'Asian',
     'asian-asianIndian': 'Asian[Asian Indian]',
-    'asian-otherAsian': `Asian[Other Asian:${customValue}]`,
+    'asian-otherAsian': `Asian[Other Asian${customAppendStr}]`,
     blackAfricanAmerican: 'Black / African American',
     'asian-chinese': 'Asian[Chinese]',
     declineToRespond: 'Decline to Respond',
@@ -558,7 +560,7 @@ export const convertDemographicRaceToReadable = (type: string): string => {
       'Native Hawaiian / Other Pacific Islander[Native Hawaiian]',
     nativeHawaiianOtherPacificIslander:
       'Native Hawaiian / Other Pacific Islander',
-    otherMultiracial: `Other / Multiracial:${customValue}`,
+    otherMultiracial: `Other / Multiracial${customAppendStr}`,
     'nativeHawaiianOtherPacificIslander-otherPacificIslander': `Native Hawaiian / Other Pacific Islander[Other Pacific Islander:${customValue}]`,
     'nativeHawaiianOtherPacificIslander-samoan':
       'Native Hawaiian / Other Pacific Islander[Samoan]',

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -542,7 +542,7 @@ export const getHouseholdCsvHeaders = (
 export const convertDemographicRaceToReadable = (type: string): string => {
   const [rootKey, customValue = ''] = type.split(':');
   //only show colon if user entered a custom value
-  const customValueFormatted = customValue ? `: ${customValue}` : '';
+  const customValueFormatted = customValue ? `:${customValue}` : '';
   const typeMap = {
     americanIndianAlaskanNative: 'American Indian / Alaskan Native',
     asian: 'Asian',

--- a/api/test/unit/utilities/application-export-helpers.spec.ts
+++ b/api/test/unit/utilities/application-export-helpers.spec.ts
@@ -297,6 +297,12 @@ describe('Testing application export helpers', () => {
       );
     });
 
+    it('tests convertDemographicRaceToReadable with valid type and empty custom value', () => {
+      expect(convertDemographicRaceToReadable('otherMultiracial')).toBe(
+        'Other / Multiracial',
+      );
+    });
+
     it('tests convertDemographicRaceToReadable with type not in typeMap', () => {
       const custom = 'This is a custom value';
       expect(convertDemographicRaceToReadable(custom)).toBe(custom);

--- a/shared-helpers/__tests__/formKeys.test.ts
+++ b/shared-helpers/__tests__/formKeys.test.ts
@@ -60,7 +60,7 @@ describe("formKeys helpers", () => {
       ["root-C"]: "C",
       ["root-D"]: "",
     }
-    const expectedArray = ["A", "B", "C", "D: "]
+    const expectedArray = ["A", "B", "C", "D"]
     expect(fieldGroupObjectToArray(testObj, "root")).toStrictEqual(expectedArray)
   })
 })

--- a/shared-helpers/__tests__/formKeys.test.ts
+++ b/shared-helpers/__tests__/formKeys.test.ts
@@ -52,4 +52,15 @@ describe("formKeys helpers", () => {
     const expectedArray = ["A", "B", "C", "D: 1,2"]
     expect(fieldGroupObjectToArray(testObj, "root")).toStrictEqual(expectedArray)
   })
+
+  it("fieldGroupObjectToArray with empty additional inputs", () => {
+    const testObj = {
+      ["root-A"]: "A",
+      ["root-B"]: "B",
+      ["root-C"]: "C",
+      ["root-D"]: "",
+    }
+    const expectedArray = ["A", "B", "C", "D: "]
+    expect(fieldGroupObjectToArray(testObj, "root")).toStrictEqual(expectedArray)
+  })
 })

--- a/shared-helpers/src/utilities/formKeys.ts
+++ b/shared-helpers/src/utilities/formKeys.ts
@@ -139,7 +139,9 @@ export const fieldGroupObjectToArray = (
   const modifiedArray: string[] = []
   const getValue = (elem: string) => {
     const formSubKey = elem.substring(elem.indexOf("-") + 1)
-    return formSubKey === formObject[elem] ? formSubKey : `${formSubKey}: ${formObject[elem]}`
+    return formSubKey === formObject[elem] || formObject[elem] === ""
+      ? formSubKey
+      : `${formSubKey}: ${formObject[elem]}`
   }
   Object.keys(formObject)
     .filter(

--- a/shared-helpers/src/utilities/formKeys.ts
+++ b/shared-helpers/src/utilities/formKeys.ts
@@ -139,10 +139,20 @@ export const fieldGroupObjectToArray = (
   const modifiedArray: string[] = []
   const getValue = (elem: string) => {
     const formSubKey = elem.substring(elem.indexOf("-") + 1)
-    return formSubKey === formObject[elem] ? formSubKey : `${formSubKey}: ${formObject[elem]}`
+    const value =
+      formSubKey === formObject[elem] || formObject[elem] === ""
+        ? formSubKey
+        : `${formSubKey}: ${formObject[elem]}`
+    console.log(value)
+    return value
   }
   Object.keys(formObject)
-    .filter((formValue) => formValue.split("-")[0] === rootKey && formObject[formValue])
+    .filter(
+      (formValue) =>
+        formValue.split("-")[0] === rootKey &&
+        //empty string handles selected checkbox fields with empty additionalText
+        (formObject[formValue] || formObject[formValue] === "")
+    )
     .forEach((elem) => {
       if (formObject[elem].isArray) {
         formObject[elem].forEach(() => {

--- a/shared-helpers/src/utilities/formKeys.ts
+++ b/shared-helpers/src/utilities/formKeys.ts
@@ -139,12 +139,7 @@ export const fieldGroupObjectToArray = (
   const modifiedArray: string[] = []
   const getValue = (elem: string) => {
     const formSubKey = elem.substring(elem.indexOf("-") + 1)
-    const value =
-      formSubKey === formObject[elem] || formObject[elem] === ""
-        ? formSubKey
-        : `${formSubKey}: ${formObject[elem]}`
-    console.log(value)
-    return value
+    return formSubKey === formObject[elem] ? formSubKey : `${formSubKey}: ${formObject[elem]}`
   }
   Object.keys(formObject)
     .filter(


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1009

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue
The ticket also mentions cleaning up the instances where doorway entered a space to get the "other" field to save which this PR doesn't cover.

## Description

This PR includes two different empty string checks in the formKeys file which prevents the selection of other without entering further information from being filtered out or being stored with a colon and space. 

## How Can This Be Tested/Reviewed?

This can be tested by 
a) submitting an online app with a mix of demographic data (including other selections without any text inputted) and going to the partners portal to see that it was stored correctly
b) submit a **paper** app to the same listing with a unique mix of demographic data also including empty other selections and then edit this paper app multiple times to ensure that the selections are saved
c) export the applications to that listing to see that they print in a legible way.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
