### PR TITLE
test: sign-in page integration test 

### DIFF
--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -463,7 +463,7 @@
   "authentication.signIn.mfaError": "This is a partner account, which for security reasons cannot login to the public site.",
   "authentication.signIn.passwordError": "Please enter a valid password",
   "authentication.signIn.passwordOutdated": "Your password has expired. Please reset your password.",
-  "authentication.signIn.pwdless.createAccountCopy": "Sign up quicky with no need to remember any passwords.",
+  "authentication.signIn.pwdless.createAccountCopy": "Sign up quickly with no need to remember any passwords.",
   "authentication.signIn.pwdless.emailHelperText": "Enter your email and we'll send you a code to sign in.",
   "authentication.signIn.pwdless.error": "The code you've used is invalid or expired.",
   "authentication.signIn.pwdless.getCode": "Get code to sign in",

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -1,12 +1,14 @@
 import React from "react"
-import { render, fireEvent } from "@testing-library/react"
+import { render, fireEvent, waitFor } from "@testing-library/react"
 import { useRouter } from "next/router"
 import { MessageContext, AuthContext } from "@bloom-housing/shared-helpers"
 import { User } from "../../../../shared-helpers/src/types/backend-swagger"
 import { SignIn as SignInComponent } from "../../src/pages/sign-in"
 
-let initialStateLoaded = false
+const initialStateLoaded = false
 let profile: User | undefined
+
+let originalShowPwdless
 
 jest.mock("next/router", () => ({
   useRouter: jest.fn(),
@@ -42,11 +44,13 @@ describe("Sign In Page", () => {
     )
 
   it("renders all page elements including fields, buttons and links", () => {
-    const { getByText, getByLabelText, getByRole } = renderSignInPage()
+    const { getByText, getByTestId, getByLabelText, getByRole } = renderSignInPage()
 
     expect(getByText("Sign In", { selector: "h1" })).toBeInTheDocument()
     expect(getByLabelText("Email")).toBeInTheDocument()
+    expect(getByTestId("sign-in-email-field")).toBeInTheDocument()
     expect(getByLabelText("Password")).toBeInTheDocument()
+    expect(getByTestId("sign-in-password-field")).toBeInTheDocument()
     expect(getByRole("link", { name: /forgot password/i })).toBeInTheDocument()
     expect(getByRole("button", { name: /sign in/i })).toBeInTheDocument()
 
@@ -102,11 +106,6 @@ describe("Sign In Page", () => {
   })
 
   describe("User not logged in", () => {
-    beforeEach(() => {
-      initialStateLoaded = true
-      profile = undefined
-    })
-
     it("shows the sign-in form", () => {
       const { getByLabelText, getByText } = render(
         <AuthContext.Provider value={{ initialStateLoaded, profile }}>
@@ -118,6 +117,85 @@ describe("Sign In Page", () => {
       expect(getByText("Sign In", { selector: "h1" })).toBeInTheDocument()
       expect(getByLabelText("Email")).toBeInTheDocument()
       expect(getByLabelText("Password")).toBeInTheDocument()
+    })
+  })
+
+  describe("Passwordless login", () => {
+    beforeEach(() => {
+      originalShowPwdless = process.env.showPwdless
+      process.env.showPwdless = "TRUE"
+    })
+
+    afterEach(() => {
+      process.env.showPwdless = originalShowPwdless
+    })
+
+    it("renders all page elements including fields, buttons and links", () => {
+      const { getByText, getByLabelText, getByTestId, getByRole } = renderSignInPage()
+
+      expect(getByText("Sign In", { selector: "h1" })).toBeInTheDocument()
+      expect(
+        getByText("Enter your email and we'll send you a code to sign in.", { selector: "p" })
+      ).toBeInTheDocument()
+      expect(getByLabelText("Email")).toBeInTheDocument()
+      expect(getByTestId("sign-in-email-field")).toBeInTheDocument()
+
+      expect(getByRole("button", { name: "Get code to sign in" })).toBeInTheDocument()
+      expect(getByRole("button", { name: "Use your password instead" })).toBeInTheDocument()
+
+      expect(getByText("Don't have an account?", { selector: "h2" })).toBeInTheDocument()
+      expect(
+        getByText("Sign up quickly with no need to remember any passwords.", { selector: "div" })
+      ).toBeInTheDocument()
+      expect(getByRole("link", { name: /create account/i })).toBeInTheDocument()
+    })
+
+    it("shows error alert and email validation error after clicking 'Get code to sign in' button without filling out email field", async () => {
+      const { findByText, getByRole } = renderSignInPage()
+
+      fireEvent.click(getByRole("button", { name: "Get code to sign in" }))
+      expect(
+        await findByText("There are errors you'll need to resolve before moving on.")
+      ).toBeInTheDocument()
+      expect(await findByText("Please enter your login email")).toBeInTheDocument()
+    })
+
+    it("shows correct page elements after clicking 'Use your password instead' button", async () => {
+      const { getByRole, getByLabelText, getByTestId } = renderSignInPage()
+
+      fireEvent.click(getByRole("button", { name: "Use your password instead" }))
+
+      await waitFor(() => {
+        expect(getByLabelText("Email")).toBeInTheDocument()
+        expect(getByTestId("sign-in-email-field")).toBeInTheDocument()
+        expect(getByLabelText("Password")).toBeInTheDocument()
+        expect(getByTestId("sign-in-password-field")).toBeInTheDocument()
+        expect(getByRole("button", { name: "Get a code instead" })).toBeInTheDocument()
+      })
+    })
+
+    it("shows correct page elements after clicking 'Use your password instead' button and then clicking 'Get a code instead' button", async () => {
+      const {
+        findByRole,
+        getByRole,
+        getByLabelText,
+        getByTestId,
+        queryByLabelText,
+        queryByTestId,
+      } = renderSignInPage()
+
+      fireEvent.click(getByRole("button", { name: "Use your password instead" }))
+      expect(await findByRole("button", { name: "Get a code instead" })).toBeInTheDocument()
+
+      fireEvent.click(getByRole("button", { name: "Get a code instead" }))
+
+      await waitFor(() => {
+        expect(getByLabelText("Email")).toBeInTheDocument()
+        expect(getByTestId("sign-in-email-field")).toBeInTheDocument()
+        expect(queryByLabelText("Password")).not.toBeInTheDocument()
+        expect(queryByTestId("sign-in-password-field")).not.toBeInTheDocument()
+        expect(getByRole("button", { name: "Use your password instead" })).toBeInTheDocument()
+      })
     })
   })
 })

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { render, fireEvent } from "@testing-library/react"
+import { useRouter } from "next/router"
+import { MessageContext } from "@bloom-housing/shared-helpers"
+import { GenericRouter } from "@bloom-housing/ui-components"
+
+import SignIn from "../../src/pages/sign-in"
+
+// not sure if i need mockRouter.push() yet
+const mockRouter: GenericRouter = {
+  pathname: "",
+  asPath: "",
+  back: jest.fn(),
+  push(url: string) {
+    this.pathname = url
+    this.asPath = url
+  },
+}
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}))
+
+beforeAll(() => {
+  window.scrollTo = jest.fn()
+})
+
+describe("SignIn Page", () => {
+  let mockMessageContext: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRouter.push("")
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+    mockMessageContext = {
+      toastMessagesRef: { current: [] },
+      addToast: jest.fn(),
+    }
+  })
+
+  const renderSignInPage = () =>
+    render(
+      <MessageContext.Provider value={mockMessageContext}>
+        <SignIn />
+      </MessageContext.Provider>
+    )
+
+  it("renders all fields, buttons and links", () => {
+    const { getByText, getByLabelText, getByRole } = renderSignInPage()
+
+    expect(getByLabelText("Email")).toBeInTheDocument()
+    expect(getByLabelText("Password")).toBeInTheDocument()
+    expect(getByRole("link", { name: /forgot password/i })).toBeInTheDocument()
+    expect(getByRole("button", { name: /sign in/i })).toBeInTheDocument()
+
+    expect(getByText("Don't have an account?")).toBeInTheDocument()
+    expect(getByRole("link", { name: /create account/i })).toBeInTheDocument()
+  })
+
+  it("shows both validation errors when clicking 'Sign in' button without filling out fields", async () => {
+    const { findByText, getByRole } = renderSignInPage()
+
+    fireEvent.click(getByRole("button", { name: /sign in/i }))
+    expect(await findByText("Please enter your login email")).toBeInTheDocument()
+    expect(await findByText("Please enter your login password")).toBeInTheDocument()
+  })
+})

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -133,39 +133,4 @@ describe("Sign In Page", () => {
       expect(getByLabelText(/password/i)).toBeInTheDocument()
     })
   })
-
-  describe("User logged in", () => {
-    const mockUser: User = {
-      id: "123",
-      email: "test@test.com",
-      firstName: "Test",
-      lastName: "User",
-      dob: new Date("2020-01-01"),
-      createdAt: new Date("2020-01-01"),
-      updatedAt: new Date("2020-01-01"),
-      jurisdictions: [],
-      mfaEnabled: false,
-      passwordUpdatedAt: new Date("2020-01-01"),
-      passwordValidForDays: 180,
-      agreedToTermsOfService: true,
-      listings: [],
-    }
-
-    beforeEach(() => {
-      initialStateLoaded = true
-      profile = mockUser
-    })
-
-    it("redirects to the account dashboard page", () => {
-      render(
-        <AuthContext.Provider value={{ initialStateLoaded, profile }}>
-          <MessageContext.Provider value={mockMessageContext}>
-            <SignIn />
-          </MessageContext.Provider>
-        </AuthContext.Provider>
-      )
-
-      expect(mockRouter.pathname).toEqual("/account/dashboard")
-    })
-  })
 })

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { render, fireEvent } from "@testing-library/react"
 import { useRouter } from "next/router"
-import { MessageContext } from "@bloom-housing/shared-helpers"
+import { MessageContext, AuthContext } from "@bloom-housing/shared-helpers"
 import { GenericRouter } from "@bloom-housing/ui-components"
+import { User } from "../../../../shared-helpers/src/types/backend-swagger"
 
 import SignIn from "../../src/pages/sign-in"
 
-// not sure if i need mockRouter.push() yet
 const mockRouter: GenericRouter = {
   pathname: "",
   asPath: "",
@@ -17,6 +17,9 @@ const mockRouter: GenericRouter = {
   },
 }
 
+let initialStateLoaded = false
+let profile: User | undefined
+
 jest.mock("next/router", () => ({
   useRouter: jest.fn(),
 }))
@@ -25,8 +28,13 @@ beforeAll(() => {
   window.scrollTo = jest.fn()
 })
 
-describe("SignIn Page", () => {
-  let mockMessageContext: any
+describe("Sign In Page", () => {
+  let mockMessageContext: {
+    toastMessagesRef: {
+      current: unknown[]
+    }
+    addToast: () => void
+  }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -46,23 +54,118 @@ describe("SignIn Page", () => {
       </MessageContext.Provider>
     )
 
-  it("renders all fields, buttons and links", () => {
+  it("renders all page elements including fields, buttons and links", () => {
     const { getByText, getByLabelText, getByRole } = renderSignInPage()
 
+    expect(getByText("Sign In", { selector: "h1" })).toBeInTheDocument()
     expect(getByLabelText("Email")).toBeInTheDocument()
     expect(getByLabelText("Password")).toBeInTheDocument()
     expect(getByRole("link", { name: /forgot password/i })).toBeInTheDocument()
     expect(getByRole("button", { name: /sign in/i })).toBeInTheDocument()
 
-    expect(getByText("Don't have an account?")).toBeInTheDocument()
+    expect(getByText("Don't have an account?", { selector: "h2" })).toBeInTheDocument()
     expect(getByRole("link", { name: /create account/i })).toBeInTheDocument()
   })
 
-  it("shows both validation errors when clicking 'Sign in' button without filling out fields", async () => {
-    const { findByText, getByRole } = renderSignInPage()
+  describe("Field validation errors", () => {
+    it("show error alert and password validation error when clicking 'Sign in' button without filling out password", async () => {
+      const { findByText, getByRole, getByLabelText } = renderSignInPage()
 
-    fireEvent.click(getByRole("button", { name: /sign in/i }))
-    expect(await findByText("Please enter your login email")).toBeInTheDocument()
-    expect(await findByText("Please enter your login password")).toBeInTheDocument()
+      fireEvent.change(getByLabelText("Email"), { target: { value: "admin@example.com" } })
+
+      fireEvent.click(getByRole("button", { name: /sign in/i }))
+      expect(
+        await findByText("There are errors you'll need to resolve before moving on.")
+      ).toBeInTheDocument()
+      expect(await findByText("Please enter your login password")).toBeInTheDocument()
+    })
+
+    it("shows error alert and  email validation error when clicking 'Sign in' button without filling out email address", async () => {
+      const { findByText, getByRole, getByLabelText } = renderSignInPage()
+
+      fireEvent.change(getByLabelText("Password"), { target: { value: "abcdef" } })
+
+      fireEvent.click(getByRole("button", { name: /sign in/i }))
+      expect(
+        await findByText("There are errors you'll need to resolve before moving on.")
+      ).toBeInTheDocument()
+      expect(await findByText("Please enter your login email")).toBeInTheDocument()
+    })
+
+    it("shows error alert and both field validation errors when clicking 'Sign in' button without filling out fields", async () => {
+      const { findByText, getByRole } = renderSignInPage()
+
+      fireEvent.click(getByRole("button", { name: /sign in/i }))
+      expect(
+        await findByText("There are errors you'll need to resolve before moving on.")
+      ).toBeInTheDocument()
+      expect(await findByText("Please enter your login email")).toBeInTheDocument()
+      expect(await findByText("Please enter your login password")).toBeInTheDocument()
+    })
+
+    it("should not show errors on render", () => {
+      const { queryByText } = renderSignInPage()
+
+      expect(
+        queryByText("There are errors you'll need to resolve before moving on.")
+      ).not.toBeInTheDocument()
+      expect(queryByText("Please enter your login email")).not.toBeInTheDocument()
+      expect(queryByText("Please enter your login password")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("User not logged in", () => {
+    beforeEach(() => {
+      initialStateLoaded = true
+      profile = undefined
+    })
+
+    it("shows the sign-in form", () => {
+      const { getByLabelText, getByText } = render(
+        <AuthContext.Provider value={{ initialStateLoaded, profile }}>
+          <MessageContext.Provider value={mockMessageContext}>
+            <SignIn />
+          </MessageContext.Provider>
+        </AuthContext.Provider>
+      )
+      expect(getByText("Sign In", { selector: "h1" })).toBeInTheDocument()
+      expect(getByLabelText(/email/i)).toBeInTheDocument()
+      expect(getByLabelText(/password/i)).toBeInTheDocument()
+    })
+  })
+
+  describe("User logged in", () => {
+    const mockUser: User = {
+      id: "123",
+      email: "test@test.com",
+      firstName: "Test",
+      lastName: "User",
+      dob: new Date("2020-01-01"),
+      createdAt: new Date("2020-01-01"),
+      updatedAt: new Date("2020-01-01"),
+      jurisdictions: [],
+      mfaEnabled: false,
+      passwordUpdatedAt: new Date("2020-01-01"),
+      passwordValidForDays: 180,
+      agreedToTermsOfService: true,
+      listings: [],
+    }
+
+    beforeEach(() => {
+      initialStateLoaded = true
+      profile = mockUser
+    })
+
+    it("redirects to the account dashboard page", () => {
+      render(
+        <AuthContext.Provider value={{ initialStateLoaded, profile }}>
+          <MessageContext.Provider value={mockMessageContext}>
+            <SignIn />
+          </MessageContext.Provider>
+        </AuthContext.Provider>
+      )
+
+      expect(mockRouter.pathname).toEqual("/account/dashboard")
+    })
   })
 })

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -2,20 +2,8 @@ import React from "react"
 import { render, fireEvent } from "@testing-library/react"
 import { useRouter } from "next/router"
 import { MessageContext, AuthContext } from "@bloom-housing/shared-helpers"
-import { GenericRouter } from "@bloom-housing/ui-components"
 import { User } from "../../../../shared-helpers/src/types/backend-swagger"
-
-import SignIn from "../../src/pages/sign-in"
-
-const mockRouter: GenericRouter = {
-  pathname: "",
-  asPath: "",
-  back: jest.fn(),
-  push(url: string) {
-    this.pathname = url
-    this.asPath = url
-  },
-}
+import { SignIn as SignInComponent } from "../../src/pages/sign-in"
 
 let initialStateLoaded = false
 let profile: User | undefined
@@ -38,8 +26,7 @@ describe("Sign In Page", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockRouter.push("")
-    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+    ;(useRouter as jest.Mock).mockReturnValue("")
 
     mockMessageContext = {
       toastMessagesRef: { current: [] },
@@ -50,7 +37,7 @@ describe("Sign In Page", () => {
   const renderSignInPage = () =>
     render(
       <MessageContext.Provider value={mockMessageContext}>
-        <SignIn />
+        <SignInComponent />
       </MessageContext.Provider>
     )
 
@@ -124,13 +111,13 @@ describe("Sign In Page", () => {
       const { getByLabelText, getByText } = render(
         <AuthContext.Provider value={{ initialStateLoaded, profile }}>
           <MessageContext.Provider value={mockMessageContext}>
-            <SignIn />
+            <SignInComponent />
           </MessageContext.Provider>
         </AuthContext.Provider>
       )
       expect(getByText("Sign In", { selector: "h1" })).toBeInTheDocument()
-      expect(getByLabelText(/email/i)).toBeInTheDocument()
-      expect(getByLabelText(/password/i)).toBeInTheDocument()
+      expect(getByLabelText("Email")).toBeInTheDocument()
+      expect(getByLabelText("Password")).toBeInTheDocument()
     })
   })
 })

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -198,3 +198,8 @@ describe("Passwordless Sign In page", () => {
     })
   })
 })
+
+describe("Mandated accounts", () => {
+  it.todo("Desktop test(s)")
+  it.todo("Mobile test(s)")
+})


### PR DESCRIPTION
This PR addresses #4560 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue (explained below)

## Description

This PR adds unit tests for:
- All page elements on page
- Field validation
- If user is not logged in

This PR does not add a test for:
- If user is logged in, they should be redirected to /account/dashboard. This currently is not happening, so I created a separate ticket to address this and handle the test after fixing.

## How Can This Be Tested/Reviewed?

- Run `yarn test:unit __tests__/pages/sign-in.test.tsx` in `public`
- LMK if i'm missing anything!

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
