### PR TITLE
fix: clear household members for Submit & New in Applications

### DIFF
--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -160,6 +160,7 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
           void router.push(`/application/${result.id}`)
         } else {
           reset()
+          setHouseholdMembers([])
           clearErrors()
           setAlert(null)
           await router.push(`/listings/${listingId}/applications/add`)


### PR DESCRIPTION
This PR addresses #4298

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The Household Members section of an Application form was persisting across "Submit & New" saves in Partners, which this PR fixes.

## How Can This Be Tested/Reviewed?

Try saving a new Application with additional Household Members by clicking Submit & New, and then verify there are no members (the form is fully cleared).

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
