### PR TITLE
feat: filterable listing list post endpoint

### DIFF
--- a/api/src/controllers/listing.controller.ts
+++ b/api/src/controllers/listing.controller.ts
@@ -88,6 +88,21 @@ export class ListingController {
     return await this.listingService.list(queryParams);
   }
 
+  @Post('list')
+  @ApiOperation({
+    summary: 'Get a paginated set of listings',
+    operationId: 'filterableList',
+  })
+  @PermissionAction(permissionActions.read)
+  @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
+  @UseInterceptors(ClassSerializerInterceptor)
+  @ApiOkResponse({ type: PaginatedListingDto })
+  public async getFilterablePaginatedSet(
+    @Body() queryParams: ListingsQueryParams,
+  ) {
+    return await this.listingService.list(queryParams);
+  }
+
   @Get(`csv`)
   @ApiOperation({
     summary: 'Get listings and units as zip',

--- a/api/src/dtos/listings/listings-query-params.dto.ts
+++ b/api/src/dtos/listings/listings-query-params.dto.ts
@@ -24,7 +24,7 @@ export class ListingsQueryParams extends PaginationAllowsAllQueryParams {
     items: {
       $ref: getSchemaPath(ListingFilterParams),
     },
-    example: { $comparison: '=', status: 'active' },
+    example: [{ $comparison: '=', status: 'active' }],
   })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(16, { groups: [ValidationsGroupsEnum.default] })
@@ -47,7 +47,8 @@ export class ListingsQueryParams extends PaginationAllowsAllQueryParams {
   @ApiPropertyOptional({
     enum: ListingOrderByKeys,
     enumName: 'ListingOrderByKeys',
-    example: '["updatedAt"]',
+    example: ['mostRecentlyUpdated'],
+    default: ['mostRecentlyUpdated'],
   })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(16, { groups: [ValidationsGroupsEnum.default] })
@@ -65,8 +66,8 @@ export class ListingsQueryParams extends PaginationAllowsAllQueryParams {
   @ApiPropertyOptional({
     enum: OrderByEnum,
     enumName: 'OrderByEnum',
-    example: '["desc"]',
-    default: '["desc"]',
+    example: ['desc'],
+    default: ['desc'],
   })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(16, { groups: [ValidationsGroupsEnum.default] })

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -392,7 +392,7 @@ describe('Listing Controller Tests', () => {
       });
 
       const res = await request(app.getHttpServer())
-        .post('/listings/list')
+        .post('/listings')
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .expect(200);
 
@@ -541,9 +541,9 @@ describe('Listing Controller Tests', () => {
       });
 
       const res = await request(app.getHttpServer())
-        .post('/listings/list')
+        .post(`/listings/list`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
-        .expect(200);
+        .expect(201);
 
       expect(res.body.meta.currentPage).toEqual(1);
       expect(res.body.meta.itemCount).toBeGreaterThanOrEqual(2);

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -380,20 +380,19 @@ describe('Listing Controller Tests', () => {
       });
     });
 
-    // without clearing the db between runs this test is flaky
-    it.skip('should get listings from list endpoint when no params are sent', async () => {
+    it('should get listings from list endpoint when no params are sent', async () => {
       const listing1 = await listingFactory(jurisdictionAId, prisma);
-      const listing1Created = await prisma.listings.create({
+      await prisma.listings.create({
         data: listing1,
       });
 
       const listing2 = await listingFactory(jurisdictionAId, prisma);
-      const listing2Created = await prisma.listings.create({
+      await prisma.listings.create({
         data: listing2,
       });
 
       const res = await request(app.getHttpServer())
-        .get('/listings')
+        .post('/listings/list')
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .expect(200);
 
@@ -406,8 +405,6 @@ describe('Listing Controller Tests', () => {
       const items = res.body.items.map((item) => item.name);
 
       expect(items.length).toBeGreaterThanOrEqual(2);
-      expect(items).toContain(listing1Created.name);
-      expect(items).toContain(listing2Created.name);
     });
 
     it('should not get listings from list endpoint when params are sent but do not match anything', async () => {
@@ -532,34 +529,14 @@ describe('Listing Controller Tests', () => {
   });
 
   describe('filterableList endpoint', () => {
-    // without clearing the db between runs this test is flaky
-    it.skip('should not get listings from list endpoint when no params are sent', async () => {
-      const res = await request(app.getHttpServer())
-        .post('/listings/list')
-        .set({ passkey: process.env.API_PASS_KEY || '' })
-        .expect(200);
-
-      expect(res.body).toEqual({
-        items: [],
-        meta: {
-          currentPage: 1,
-          itemCount: 0,
-          itemsPerPage: 10,
-          totalItems: 0,
-          totalPages: 0,
-        },
-      });
-    });
-
-    // without clearing the db between runs this test is flaky
-    it.skip('should get listings from list endpoint when no params are sent', async () => {
+    it('should get listings from list endpoint when no params are sent', async () => {
       const listing1 = await listingFactory(jurisdictionAId, prisma);
-      const listing1Created = await prisma.listings.create({
+      await prisma.listings.create({
         data: listing1,
       });
 
       const listing2 = await listingFactory(jurisdictionAId, prisma);
-      const listing2Created = await prisma.listings.create({
+      await prisma.listings.create({
         data: listing2,
       });
 
@@ -577,8 +554,6 @@ describe('Listing Controller Tests', () => {
       const items = res.body.items.map((item) => item.name);
 
       expect(items.length).toBeGreaterThanOrEqual(2);
-      expect(items).toContain(listing1Created.name);
-      expect(items).toContain(listing2Created.name);
     });
 
     it('should not get listings from list endpoint when params are sent but do not match anything', async () => {

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -531,6 +531,180 @@ describe('Listing Controller Tests', () => {
     });
   });
 
+  describe('filterableList endpoint', () => {
+    // without clearing the db between runs this test is flaky
+    it.skip('should not get listings from list endpoint when no params are sent', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/listings/list')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(200);
+
+      expect(res.body).toEqual({
+        items: [],
+        meta: {
+          currentPage: 1,
+          itemCount: 0,
+          itemsPerPage: 10,
+          totalItems: 0,
+          totalPages: 0,
+        },
+      });
+    });
+
+    // without clearing the db between runs this test is flaky
+    it.skip('should get listings from list endpoint when no params are sent', async () => {
+      const listing1 = await listingFactory(jurisdictionAId, prisma);
+      const listing1Created = await prisma.listings.create({
+        data: listing1,
+      });
+
+      const listing2 = await listingFactory(jurisdictionAId, prisma);
+      const listing2Created = await prisma.listings.create({
+        data: listing2,
+      });
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/list')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(200);
+
+      expect(res.body.meta.currentPage).toEqual(1);
+      expect(res.body.meta.itemCount).toBeGreaterThanOrEqual(2);
+      expect(res.body.meta.itemsPerPage).toEqual(10);
+      expect(res.body.meta.totalItems).toBeGreaterThanOrEqual(2);
+      expect(res.body.meta.totalPages).toBeGreaterThanOrEqual(1);
+
+      const items = res.body.items.map((item) => item.name);
+
+      expect(items.length).toBeGreaterThanOrEqual(2);
+      expect(items).toContain(listing1Created.name);
+      expect(items).toContain(listing2Created.name);
+    });
+
+    it('should not get listings from list endpoint when params are sent but do not match anything', async () => {
+      const queryParams: ListingsQueryParams = {
+        limit: 1,
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['='],
+            jurisdiction: randomUUID(),
+          },
+          {
+            $comparison: Compare.IN,
+            name: 'random name',
+          },
+          {
+            $comparison: Compare['='],
+            status: 'active',
+          },
+        ],
+      };
+      const query = stringify(queryParams as any);
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body).toEqual({
+        items: [],
+        meta: {
+          currentPage: 1,
+          itemCount: 0,
+          itemsPerPage: 1,
+          totalItems: 0,
+          totalPages: 0,
+        },
+      });
+    });
+
+    it('should get listings from list endpoint when params are sent', async () => {
+      const listing1 = await listingFactory(jurisdictionAId, prisma, {
+        listing: { name: 'filterListing3' } as Prisma.ListingsCreateInput,
+      });
+      const listing1Created = await prisma.listings.create({
+        data: listing1,
+      });
+
+      const listing2 = await listingFactory(jurisdictionAId, prisma, {
+        listing: { name: 'filterListing4' } as Prisma.ListingsCreateInput,
+      });
+      const listing2Created = await prisma.listings.create({
+        data: listing2,
+      });
+
+      const orderedNames = [listing1Created.name, listing2Created.name].sort(
+        (a, b) => a.localeCompare(b),
+      );
+
+      let queryParams: ListingsQueryParams = {
+        limit: 1,
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare.IN,
+            name: orderedNames.toString(),
+          },
+        ],
+        orderBy: [ListingOrderByKeys.name],
+        orderDir: [OrderByEnum.ASC],
+      };
+      let query = stringify(queryParams as any);
+
+      let res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.meta).toEqual({
+        currentPage: 1,
+        itemCount: 1,
+        itemsPerPage: 1,
+        totalItems: 2,
+        totalPages: 2,
+      });
+
+      expect(res.body.items.length).toEqual(1);
+      expect(res.body.items[0].name).toEqual(orderedNames[0]);
+
+      queryParams = {
+        limit: 1,
+        page: 2,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare.IN,
+            name: orderedNames.toString(),
+          },
+        ],
+        orderBy: [ListingOrderByKeys.name],
+        orderDir: [OrderByEnum.ASC],
+      };
+      query = stringify(queryParams as any);
+
+      res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.meta).toEqual({
+        currentPage: 2,
+        itemCount: 1,
+        itemsPerPage: 1,
+        totalItems: 2,
+        totalPages: 2,
+      });
+      expect(res.body.items.length).toEqual(1);
+      expect(res.body.items[0].name).toEqual(orderedNames[1]);
+    });
+  });
+
   describe('retrieve listings endpoint', () => {
     it('should get listings from retrieveListings endpoint', async () => {
       const multiselectQuestion1 = await prisma.multiselectQuestions.create({

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -392,7 +392,7 @@ describe('Listing Controller Tests', () => {
       });
 
       const res = await request(app.getHttpServer())
-        .post('/listings')
+        .get('/listings')
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .expect(200);
 

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -1076,6 +1076,14 @@ describe('Testing Permissioning of endpoints as Admin User', () => {
         .expect(200);
     });
 
+    it('should succeed for filterableList endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
     it('should succeed for retrieveListings endpoint', async () => {
       const multiselectQuestion1 = await prisma.multiselectQuestions.create({
         data: multiselectQuestionFactory(jurisdictionId, {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -1051,6 +1051,14 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         .expect(200);
     });
 
+    it('should succeed for filterableList endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
     it('should succeed for retrieveListings endpoint', async () => {
       const multiselectQuestion1 = await prisma.multiselectQuestions.create({
         data: multiselectQuestionFactory(jurisId, {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -1021,6 +1021,14 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the wron
         .expect(200);
     });
 
+    it('should succeed for filterableList endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
     it('should succeed for retrieveListings endpoint', async () => {
       const multiselectQuestion1 = await prisma.multiselectQuestions.create({
         data: multiselectQuestionFactory(jurisId, {

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -938,6 +938,14 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .expect(200);
     });
 
+    it('should succeed for filterableList endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
     it('should succeed for retrieveListings endpoint', async () => {
       const multiselectQuestion1 = await prisma.multiselectQuestions.create({
         data: multiselectQuestionFactory(jurisdictionId, {

--- a/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
@@ -1046,6 +1046,14 @@ describe('Testing Permissioning of endpoints as partner with correct listing', (
         .expect(200);
     });
 
+    it('should succeed for filterableList endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
     it('should succeed for retrieveListings endpoint', async () => {
       await request(app.getHttpServer())
         .get(`/listings/byMultiselectQuestion/${listingMulitselectQuestion}`)

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -1016,6 +1016,14 @@ describe('Testing Permissioning of endpoints as partner with wrong listing', () 
         .expect(200);
     });
 
+    it('should succeed for filterableList endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
     it('should succeed for retrieveListings endpoint', async () => {
       await request(app.getHttpServer())
         .get(`/listings/byMultiselectQuestion/${listingMulitselectQuestion}`)

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -1009,6 +1009,14 @@ describe('Testing Permissioning of endpoints as public user', () => {
         .expect(200);
     });
 
+    it('should succeed for filterableList endpoint', async () => {
+      await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(201);
+    });
+
     it('should succeed for retrieveListings endpoint', async () => {
       const multiselectQuestion1 = await prisma.multiselectQuestions.create({
         data: multiselectQuestionFactory(jurisdictionAId, {

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -236,6 +236,28 @@ export class ListingsService {
     })
   }
   /**
+   * Get a paginated set of listings
+   */
+  filterableList(
+    params: {
+      /** requestBody */
+      body?: ListingsQueryParams
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<PaginatedListing> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/listings/list"
+
+      const configs: IRequestConfig = getConfigs("post", "application/json", url, options)
+
+      let data = params.body
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
    * Get listings and units as zip
    */
   listAsCsv(


### PR DESCRIPTION
This PR addresses [#(4515)](https://github.com/bloom-housing/bloom/issues/4515)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Creates new listings list endpoint with the same functionality but uses a POST instead of a GET.

## How Can This Be Tested/Reviewed?

Using the API, call the new endpoint `listings/list` using POST. Should have the same results as the GET `listings?` endpoint.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
