### PR TITLE
fix: add passkey to swagger

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -57,6 +57,20 @@ async function bootstrap() {
     .addTag('listings')
     .build();
   const document = SwaggerModule.createDocument(app, config);
+  // Add passkey as an optional header to all endpoints
+  Object.values(document.paths).forEach((path) => {
+    Object.values(path).forEach((method) => {
+      method.parameters = [
+        ...(method.parameters || []),
+        {
+          in: 'header',
+          name: 'passkey',
+          description: 'Pass key',
+          required: false,
+        },
+      ];
+    });
+  });
   SwaggerModule.setup('api', app, document);
   const configService: ConfigService = app.get(ConfigService);
 


### PR DESCRIPTION
This PR does not address a specific ticket but will be useful for using the API in deployed environments

## Description

If passkey is enabled for an environment you are not able to use the swagger UI. This adds an optional header option to the UI to be able to send the passkey in the request.

I tested that this did not impact the backend-swagger when running `yarn generate:client`

## How Can This Be Tested/Reviewed?

Start up the backend and go to `http://localhost:3100/api`. For all endpoints you should see "passkey" as a header field. If you enable passkey locally you should be able to use this UI to send any request.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
