### PR TITLE
fix: minor filter adjustments for doorway

### DIFF
--- a/api/prisma/seed-helpers/listing-factory.ts
+++ b/api/prisma/seed-helpers/listing-factory.ts
@@ -17,7 +17,6 @@ import { unitFactoryMany } from './unit-factory';
 import { reservedCommunityTypeFactoryGet } from './reserved-community-type-factory';
 import { randomBoolean } from './boolean-generator';
 
-
 const cloudinaryIds = [
   'dev/blake-wheeler-zBHU08hdzhY-unsplash_swqash',
   'dev/krzysztof-hepner-V7Q0Oh3Az-c-unsplash_xoj7sr',
@@ -138,7 +137,9 @@ export const listingFactory = async (
     name: randomName(),
     paperApplication: Math.random() < 0.5,
     referralOpportunity: Math.random() < 0.5,
-    reviewOrderType: optionalParams?.reviewOrderType ?? undefined,
+    reviewOrderType:
+      optionalParams?.reviewOrderType ??
+      ReviewOrderTypeEnum.firstComeFirstServe,
     status: optionalParams?.status || ListingsStatusEnum.active,
     unitsAvailable: units?.length || 0,
 

--- a/api/src/dtos/listings/listings-filter-params.dto.ts
+++ b/api/src/dtos/listings/listings-filter-params.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { HomeTypeEnum, ListingsStatusEnum, RegionEnum } from '@prisma/client';
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
@@ -29,16 +29,18 @@ export class ListingFilterParams extends BaseFilter {
 
   @Expose()
   @ApiPropertyOptional({
-    example: 2,
+    example: '2',
   })
   @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @Type(() => Number)
   [ListingFilterKeys.bathrooms]?: number;
 
   @Expose()
   @ApiPropertyOptional({
-    example: 3,
+    example: '3',
   })
   @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @Type(() => Number)
   [ListingFilterKeys.bedrooms]?: number;
 
   @Expose()

--- a/api/src/dtos/listings/listings-query-body.dto.ts
+++ b/api/src/dtos/listings/listings-query-body.dto.ts
@@ -50,6 +50,7 @@ export class ListingsQueryBody extends PaginationAllowsAllQueryParams {
     enumName: 'ListingOrderByKeys',
     example: ['mostRecentlyUpdated'],
     default: ['mostRecentlyUpdated'],
+    isArray: true,
   })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(16, { groups: [ValidationsGroupsEnum.default] })
@@ -69,6 +70,7 @@ export class ListingsQueryBody extends PaginationAllowsAllQueryParams {
     enumName: 'OrderByEnum',
     example: ['desc'],
     default: ['desc'],
+    isArray: true,
   })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(16, { groups: [ValidationsGroupsEnum.default] })

--- a/api/src/dtos/listings/listings-query-params.dto.ts
+++ b/api/src/dtos/listings/listings-query-params.dto.ts
@@ -52,6 +52,7 @@ export class ListingsQueryParams extends PaginationAllowsAllQueryParams {
     enumName: 'ListingOrderByKeys',
     example: ['mostRecentlyUpdated'],
     default: ['mostRecentlyUpdated'],
+    isArray: true,
   })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(16, { groups: [ValidationsGroupsEnum.default] })
@@ -71,6 +72,7 @@ export class ListingsQueryParams extends PaginationAllowsAllQueryParams {
     enumName: 'OrderByEnum',
     example: ['desc'],
     default: ['desc'],
+    isArray: true,
   })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @ArrayMaxSize(16, { groups: [ValidationsGroupsEnum.default] })

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2761,10 +2761,10 @@ export interface ListingsQueryBody {
   view?: ListingViews
 
   /**  */
-  orderBy?: ListingOrderByKeys
+  orderBy?: ListingOrderByKeys[]
 
   /**  */
-  orderDir?: OrderByEnum
+  orderDir?: OrderByEnum[]
 
   /**  */
   search?: string


### PR DESCRIPTION
This PR addresses #(4542)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Doorway frontend (as well as Detroit) send back strings for bedrooms and bathrooms. Filter being a number without casting the string to a number caused 500 errors and the map to break. Adding @Type casts the string to a number and allows for numbers to be sent as well. Still catches bad strings that are not numbers.

Other fixes caught:
- isArray accidentally removed from @ApiPropertyOptional for OrderBy and OrderDir fields, caused complaints in FE code, no errors
- Adjust listing-factory to alleviate issue in Doorway e2e tests

## How Can This Be Tested/Reviewed?

Spin up backend.
Test bedroom and bathroom filters. Use both numbers, numbers as strings and random strings (success, success, failure respectively)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
