### PR TITLE
fix: add additional logging for bulk email sends

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
     logger:
       process.env.NODE_ENV === 'development'
         ? ['error', 'warn', 'log', 'debug']
-        : ['error', 'warn'],
+        : ['error', 'warn', 'log'],
   });
   const allowList = process.env.CORS_ORIGINS || [];
   const allowListRegex = process.env.CORS_REGEX

--- a/api/src/modules/email.module.ts
+++ b/api/src/modules/email.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MailService } from '@sendgrid/mail';
 import { EmailService } from '../services/email.service';
@@ -18,6 +18,7 @@ import { SendGridService } from '../services/sendgrid.service';
     GoogleTranslateService,
     SendGridService,
     MailService,
+    Logger,
   ],
   exports: [EmailService],
 })

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, Injectable } from '@nestjs/common';
+import { HttpException, Inject, Injectable, Logger } from '@nestjs/common';
 import { ResponseError } from '@sendgrid/helpers/classes';
 import { MailDataRequired } from '@sendgrid/helpers/classes/mail';
 import fs from 'fs';
@@ -44,6 +44,8 @@ export class EmailService {
     private readonly sendGrid: SendGridService,
     private readonly translationService: TranslationService,
     private readonly jurisdictionService: JurisdictionService,
+    @Inject(Logger)
+    private logger = new Logger(EmailService.name),
   ) {
     this.polyglot = new Polyglot({
       phrases: {},
@@ -401,6 +403,9 @@ export class EmailService {
     try {
       const jurisdiction = await this.getJurisdiction([jurisdictionId]);
       void (await this.loadTranslations(jurisdiction));
+      this.logger.log(
+        `Sending request approval email for listing ${listingInfo.name} to ${emails.length} emails`,
+      );
       await this.send(
         emails,
         jurisdiction.emailFromAddress,
@@ -428,6 +433,9 @@ export class EmailService {
         ? await this.getJurisdiction([{ id: listingInfo.juris }])
         : user.jurisdictions[0];
       void (await this.loadTranslations(jurisdiction));
+      this.logger.log(
+        `Sending changes requested email for listing ${listingInfo.name} to ${emails.length} emails`,
+      );
       await this.send(
         emails,
         jurisdiction.emailFromAddress,
@@ -453,6 +461,9 @@ export class EmailService {
     try {
       const jurisdiction = await this.getJurisdiction([jurisdictionId]);
       void (await this.loadTranslations(jurisdiction));
+      this.logger.log(
+        `Sending listing approved email for listing ${listingInfo.name} to ${emails.length} emails`,
+      );
       await this.send(
         emails,
         jurisdiction.emailFromAddress,
@@ -548,6 +559,9 @@ export class EmailService {
         { id: listingInfo.juris },
       ]);
       void (await this.loadTranslations(jurisdiction));
+      this.logger.log(
+        `Sending lottery released email for listing ${listingInfo.name} to ${emails.length} emails`,
+      );
       await this.send(
         emails,
         jurisdiction.emailFromAddress,
@@ -576,6 +590,9 @@ export class EmailService {
         { id: listingInfo.juris },
       ]);
       void (await this.loadTranslations(jurisdiction));
+      this.logger.log(
+        `Sending lottery published admin email for listing ${listingInfo.name} to ${emails.length} emails`,
+      );
       await this.send(
         emails,
         jurisdiction.emailFromAddress,
@@ -607,6 +624,9 @@ export class EmailService {
 
       for (const language in emails) {
         void (await this.loadTranslations(null, language as LanguagesEnum));
+        this.logger.log(
+          `Sending lottery published ${language} email for listing ${listingInfo.name} to ${emails[language]?.length} emails`,
+        );
         await this.send(
           emails[language],
           jurisdiction.emailFromAddress,

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -203,7 +203,7 @@ export class UserService {
         confirmationToken,
       );
 
-      this.emailService.changeEmail(
+      await this.emailService.changeEmail(
         dto.jurisdictions && dto.jurisdictions[0]
           ? dto.jurisdictions[0].name
           : jurisdictionName,
@@ -366,7 +366,7 @@ export class UserService {
           dto.appUrl,
           confirmationToken,
         );
-        this.emailService.welcome(
+        await this.emailService.welcome(
           storedUser.jurisdictions && storedUser.jurisdictions.length
             ? storedUser.jurisdictions[0].name
             : null,
@@ -379,7 +379,7 @@ export class UserService {
           dto.appUrl,
           confirmationToken,
         );
-        this.emailService.invitePartnerUser(
+        await this.emailService.invitePartnerUser(
           storedUser.jurisdictions,
           storedUser as unknown as User,
           dto.appUrl,
@@ -438,7 +438,7 @@ export class UserService {
         id: storedUser.id,
       },
     });
-    this.emailService.forgotPassword(
+    await this.emailService.forgotPassword(
       storedUser.jurisdictions,
       mapTo(User, storedUser),
       dto.appUrl,
@@ -711,7 +711,7 @@ export class UserService {
           dto.appUrl,
           confirmationToken,
         );
-        this.emailService.welcome(
+        await this.emailService.welcome(
           jurisdictionName,
           mapTo(User, newUser),
           dto.appUrl,
@@ -723,7 +723,7 @@ export class UserService {
         this.configService.get('PARTNERS_PORTAL_URL'),
         confirmationToken,
       );
-      this.emailService.invitePartnerUser(
+      await this.emailService.invitePartnerUser(
         dto.jurisdictions,
         mapTo(User, newUser),
         this.configService.get('PARTNERS_PORTAL_URL'),

--- a/api/test/integration/user.e2e-spec.ts
+++ b/api/test/integration/user.e2e-spec.ts
@@ -84,723 +84,745 @@ describe('User Controller Tests', () => {
     await app.close();
   });
 
-  // without clearing the db between tests or test suites this is flakes because of other e2e tests
-  it.skip('should get no users from list() when no params and no data', async () => {
-    const res = await request(app.getHttpServer())
-      .get(`/user/list?`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .expect(200);
-    expect(res.body.items.length).toEqual(0);
+  describe('list endpoint', () => {
+    // without clearing the db between tests or test suites this is flakes because of other e2e tests
+    it.skip('should get no users from list() when no params and no data', async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/user/list?`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(200);
+      expect(res.body.items.length).toEqual(0);
+    });
+
+    it('should get users from list() when no params', async () => {
+      await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+      await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .get(`/user/list?`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+      expect(res.body.items.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('should get users from list() when params sent', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory({
+          roles: { isPartner: true },
+          firstName: '1110',
+        }),
+      });
+      const userB = await prisma.userAccounts.create({
+        data: await userFactory({
+          roles: { isPartner: true },
+          firstName: '1111',
+        }),
+      });
+
+      const queryParams: UserQueryParams = {
+        limit: 2,
+        page: 1,
+        filter: [
+          {
+            isPortalUser: true,
+          },
+        ],
+        search: '111',
+      };
+      const query = stringify(queryParams as any);
+
+      const res = await request(app.getHttpServer())
+        .get(`/user/list?${query}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+      expect(res.body.items.length).toBeGreaterThanOrEqual(2);
+      const ids = res.body.items.map((item) => item.id);
+      expect(ids).toContain(userA.id);
+      expect(ids).toContain(userB.id);
+    });
   });
 
-  it('should get users from list() when no params', async () => {
-    await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-    await prisma.userAccounts.create({
-      data: await userFactory(),
+  describe('retrieve endpoint', () => {
+    it("should error when retrieve() called with id that doesn't exist", async () => {
+      const id = randomUUID();
+      const res = await request(app.getHttpServer())
+        .get(`/user/${id}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(404);
+      expect(res.body.message).toEqual(
+        `user id: ${id} was requested but not found`,
+      );
     });
 
-    const res = await request(app.getHttpServer())
-      .get(`/user/list?`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .set('Cookie', cookies)
-      .expect(200);
-    expect(res.body.items.length).toBeGreaterThanOrEqual(2);
+    it('should get user from retrieve()', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .get(`/user/${userA.id}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+
+      expect(res.body.id).toEqual(userA.id);
+    });
   });
 
-  it('should get users from list() when params sent', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory({
-        roles: { isPartner: true },
-        firstName: '1110',
-      }),
-    });
-    const userB = await prisma.userAccounts.create({
-      data: await userFactory({
-        roles: { isPartner: true },
-        firstName: '1111',
-      }),
+  describe('update endpoint', () => {
+    it('should update user when user exists', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .put(`/user/${userA.id}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          id: userA.id,
+          firstName: 'New User First Name',
+          lastName: 'New User Last Name',
+        } as UserUpdate)
+        .set('Cookie', cookies)
+        .expect(200);
+
+      expect(res.body.id).toEqual(userA.id);
+      expect(res.body.firstName).toEqual('New User First Name');
+      expect(res.body.lastName).toEqual('New User Last Name');
     });
 
-    const queryParams: UserQueryParams = {
-      limit: 2,
-      page: 1,
-      filter: [
-        {
-          isPortalUser: true,
+    it("should error when updating user that doesn't exist", async () => {
+      await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+      const randomId = randomUUID();
+      const res = await request(app.getHttpServer())
+        .put(`/user/${randomId}`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          id: randomId,
+          firstName: 'New User First Name',
+          lastName: 'New User Last Name',
+        } as UserUpdate)
+        .set('Cookie', cookies)
+        .expect(404);
+
+      expect(res.body.message).toEqual(
+        `user id: ${randomId} was requested but not found`,
+      );
+    });
+  });
+
+  describe('delete endpoint', () => {
+    it('should delete user when user exists', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .delete(`/user/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          id: userA.id,
+        } as IdDTO)
+        .set('Cookie', cookies)
+        .expect(200);
+
+      expect(res.body.success).toEqual(true);
+    });
+
+    it("should error when deleting user that doesn't exist", async () => {
+      const randomId = randomUUID();
+      const res = await request(app.getHttpServer())
+        .delete(`/user/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          id: randomId,
+        } as IdDTO)
+        .set('Cookie', cookies)
+        .expect(404);
+
+      expect(res.body.message).toEqual(
+        `user id: ${randomId} was requested but not found`,
+      );
+    });
+  });
+
+  describe('resend confirmation endpoint', () => {
+    it('should resend confirmation for public when user exists', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .post(`/user/resend-confirmation/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: 'https://www.google.com',
+        } as EmailAndAppUrl)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.body.success).toEqual(true);
+      const mockWelcome = jest.spyOn(testEmailService, 'welcome');
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
         },
-      ],
-      search: '111',
-    };
-    const query = stringify(queryParams as any);
+      });
 
-    const res = await request(app.getHttpServer())
-      .get(`/user/list?${query}`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .set('Cookie', cookies)
-      .expect(200);
-    expect(res.body.items.length).toBeGreaterThanOrEqual(2);
-    const ids = res.body.items.map((item) => item.id);
-    expect(ids).toContain(userA.id);
-    expect(ids).toContain(userB.id);
-  });
-
-  it("should error when retrieve() called with id that doesn't exist", async () => {
-    const id = randomUUID();
-    const res = await request(app.getHttpServer())
-      .get(`/user/${id}`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .set('Cookie', cookies)
-      .expect(404);
-    expect(res.body.message).toEqual(
-      `user id: ${id} was requested but not found`,
-    );
-  });
-
-  it('should get user from retrieve()', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
+      expect(userPostResend.email).toBe(userA.email);
+      expect(userPostResend.confirmationToken).not.toBeNull();
+      expect(mockWelcome.mock.calls.length).toBe(1);
     });
 
-    const res = await request(app.getHttpServer())
-      .get(`/user/${userA.id}`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .set('Cookie', cookies)
-      .expect(200);
-
-    expect(res.body.id).toEqual(userA.id);
-  });
-
-  it('should update user when user exists', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-
-    const res = await request(app.getHttpServer())
-      .put(`/user/${userA.id}`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        id: userA.id,
-        firstName: 'New User First Name',
-        lastName: 'New User Last Name',
-      } as UserUpdate)
-      .set('Cookie', cookies)
-      .expect(200);
-
-    expect(res.body.id).toEqual(userA.id);
-    expect(res.body.firstName).toEqual('New User First Name');
-    expect(res.body.lastName).toEqual('New User Last Name');
-  });
-
-  it("should error when updating user that doesn't exist", async () => {
-    await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-    const randomId = randomUUID();
-    const res = await request(app.getHttpServer())
-      .put(`/user/${randomId}`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        id: randomId,
-        firstName: 'New User First Name',
-        lastName: 'New User Last Name',
-      } as UserUpdate)
-      .set('Cookie', cookies)
-      .expect(404);
-
-    expect(res.body.message).toEqual(
-      `user id: ${randomId} was requested but not found`,
-    );
-  });
-
-  it('should delete user when user exists', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-
-    const res = await request(app.getHttpServer())
-      .delete(`/user/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        id: userA.id,
-      } as IdDTO)
-      .set('Cookie', cookies)
-      .expect(200);
-
-    expect(res.body.success).toEqual(true);
-  });
-
-  it("should error when deleting user that doesn't exist", async () => {
-    const randomId = randomUUID();
-    const res = await request(app.getHttpServer())
-      .delete(`/user/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        id: randomId,
-      } as IdDTO)
-      .set('Cookie', cookies)
-      .expect(404);
-
-    expect(res.body.message).toEqual(
-      `user id: ${randomId} was requested but not found`,
-    );
-  });
-
-  it('should resend confirmation for public when user exists', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-
-    const res = await request(app.getHttpServer())
-      .post(`/user/resend-confirmation/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: 'https://www.google.com',
-      } as EmailAndAppUrl)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.body.success).toEqual(true);
-    const mockWelcome = jest.spyOn(testEmailService, 'welcome');
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.email).toBe(userA.email);
-    expect(userPostResend.confirmationToken).not.toBeNull();
-    expect(mockWelcome.mock.calls.length).toBe(1);
-  });
-
-  it('should succeed when trying to resend confirmation but not update record when user is already confirmed', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: {
-        ...(await userFactory()),
-        confirmedAt: new Date(),
-      },
-    });
-
-    const mockWelcome = jest.spyOn(testEmailService, 'welcome');
-    const res = await request(app.getHttpServer())
-      .post(`/user/resend-confirmation/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: 'https://www.google.com',
-      } as EmailAndAppUrl)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.body.success).toEqual(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.email).toBe(userA.email);
-    expect(userPostResend.confirmationToken).toBeNull();
-    expect(mockWelcome.mock.calls.length).toBe(0);
-  });
-
-  it('should error trying to resend confirmation but no user exists', async () => {
-    const email = 'test@nonexistent.com';
-    const mockWelcome = jest.spyOn(testEmailService, 'welcome');
-    const res = await request(app.getHttpServer())
-      .post(`/user/resend-confirmation/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: email,
-        appUrl: 'https://www.google.com',
-      } as EmailAndAppUrl)
-      .set('Cookie', cookies)
-      .expect(404);
-
-    expect(res.body.message).toEqual(
-      `user email: ${email} was requested but not found`,
-    );
-    expect(mockWelcome.mock.calls.length).toBe(0);
-  });
-
-  it('should resend partner confirmation when user exists', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-    const mockinvitePartnerUser = jest.spyOn(
-      testEmailService,
-      'invitePartnerUser',
-    );
-    const res = await request(app.getHttpServer())
-      .post(`/user/resend-partner-confirmation/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: 'https://www.google.com',
-      } as EmailAndAppUrl)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.body.success).toEqual(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.email).toBe(userA.email);
-    expect(userPostResend.confirmationToken).not.toBeNull();
-    expect(mockinvitePartnerUser.mock.calls.length).toBe(1);
-  });
-
-  it('should succeed when trying to resend partner confirmation but not update record when user is already confirmed', async () => {
-    const mockinvitePartnerUser = jest.spyOn(
-      testEmailService,
-      'invitePartnerUser',
-    );
-    const userA = await prisma.userAccounts.create({
-      data: {
-        ...(await userFactory()),
-        confirmedAt: new Date(),
-      },
-    });
-
-    const res = await request(app.getHttpServer())
-      .post(`/user/resend-partner-confirmation/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: 'https://www.google.com',
-      } as EmailAndAppUrl)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.body.success).toEqual(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.email).toBe(userA.email);
-    expect(userPostResend.confirmationToken).toBeNull();
-    expect(mockinvitePartnerUser.mock.calls.length).toBe(0);
-  });
-
-  it('should error trying to resend partner confirmation but no user exists', async () => {
-    const email = 'test@nonexistent.com';
-    const res = await request(app.getHttpServer())
-      .post(`/user/resend-partner-confirmation/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: email,
-        appUrl: 'https://www.google.com',
-      } as EmailAndAppUrl)
-      .set('Cookie', cookies)
-      .expect(404);
-
-    expect(res.body.message).toEqual(
-      `user email: ${email} was requested but not found`,
-    );
-  });
-
-  it('should verify token as valid', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-
-    const confToken = userService.createConfirmationToken(
-      userA.id,
-      userA.email,
-    );
-    await prisma.userAccounts.update({
-      where: {
-        id: userA.id,
-      },
-      data: {
-        confirmationToken: confToken,
-        confirmedAt: null,
-      },
-    });
-    const res = await request(app.getHttpServer())
-      .post(`/user/is-confirmation-token-valid/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        token: confToken,
-      } as ConfirmationRequest)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.body.success).toEqual(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.hitConfirmationUrl).not.toBeNull();
-    expect(userPostResend.confirmationToken).toEqual(confToken);
-  });
-
-  it('should fail to verify token when incorrect user id is provided', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-
-    const storedConfToken = userService.createConfirmationToken(
-      userA.id,
-      userA.email,
-    );
-    await prisma.userAccounts.update({
-      where: {
-        id: userA.id,
-      },
-      data: {
-        confirmationToken: storedConfToken,
-        confirmedAt: null,
-      },
-    });
-
-    const fakeConfToken = userService.createConfirmationToken(
-      randomUUID(),
-      userA.email,
-    );
-    const res = await request(app.getHttpServer())
-      .post(`/user/is-confirmation-token-valid/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        token: fakeConfToken,
-      } as ConfirmationRequest)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.status).toBe(201);
-    expect(res.body.success).toBe(undefined);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.hitConfirmationUrl).toBeNull();
-  });
-
-  it('should fail to verify token when token mismatch', async () => {
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory(),
-    });
-
-    const storedConfToken = userService.createConfirmationToken(
-      userA.id,
-      userA.email,
-    );
-    await prisma.userAccounts.update({
-      where: {
-        id: userA.id,
-      },
-      data: {
-        confirmationToken: storedConfToken,
-        confirmedAt: null,
-      },
-    });
-
-    const fakeConfToken = userService.createConfirmationToken(
-      userA.id,
-      userA.email + 'x',
-    );
-    const res = await request(app.getHttpServer())
-      .post(`/user/is-confirmation-token-valid/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        token: fakeConfToken,
-      } as ConfirmationRequest)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.status).toBe(201);
-    expect(res.body.success).toBe(undefined);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.hitConfirmationUrl).toBeNull();
-  });
-
-  it('should set resetToken when forgot-password is called by public user on the public site', async () => {
-    const juris = await prisma.jurisdictions.create({
-      data: jurisdictionFactory(),
-    });
-
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory({ jurisdictionIds: [juris.id] }),
-    });
-
-    const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
-    const res = await request(app.getHttpServer())
-      .put(`/user/forgot-password/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: juris.publicUrl,
-      } as EmailAndAppUrl)
-      .expect(200);
-
-    expect(res.body.success).toBe(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.resetToken).not.toBeNull();
-    expect(mockforgotPassword.mock.calls.length).toBe(1);
-  });
-
-  it('should not set resetToken when forgot-password is called by public user on the partners site', async () => {
-    const juris = await prisma.jurisdictions.create({
-      data: jurisdictionFactory(),
-    });
-
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory({ jurisdictionIds: [juris.id] }),
-    });
-
-    const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
-    const res = await request(app.getHttpServer())
-      .put(`/user/forgot-password/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: process.env.PARTNERS_PORTAL_URL,
-      } as EmailAndAppUrl)
-      .expect(200);
-
-    expect(res.body.success).toBe(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.resetToken).toBeNull();
-    expect(mockforgotPassword.mock.calls.length).toBe(0);
-  });
-
-  it('should set resetToken when forgot-password is called by partner user on the partners site', async () => {
-    const juris = await prisma.jurisdictions.create({
-      data: jurisdictionFactory(),
-    });
-
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory({
-        roles: { isAdmin: true },
-        jurisdictionIds: [juris.id],
-      }),
-    });
-
-    const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
-    const res = await request(app.getHttpServer())
-      .put(`/user/forgot-password/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: process.env.PARTNERS_PORTAL_URL,
-      } as EmailAndAppUrl)
-      .expect(200);
-
-    expect(res.body.success).toBe(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.resetToken).not.toBeNull();
-    expect(mockforgotPassword.mock.calls.length).toBe(1);
-  });
-
-  it('should not set resetToken when forgot-password is called by partner user on the public site', async () => {
-    const juris = await prisma.jurisdictions.create({
-      data: jurisdictionFactory(),
-    });
-
-    const userA = await prisma.userAccounts.create({
-      data: await userFactory({
-        roles: { isAdmin: true },
-        jurisdictionIds: [juris.id],
-      }),
-    });
-
-    const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
-    const res = await request(app.getHttpServer())
-      .put(`/user/forgot-password/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: userA.email,
-        appUrl: juris.publicUrl,
-      } as EmailAndAppUrl)
-      .expect(200);
-
-    expect(res.body.success).toBe(true);
-
-    const userPostResend = await prisma.userAccounts.findUnique({
-      where: {
-        id: userA.id,
-      },
-    });
-
-    expect(userPostResend.resetToken).toBeNull();
-    expect(mockforgotPassword.mock.calls.length).toBe(0);
-  });
-
-  it('should create public user', async () => {
-    const juris = await prisma.jurisdictions.create({
-      data: jurisdictionFactory(),
-    });
-
-    const data = await applicationFactory();
-    data.applicant.create.emailAddress = 'publicuser@email.com';
-    const application = await prisma.applications.create({
-      data,
-    });
-
-    const res = await request(app.getHttpServer())
-      .post(`/user/`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        firstName: 'Public User firstName',
-        lastName: 'Public User lastName',
-        password: 'Abcdef12345!',
-        email: 'publicUser@email.com',
-        jurisdictions: [{ id: juris.id }],
-      } as UserCreate)
-      .set('Cookie', cookies)
-      .expect(201);
-
-    expect(res.body.firstName).toEqual('Public User firstName');
-    expect(res.body.jurisdictions).toEqual([
-      expect.objectContaining({ id: juris.id, name: juris.name }),
-    ]);
-    expect(res.body.email).toEqual('publicuser@email.com');
-
-    const applicationsOnUser = await prisma.userAccounts.findUnique({
-      include: {
-        applications: true,
-      },
-      where: {
-        id: res.body.id,
-      },
-    });
-    expect(applicationsOnUser.applications.map((app) => app.id)).toContain(
-      application.id,
-    );
-  });
-
-  it('should create partner user', async () => {
-    const juris = await prisma.jurisdictions.create({
-      data: jurisdictionFactory(),
-    });
-
-    const res = await request(app.getHttpServer())
-      .post(`/user/invite`)
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        firstName: 'Partner User firstName',
-        lastName: 'Partner User lastName',
-        password: 'Abcdef12345!',
-        email: 'partnerUser@email.com',
-        jurisdictions: [{ id: juris.id }],
-        agreedToTermsOfService: true,
-        userRoles: {
-          isAdmin: true,
+    it('should succeed when trying to resend confirmation but not update record when user is already confirmed', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: {
+          ...(await userFactory()),
+          confirmedAt: new Date(),
         },
-      } as UserInvite)
-      .set('Cookie', cookies)
-      .expect(201);
+      });
 
-    expect(res.body.firstName).toEqual('Partner User firstName');
-    expect(res.body.jurisdictions).toEqual([
-      expect.objectContaining({ id: juris.id, name: juris.name }),
-    ]);
-    expect(res.body.email).toEqual('partneruser@email.com');
+      const mockWelcome = jest.spyOn(testEmailService, 'welcome');
+      const res = await request(app.getHttpServer())
+        .post(`/user/resend-confirmation/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: 'https://www.google.com',
+        } as EmailAndAppUrl)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.body.success).toEqual(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.email).toBe(userA.email);
+      expect(userPostResend.confirmationToken).toBeNull();
+      expect(mockWelcome.mock.calls.length).toBe(0);
+    });
+
+    it('should error trying to resend confirmation but no user exists', async () => {
+      const email = 'test@nonexistent.com';
+      const mockWelcome = jest.spyOn(testEmailService, 'welcome');
+      const res = await request(app.getHttpServer())
+        .post(`/user/resend-confirmation/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: email,
+          appUrl: 'https://www.google.com',
+        } as EmailAndAppUrl)
+        .set('Cookie', cookies)
+        .expect(404);
+
+      expect(res.body.message).toEqual(
+        `user email: ${email} was requested but not found`,
+      );
+      expect(mockWelcome.mock.calls.length).toBe(0);
+    });
   });
 
-  it('should request single use code successfully', async () => {
-    const storedUser = await prisma.userAccounts.create({
-      data: await userFactory({
-        roles: { isAdmin: true },
-        mfaEnabled: true,
-        confirmedAt: new Date(),
-        phoneNumber: '111-111-1111',
-        phoneNumberVerified: true,
-      }),
+  describe('resend confirmation partners endpoint', () => {
+    it('should resend partner confirmation when user exists', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+      const mockinvitePartnerUser = jest.spyOn(
+        testEmailService,
+        'invitePartnerUser',
+      );
+      const res = await request(app.getHttpServer())
+        .post(`/user/resend-partner-confirmation/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: 'https://www.google.com',
+        } as EmailAndAppUrl)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.body.success).toEqual(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.email).toBe(userA.email);
+      expect(userPostResend.confirmationToken).not.toBeNull();
+      expect(mockinvitePartnerUser.mock.calls.length).toBe(1);
     });
 
-    const jurisdiction = await prisma.jurisdictions.create({
-      data: {
-        name: 'single_use_code_1',
-        allowSingleUseCodeLogin: true,
-        rentalAssistanceDefault: 'test',
-      },
+    it('should succeed when trying to resend partner confirmation but not update record when user is already confirmed', async () => {
+      const mockinvitePartnerUser = jest.spyOn(
+        testEmailService,
+        'invitePartnerUser',
+      );
+      const userA = await prisma.userAccounts.create({
+        data: {
+          ...(await userFactory()),
+          confirmedAt: new Date(),
+        },
+      });
+
+      const res = await request(app.getHttpServer())
+        .post(`/user/resend-partner-confirmation/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: 'https://www.google.com',
+        } as EmailAndAppUrl)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.body.success).toEqual(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.email).toBe(userA.email);
+      expect(userPostResend.confirmationToken).toBeNull();
+      expect(mockinvitePartnerUser.mock.calls.length).toBe(0);
     });
-    emailService.sendSingleUseCode = jest.fn();
 
-    const res = await request(app.getHttpServer())
-      .post('/user/request-single-use-code')
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: storedUser.email,
-      } as RequestMfaCode)
-      .set({ jurisdictionname: jurisdiction.name })
-      .expect(201);
+    it('should error trying to resend partner confirmation but no user exists', async () => {
+      const email = 'test@nonexistent.com';
+      const res = await request(app.getHttpServer())
+        .post(`/user/resend-partner-confirmation/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: email,
+          appUrl: 'https://www.google.com',
+        } as EmailAndAppUrl)
+        .set('Cookie', cookies)
+        .expect(404);
 
-    expect(res.body).toEqual({ success: true });
-
-    expect(emailService.sendSingleUseCode).toHaveBeenCalled();
-
-    const user = await prisma.userAccounts.findUnique({
-      where: {
-        id: storedUser.id,
-      },
+      expect(res.body.message).toEqual(
+        `user email: ${email} was requested but not found`,
+      );
     });
-
-    expect(user.singleUseCode).not.toBeNull();
-    expect(user.singleUseCodeUpdatedAt).not.toBeNull();
   });
 
-  it('should request single use code, but user does not exist', async () => {
-    const jurisdiction = await prisma.jurisdictions.create({
-      data: {
-        name: 'single_use_code_3',
-        allowSingleUseCodeLogin: true,
-        rentalAssistanceDefault: 'test',
-      },
+  describe('verify endpoint', () => {
+    it('should verify token as valid', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+
+      const confToken = userService.createConfirmationToken(
+        userA.id,
+        userA.email,
+      );
+      await prisma.userAccounts.update({
+        where: {
+          id: userA.id,
+        },
+        data: {
+          confirmationToken: confToken,
+          confirmedAt: null,
+        },
+      });
+      const res = await request(app.getHttpServer())
+        .post(`/user/is-confirmation-token-valid/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          token: confToken,
+        } as ConfirmationRequest)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.body.success).toEqual(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.hitConfirmationUrl).not.toBeNull();
+      expect(userPostResend.confirmationToken).toEqual(confToken);
     });
-    emailService.sendSingleUseCode = jest.fn();
 
-    const res = await request(app.getHttpServer())
-      .post('/user/request-single-use-code')
-      .set({ passkey: process.env.API_PASS_KEY || '' })
-      .send({
-        email: 'thisEmailDoesNotExist@exygy.com',
-      } as RequestMfaCode)
-      .set({ jurisdictionname: jurisdiction.name })
-      .expect(201);
-    expect(res.body.success).toEqual(true);
+    it('should fail to verify token when incorrect user id is provided', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
 
-    expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
+      const storedConfToken = userService.createConfirmationToken(
+        userA.id,
+        userA.email,
+      );
+      await prisma.userAccounts.update({
+        where: {
+          id: userA.id,
+        },
+        data: {
+          confirmationToken: storedConfToken,
+          confirmedAt: null,
+        },
+      });
+
+      const fakeConfToken = userService.createConfirmationToken(
+        randomUUID(),
+        userA.email,
+      );
+      const res = await request(app.getHttpServer())
+        .post(`/user/is-confirmation-token-valid/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          token: fakeConfToken,
+        } as ConfirmationRequest)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(undefined);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.hitConfirmationUrl).toBeNull();
+    });
+
+    it('should fail to verify token when token mismatch', async () => {
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory(),
+      });
+
+      const storedConfToken = userService.createConfirmationToken(
+        userA.id,
+        userA.email,
+      );
+      await prisma.userAccounts.update({
+        where: {
+          id: userA.id,
+        },
+        data: {
+          confirmationToken: storedConfToken,
+          confirmedAt: null,
+        },
+      });
+
+      const fakeConfToken = userService.createConfirmationToken(
+        userA.id,
+        userA.email + 'x',
+      );
+      const res = await request(app.getHttpServer())
+        .post(`/user/is-confirmation-token-valid/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          token: fakeConfToken,
+        } as ConfirmationRequest)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(undefined);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.hitConfirmationUrl).toBeNull();
+    });
+  });
+
+  describe('forgot password endpoint', () => {
+    it('should set resetToken when forgot-password is called by public user on the public site', async () => {
+      const juris = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory({ jurisdictionIds: [juris.id] }),
+      });
+
+      const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
+      const res = await request(app.getHttpServer())
+        .put(`/user/forgot-password/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: juris.publicUrl,
+        } as EmailAndAppUrl)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.resetToken).not.toBeNull();
+      expect(mockforgotPassword.mock.calls.length).toBe(1);
+    });
+
+    it('should not set resetToken when forgot-password is called by public user on the partners site', async () => {
+      const juris = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory({ jurisdictionIds: [juris.id] }),
+      });
+
+      const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
+      const res = await request(app.getHttpServer())
+        .put(`/user/forgot-password/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: process.env.PARTNERS_PORTAL_URL,
+        } as EmailAndAppUrl)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.resetToken).toBeNull();
+      expect(mockforgotPassword.mock.calls.length).toBe(0);
+    });
+
+    it('should set resetToken when forgot-password is called by partner user on the partners site', async () => {
+      const juris = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory({
+          roles: { isAdmin: true },
+          jurisdictionIds: [juris.id],
+        }),
+      });
+
+      const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
+      const res = await request(app.getHttpServer())
+        .put(`/user/forgot-password/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: process.env.PARTNERS_PORTAL_URL,
+        } as EmailAndAppUrl)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.resetToken).not.toBeNull();
+      expect(mockforgotPassword.mock.calls.length).toBe(1);
+    });
+
+    it('should not set resetToken when forgot-password is called by partner user on the public site', async () => {
+      const juris = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+
+      const userA = await prisma.userAccounts.create({
+        data: await userFactory({
+          roles: { isAdmin: true },
+          jurisdictionIds: [juris.id],
+        }),
+      });
+
+      const mockforgotPassword = jest.spyOn(testEmailService, 'forgotPassword');
+      const res = await request(app.getHttpServer())
+        .put(`/user/forgot-password/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: userA.email,
+          appUrl: juris.publicUrl,
+        } as EmailAndAppUrl)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+
+      const userPostResend = await prisma.userAccounts.findUnique({
+        where: {
+          id: userA.id,
+        },
+      });
+
+      expect(userPostResend.resetToken).toBeNull();
+      expect(mockforgotPassword.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe('create endpoint', () => {
+    it('should create public user', async () => {
+      const juris = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+
+      const data = await applicationFactory();
+      data.applicant.create.emailAddress = 'publicuser@email.com';
+      const application = await prisma.applications.create({
+        data,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post(`/user/`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          firstName: 'Public User firstName',
+          lastName: 'Public User lastName',
+          password: 'Abcdef12345!',
+          email: 'publicUser@email.com',
+          jurisdictions: [{ id: juris.id }],
+        } as UserCreate)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.body.firstName).toEqual('Public User firstName');
+      expect(res.body.jurisdictions).toEqual([
+        expect.objectContaining({ id: juris.id, name: juris.name }),
+      ]);
+      expect(res.body.email).toEqual('publicuser@email.com');
+
+      const applicationsOnUser = await prisma.userAccounts.findUnique({
+        include: {
+          applications: true,
+        },
+        where: {
+          id: res.body.id,
+        },
+      });
+      expect(applicationsOnUser.applications.map((app) => app.id)).toContain(
+        application.id,
+      );
+    });
+  });
+
+  describe('invite partner endpoint', () => {
+    it('should create partner user', async () => {
+      const juris = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+
+      const res = await request(app.getHttpServer())
+        .post(`/user/invite`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          firstName: 'Partner User firstName',
+          lastName: 'Partner User lastName',
+          password: 'Abcdef12345!',
+          email: 'partnerUser@email.com',
+          jurisdictions: [{ id: juris.id }],
+          agreedToTermsOfService: true,
+          userRoles: {
+            isAdmin: true,
+          },
+        } as UserInvite)
+        .set('Cookie', cookies)
+        .expect(201);
+
+      expect(res.body.firstName).toEqual('Partner User firstName');
+      expect(res.body.jurisdictions).toEqual([
+        expect.objectContaining({ id: juris.id, name: juris.name }),
+      ]);
+      expect(res.body.email).toEqual('partneruser@email.com');
+    });
+  });
+
+  describe('request single use code endpoint', () => {
+    it('should request single use code successfully', async () => {
+      const storedUser = await prisma.userAccounts.create({
+        data: await userFactory({
+          roles: { isAdmin: true },
+          mfaEnabled: true,
+          confirmedAt: new Date(),
+          phoneNumber: '111-111-1111',
+          phoneNumberVerified: true,
+        }),
+      });
+
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: {
+          name: 'single_use_code_1',
+          allowSingleUseCodeLogin: true,
+          rentalAssistanceDefault: 'test',
+        },
+      });
+      emailService.sendSingleUseCode = jest.fn();
+
+      const res = await request(app.getHttpServer())
+        .post('/user/request-single-use-code')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: storedUser.email,
+        } as RequestMfaCode)
+        .set({ jurisdictionname: jurisdiction.name })
+        .expect(201);
+
+      expect(res.body).toEqual({ success: true });
+
+      expect(emailService.sendSingleUseCode).toHaveBeenCalled();
+
+      const user = await prisma.userAccounts.findUnique({
+        where: {
+          id: storedUser.id,
+        },
+      });
+
+      expect(user.singleUseCode).not.toBeNull();
+      expect(user.singleUseCodeUpdatedAt).not.toBeNull();
+    });
+
+    it('should request single use code, but user does not exist', async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: {
+          name: 'single_use_code_3',
+          allowSingleUseCodeLogin: true,
+          rentalAssistanceDefault: 'test',
+        },
+      });
+      emailService.sendSingleUseCode = jest.fn();
+
+      const res = await request(app.getHttpServer())
+        .post('/user/request-single-use-code')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          email: 'thisEmailDoesNotExist@exygy.com',
+        } as RequestMfaCode)
+        .set({ jurisdictionname: jurisdiction.name })
+        .expect(201);
+      expect(res.body.success).toEqual(true);
+
+      expect(emailService.sendSingleUseCode).not.toHaveBeenCalled();
+    });
   });
 });

--- a/api/test/unit/services/email.service.spec.ts
+++ b/api/test/unit/services/email.service.spec.ts
@@ -16,6 +16,7 @@ import { yellowstoneAddress } from '../../../prisma/seed-helpers/address-factory
 import { Application } from '../../../src/dtos/applications/application.dto';
 import { User } from '../../../src/dtos/users/user.dto';
 import { ApplicationCreate } from '../../../src/dtos/applications/application-create.dto';
+import { Logger } from '@nestjs/common';
 
 let sendMock;
 const translationServiceMock = {
@@ -40,6 +41,7 @@ describe('Testing email service', () => {
       imports: [ConfigModule],
       providers: [
         EmailService,
+        Logger,
         SendGridService,
         MailService,
         {

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -18,6 +18,7 @@ import { PermissionService } from '../../../src/services/permission.service';
 import { permissionActions } from '../../../src/enums/permissions/permission-actions-enum';
 import { OrderByEnum } from '../../../src/enums/shared/order-by-enum';
 import { UserViews } from '../../../src/enums/user/view-enum';
+import { Logger } from '@nestjs/common';
 
 describe('Testing user service', () => {
   let service: UserService;
@@ -84,6 +85,7 @@ describe('Testing user service', () => {
         SendGridService,
         TranslationService,
         JurisdictionService,
+        Logger,
         {
           provide: SendGridService,
           useValue: SendGridServiceMock,


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/983, 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR pulls over the appropriate pieces from [this Doorway PR](https://github.com/metrotranscom/doorway/pull/1013). Specifically the additional logging around bulk email sends. The rest of the PR is not required in Core since we do not use AWS SES.

NOTE:
- An additional change of now logging "LOG" level via the logger
  - I feel like we should get as much as possible in the logs as possible. I think this would have minimal impact since using `console.log` was already getting logged to papertrail

## How Can This Be Tested/Reviewed?

This can be tested by going through the flows that trigger a bulk email send and make sure that appropriate logging appears in the terminal

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
