### PR TITLE
fix: submission date time format on paper app

### DIFF
--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -1,4 +1,4 @@
-import { TimeFieldPeriod } from "@bloom-housing/ui-components"
+import { DateFieldValues, TimeFieldPeriod, TimeFieldValues } from "@bloom-housing/ui-components"
 import {
   fieldGroupObjectToArray,
   adaFeatureKeys,
@@ -27,6 +27,8 @@ import {
   MultiselectQuestionsApplicationSectionEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 dayjs.extend(customParseFormat)
+
+const TIME_24H_FORMAT = "MM/DD/YYYY HH:mm:ss"
 
 /*
   Some of fields are optional, not active, so it occurs 'undefined' as value.
@@ -83,28 +85,28 @@ export const mapFormToApi = ({
     ? data.application?.language
     : null
 
-  const submissionDate: Date | null = (() => {
-    const TIME_24H_FORMAT = "MM/DD/YYYY HH:mm:ss"
+  const getDateTime = (date: DateFieldValues, time: TimeFieldValues) => {
+    let day = date?.day
+    let month = date?.month
+    const year = date?.year
+    const { hours, minutes = 0, seconds = 0, period } = time || {}
 
-    // rename default (wrong property names)
-    const {
-      day: submissionDay,
-      month: submissionMonth,
-      year: submissionYear,
-    } = data.dateSubmitted || {}
-    const { hours, minutes = 0, seconds = 0, period } = data?.timeSubmitted || {}
+    if (!day || !month || !year) return null
 
-    if (!submissionDay || !submissionMonth || !submissionYear) return null
+    if (month.length === 1) month = `0${month}`
+    if (day.length === 1) day = `0${day}`
 
     const dateString = dayjs(
-      `${submissionMonth}/${submissionDay}/${submissionYear} ${hours}:${minutes}:${seconds} ${period}`,
+      `${month}/${day}/${year} ${hours}:${minutes}:${seconds} ${period}`,
       "MM/DD/YYYY hh:mm:ss a"
     ).format(TIME_24H_FORMAT)
 
     const formattedDate = dayjs(dateString, TIME_24H_FORMAT).toDate()
 
     return formattedDate
-  })()
+  }
+
+  const submissionDate: Date | null = getDateTime(data?.dateSubmitted, data?.timeSubmitted)
 
   // create applicant
   const applicant = ((): ApplicantUpdate => {


### PR DESCRIPTION
This PR addresses #4502 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

NOTE: Pulls over some but not all code from [this Doorway PR](https://github.com/metrotranscom/doorway/pull/979) to fix a user's inability to successfully save single digit dates i.e. `1/01/2025, 1/1/2025, 01/1/2025`

## How Can This Be Tested/Reviewed?

Run the same process from the Loom video in #4502 and you should be able to edit and save dates in either `M/D/YYYY` or `MM/DD/YYYY` format

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
