### PR TITLE
refactor: listing status messages

### DIFF
--- a/shared-helpers/package.json
+++ b/shared-helpers/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@bloom-housing/ui-components": "12.4.0",
-    "@bloom-housing/ui-seeds": "1.19.0",
+    "@bloom-housing/ui-seeds": "1.19.1",
     "@heroicons/react": "^2.1.1",
     "axios-cookiejar-support": "4.0.6",
     "tough-cookie": "4.1.3"

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bloom-housing/shared-helpers": "^7.7.1",
     "@bloom-housing/ui-components": "12.4.0",
-    "@bloom-housing/ui-seeds": "1.19.0",
+    "@bloom-housing/ui-seeds": "1.19.1",
     "@heroicons/react": "^2.1.1",
     "@mapbox/mapbox-sdk": "^0.13.0",
     "ag-grid-community": "^26.0.0",

--- a/sites/public/__tests__/components/browse/ListingBrowse.test.tsx
+++ b/sites/public/__tests__/components/browse/ListingBrowse.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { setupServer } from "msw/lib/node"
 import { render } from "@testing-library/react"
-import { listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { ListingBrowse } from "../../../src/components/browse/ListingBrowse"
 import { mockNextRouter } from "../../testUtils"
 
@@ -18,7 +18,9 @@ afterAll(() => server.close())
 
 describe("<ListingBrowse>", () => {
   it("shows empty state", () => {
-    const view = render(<ListingBrowse openListings={[]} closedListings={[]} />)
+    const view = render(
+      <ListingBrowse openListings={[]} closedListings={[]} jurisdiction={jurisdiction} />
+    )
     expect(view.getByText("No listings currently have open applications.")).toBeDefined()
   })
   it("shows multiple open listings", () => {
@@ -29,6 +31,7 @@ describe("<ListingBrowse>", () => {
           { ...listing, name: "ListingB" },
         ]}
         closedListings={[]}
+        jurisdiction={jurisdiction}
       />
     )
     expect(view.queryByText("No listings currently have open applications.")).toBeNull()

--- a/sites/public/__tests__/components/browse/ListingCard.test.tsx
+++ b/sites/public/__tests__/components/browse/ListingCard.test.tsx
@@ -1,12 +1,23 @@
 import React from "react"
 import { render } from "@testing-library/react"
-import { listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { ListingCard } from "../../../src/components/browse/ListingCard"
 import { getListingTags } from "../../../src/components/listing/listing_sections/MainDetails"
+import { ListingsStatusEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import dayjs from "dayjs"
 
 describe("<ListingCard>", () => {
   it("shows all card content", () => {
-    const view = render(<ListingCard listing={listing} />)
+    const view = render(
+      <ListingCard
+        listing={{
+          ...listing,
+          status: ListingsStatusEnum.active,
+          applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
     const tags = getListingTags(listing, true)
     expect(view.getByText(listing.name)).toBeDefined()
     expect(view.getByText("98 Archer Street, San Jose, CA 95112")).toBeDefined()

--- a/sites/public/__tests__/components/listing/listing_sections/Availability.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/Availability.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { render, cleanup } from "@testing-library/react"
+import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { Availability } from "../../../../src/components/listing/listing_sections/Availability"
 import {
   ListingsStatusEnum,
@@ -12,12 +13,16 @@ describe("<Availability>", () => {
   it("shows nothing if listing is closed with no reserved community type", () => {
     const { queryByText } = render(
       <Availability
-        reservedCommunityDescription={null}
-        reservedCommunityType={null}
-        reviewOrder={ReviewOrderTypeEnum.firstComeFirstServe}
-        status={ListingsStatusEnum.closed}
-        unitsAvailable={100}
-        waitlistOpenSpots={null}
+        listing={{
+          ...listing,
+          reservedCommunityDescription: null,
+          reservedCommunityTypes: null,
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          status: ListingsStatusEnum.closed,
+          unitsAvailable: 100,
+          waitlistOpenSpots: null,
+        }}
+        jurisdiction={jurisdiction}
       />
     )
     expect(queryByText("Reserved Building")).toBeNull()
@@ -25,29 +30,19 @@ describe("<Availability>", () => {
     expect(queryByText("Vacant Units Available")).toBeNull()
     expect(queryByText("Waitlist is open")).toBeNull()
   })
-  it("shows senior reserved community type while listing is closed", () => {
-    const { getByText } = render(
-      <Availability
-        reservedCommunityDescription={null}
-        reservedCommunityType={{ id: "id", name: "senior" }}
-        reviewOrder={ReviewOrderTypeEnum.firstComeFirstServe}
-        status={ListingsStatusEnum.closed}
-        unitsAvailable={100}
-        waitlistOpenSpots={null}
-      />
-    )
-    expect(getByText("Senior Building")).toBeDefined()
-    expect(getByText("Seniors")).toBeDefined()
-  })
   it("shows reserved community type while listing is closed", () => {
     const { getByText, queryByText } = render(
       <Availability
-        reservedCommunityDescription={null}
-        reservedCommunityType={{ id: "id", name: "veteran" }}
-        reviewOrder={ReviewOrderTypeEnum.firstComeFirstServe}
-        status={ListingsStatusEnum.closed}
-        unitsAvailable={100}
-        waitlistOpenSpots={null}
+        listing={{
+          ...listing,
+          reservedCommunityDescription: null,
+          reservedCommunityTypes: { id: "id", name: "veteran" },
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          status: ListingsStatusEnum.closed,
+          unitsAvailable: 100,
+          waitlistOpenSpots: null,
+        }}
+        jurisdiction={jurisdiction}
       />
     )
     expect(getByText("Reserved Building")).toBeDefined()
@@ -58,12 +53,16 @@ describe("<Availability>", () => {
   it("shows reserved community type, description, availability while listing is open with fcfs type", () => {
     const { getByText, queryByText } = render(
       <Availability
-        reservedCommunityDescription={"Reserved community type description"}
-        reservedCommunityType={{ id: "id", name: "veteran" }}
-        reviewOrder={ReviewOrderTypeEnum.firstComeFirstServe}
-        status={ListingsStatusEnum.active}
-        unitsAvailable={100}
-        waitlistOpenSpots={null}
+        listing={{
+          ...listing,
+          reservedCommunityDescription: "Reserved community type description",
+          reservedCommunityTypes: { id: "id", name: "veteran" },
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          status: ListingsStatusEnum.active,
+          unitsAvailable: 100,
+          waitlistOpenSpots: null,
+        }}
+        jurisdiction={jurisdiction}
       />
     )
     expect(getByText("Reserved Building")).toBeDefined()
@@ -82,12 +81,16 @@ describe("<Availability>", () => {
   it("shows availability with lottery type", () => {
     const { getByText, queryByText } = render(
       <Availability
-        reservedCommunityDescription={null}
-        reservedCommunityType={null}
-        reviewOrder={ReviewOrderTypeEnum.lottery}
-        status={ListingsStatusEnum.active}
-        unitsAvailable={100}
-        waitlistOpenSpots={null}
+        listing={{
+          ...listing,
+          reservedCommunityDescription: null,
+          reservedCommunityTypes: null,
+          reviewOrderType: ReviewOrderTypeEnum.lottery,
+          status: ListingsStatusEnum.active,
+          unitsAvailable: 100,
+          waitlistOpenSpots: null,
+        }}
+        jurisdiction={jurisdiction}
       />
     )
     expect(getByText("Vacant Units Available")).toBeDefined()
@@ -101,12 +104,16 @@ describe("<Availability>", () => {
   it("shows availability for one unit with lottery type", () => {
     const { getByText, queryByText } = render(
       <Availability
-        reservedCommunityDescription={null}
-        reservedCommunityType={null}
-        reviewOrder={ReviewOrderTypeEnum.lottery}
-        status={ListingsStatusEnum.active}
-        unitsAvailable={1}
-        waitlistOpenSpots={null}
+        listing={{
+          ...listing,
+          reservedCommunityDescription: null,
+          reservedCommunityTypes: null,
+          reviewOrderType: ReviewOrderTypeEnum.lottery,
+          status: ListingsStatusEnum.active,
+          unitsAvailable: 1,
+          waitlistOpenSpots: null,
+        }}
+        jurisdiction={jurisdiction}
       />
     )
     expect(getByText("Vacant Units Available")).toBeDefined()
@@ -120,12 +127,16 @@ describe("<Availability>", () => {
   it("shows availability with waitlist type and spots", () => {
     const { getByText, queryByText } = render(
       <Availability
-        reservedCommunityDescription={null}
-        reservedCommunityType={null}
-        reviewOrder={ReviewOrderTypeEnum.waitlist}
-        status={ListingsStatusEnum.active}
-        unitsAvailable={null}
-        waitlistOpenSpots={100}
+        listing={{
+          ...listing,
+          reservedCommunityDescription: null,
+          reservedCommunityTypes: null,
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+          status: ListingsStatusEnum.active,
+          unitsAvailable: null,
+          waitlistOpenSpots: 100,
+        }}
+        jurisdiction={jurisdiction}
       />
     )
     expect(getByText("Waitlist is open")).toBeDefined()
@@ -136,12 +147,16 @@ describe("<Availability>", () => {
   it("shows availability while listing is open with no spots entered", () => {
     const { queryByText } = render(
       <Availability
-        reservedCommunityDescription={null}
-        reservedCommunityType={null}
-        reviewOrder={ReviewOrderTypeEnum.waitlist}
-        status={ListingsStatusEnum.active}
-        unitsAvailable={null}
-        waitlistOpenSpots={null}
+        listing={{
+          ...listing,
+          reservedCommunityDescription: null,
+          reservedCommunityTypes: null,
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+          status: ListingsStatusEnum.active,
+          unitsAvailable: null,
+          waitlistOpenSpots: null,
+        }}
+        jurisdiction={jurisdiction}
       />
     )
     expect(queryByText("Waitlist Slot", { exact: false })).toBeNull()

--- a/sites/public/__tests__/components/listing/listing_sections/Availability.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/Availability.test.tsx
@@ -343,6 +343,7 @@ describe("<Availability>", () => {
     expect(view.getAllByText("Under Construction").length).toBe(2)
     expect(view.queryByText("First Come First Serve")).toBeNull()
     expect(view.queryByText("Vacant Units Available")).toBeNull()
+    expect(view.getByText("Residents should apply in Spring 2026")).toBeDefined()
     expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
     expect(
       view.getByText(

--- a/sites/public/__tests__/components/listing/listing_sections/Availability.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/Availability.test.tsx
@@ -1,17 +1,43 @@
 import React from "react"
+import dayjs from "dayjs"
 import { render, cleanup } from "@testing-library/react"
 import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
-import { Availability } from "../../../../src/components/listing/listing_sections/Availability"
 import {
+  FeatureFlag,
+  FeatureFlagEnum,
   ListingsStatusEnum,
+  MarketingSeasonEnum,
+  MarketingTypeEnum,
   ReviewOrderTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { Availability } from "../../../../src/components/listing/listing_sections/Availability"
 
 afterEach(cleanup)
 
 describe("<Availability>", () => {
-  it("shows nothing if listing is closed with no reserved community type", () => {
-    const { queryByText } = render(
+  it("shows reserved community type", () => {
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
+          reservedCommunityDescription: "Community type description",
+          reservedCommunityTypes: { id: "id", name: "veteran" },
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          status: ListingsStatusEnum.closed,
+          unitsAvailable: 100,
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
+    expect(view.getByText("Applications Closed")).toBeDefined()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Reserved Building")).toBeDefined()
+    expect(view.getByText("Veteran")).toBeDefined()
+    expect(view.getByText("Community type description")).toBeDefined()
+  })
+  it("shows correct data for closed fcfs listing", () => {
+    const dueDate = dayjs(new Date()).subtract(5, "days").hour(10).minute(30).toDate()
+    const view = render(
       <Availability
         listing={{
           ...listing,
@@ -20,146 +46,308 @@ describe("<Availability>", () => {
           reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
           status: ListingsStatusEnum.closed,
           unitsAvailable: 100,
-          waitlistOpenSpots: null,
+          applicationDueDate: dueDate,
         }}
         jurisdiction={jurisdiction}
       />
     )
-    expect(queryByText("Reserved Building")).toBeNull()
-    expect(queryByText("Senior Building")).toBeNull()
-    expect(queryByText("Vacant Units Available")).toBeNull()
-    expect(queryByText("Waitlist is open")).toBeNull()
-  })
-  it("shows reserved community type while listing is closed", () => {
-    const { getByText, queryByText } = render(
-      <Availability
-        listing={{
-          ...listing,
-          reservedCommunityDescription: null,
-          reservedCommunityTypes: { id: "id", name: "veteran" },
-          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
-          status: ListingsStatusEnum.closed,
-          unitsAvailable: 100,
-          waitlistOpenSpots: null,
-        }}
-        jurisdiction={jurisdiction}
-      />
-    )
-    expect(getByText("Reserved Building")).toBeDefined()
-    expect(getByText("Veteran")).toBeDefined()
-    expect(queryByText("Vacant Units Available")).toBeNull()
-    expect(queryByText("Waitlist is open")).toBeNull()
-  })
-  it("shows reserved community type, description, availability while listing is open with fcfs type", () => {
-    const { getByText, queryByText } = render(
-      <Availability
-        listing={{
-          ...listing,
-          reservedCommunityDescription: "Reserved community type description",
-          reservedCommunityTypes: { id: "id", name: "veteran" },
-          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
-          status: ListingsStatusEnum.active,
-          unitsAvailable: 100,
-          waitlistOpenSpots: null,
-        }}
-        jurisdiction={jurisdiction}
-      />
-    )
-    expect(getByText("Reserved Building")).toBeDefined()
-    expect(getByText("Veteran")).toBeDefined()
-    expect(getByText("Reserved community type description")).toBeDefined()
-    expect(getByText("Vacant Units Available")).toBeDefined()
-    expect(getByText("100 Vacant Units")).toBeDefined()
+    expect(view.getByText("Applications Closed")).toBeDefined()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("First Come First Serve")).toBeDefined()
+    expect(view.queryByText("Vacant Units Available")).toBeNull()
     expect(
-      getByText(
+      view.getByText(
         "Eligible applicants will be contacted on a first come first serve basis until vacancies are filled."
       )
     ).toBeDefined()
-    expect(queryByText("Waitlist is open")).toBeNull()
+    expect(view.getByText("100 units")).toBeDefined()
   })
-
-  it("shows availability with lottery type", () => {
-    const { getByText, queryByText } = render(
+  it("shows correct data for open fcfs listing", () => {
+    const dueDate = dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate()
+    const view = render(
       <Availability
         listing={{
           ...listing,
-          reservedCommunityDescription: null,
-          reservedCommunityTypes: null,
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          status: ListingsStatusEnum.active,
+          unitsAvailable: 1,
+          applicationDueDate: dueDate,
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
+    expect(view.queryByText("Applications Closed")).toBeNull()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("First Come First Serve")).toBeDefined()
+    expect(view.getByText("Vacant Units Available")).toBeDefined()
+    expect(view.getByText("Application Due:", { exact: false })).toBeDefined()
+    expect(view.getByText(dayjs(dueDate).format("MMM DD, YYYY"), { exact: false })).toBeDefined()
+    expect(
+      view.getByText(
+        "Eligible applicants will be contacted on a first come first serve basis until vacancies are filled."
+      )
+    ).toBeDefined()
+    expect(view.getByText("1 unit")).toBeDefined()
+  })
+  it("shows correct data for closed lottery listing", () => {
+    const dueDate = dayjs(new Date()).subtract(5, "days").hour(10).minute(30).toDate()
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
+          reviewOrderType: ReviewOrderTypeEnum.lottery,
+          status: ListingsStatusEnum.closed,
+          unitsAvailable: 100,
+          applicationDueDate: dueDate,
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
+    expect(view.getByText("Applications Closed")).toBeDefined()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Lottery")).toBeDefined()
+    expect(view.queryByText("Vacant Units Available")).toBeNull()
+    expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
+    expect(view.queryByText(dayjs(dueDate).format("MMM DD, YYYY"), { exact: false })).toBeNull()
+    expect(
+      view.getByText(
+        "Applicants will be reviewed in lottery rank order until all vacancies are filled."
+      )
+    ).toBeDefined()
+    expect(view.getByText("100 units")).toBeDefined()
+  })
+
+  it("shows correct data for open lottery listing", () => {
+    const dueDate = dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate()
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
           reviewOrderType: ReviewOrderTypeEnum.lottery,
           status: ListingsStatusEnum.active,
           unitsAvailable: 100,
-          waitlistOpenSpots: null,
+          applicationDueDate: dueDate,
         }}
         jurisdiction={jurisdiction}
       />
     )
-    expect(getByText("Vacant Units Available")).toBeDefined()
-    expect(getByText("100 Vacant Units")).toBeDefined()
+    expect(view.queryByText("Applications Closed")).toBeNull()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Lottery")).toBeDefined()
+    expect(view.getByText("Vacant Units Available")).toBeDefined()
+    expect(view.getByText("Application Due:", { exact: false })).toBeDefined()
+    expect(view.getByText(dayjs(dueDate).format("MMM DD, YYYY"), { exact: false })).toBeDefined()
     expect(
-      getByText("Applicants will be reviewed in lottery rank order until all vacancies are filled.")
+      view.getByText(
+        "Applicants will be reviewed in lottery rank order until all vacancies are filled."
+      )
     ).toBeDefined()
-    expect(queryByText("Waitlist is open")).toBeNull()
-    expect(queryByText("Reserved Building")).toBeNull()
+    expect(view.getByText("100 units")).toBeDefined()
   })
-  it("shows availability for one unit with lottery type", () => {
-    const { getByText, queryByText } = render(
+
+  it("shows correct data for closed waitlist listing, due date, no spots", () => {
+    const dueDate = dayjs(new Date()).subtract(5, "days").hour(10).minute(30).toDate()
+    const view = render(
       <Availability
         listing={{
           ...listing,
-          reservedCommunityDescription: null,
-          reservedCommunityTypes: null,
-          reviewOrderType: ReviewOrderTypeEnum.lottery,
-          status: ListingsStatusEnum.active,
-          unitsAvailable: 1,
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+          status: ListingsStatusEnum.closed,
           waitlistOpenSpots: null,
+          applicationDueDate: dueDate,
         }}
         jurisdiction={jurisdiction}
       />
     )
-    expect(getByText("Vacant Units Available")).toBeDefined()
-    expect(getByText("1 Vacant Unit")).toBeDefined()
-    expect(
-      getByText("Applicants will be reviewed in lottery rank order until all vacancies are filled.")
-    ).toBeDefined()
-    expect(queryByText("Waitlist is open")).toBeNull()
-    expect(queryByText("Reserved Building")).toBeNull()
+    expect(view.getByText("Applications Closed")).toBeDefined()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Waitlist")).toBeDefined()
+    expect(view.queryByText("Waitlist is open")).toBeNull()
+    expect(view.queryByText("Open Waitlist Slots")).toBeNull()
+    expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
+    expect(view.queryByText(dayjs(dueDate).format("MMM DD, YYYY"), { exact: false })).toBeNull()
+    expect(view.queryByText("Submit an application for an open slot on the waitlist.")).toBeNull()
   })
-  it("shows availability with waitlist type and spots", () => {
-    const { getByText, queryByText } = render(
+
+  it("shows correct data for open waitlist listing, due date, no spots", () => {
+    const dueDate = dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate()
+    const view = render(
       <Availability
         listing={{
           ...listing,
-          reservedCommunityDescription: null,
-          reservedCommunityTypes: null,
           reviewOrderType: ReviewOrderTypeEnum.waitlist,
           status: ListingsStatusEnum.active,
-          unitsAvailable: null,
-          waitlistOpenSpots: 100,
+          waitlistOpenSpots: null,
+          applicationDueDate: dueDate,
         }}
         jurisdiction={jurisdiction}
       />
     )
-    expect(getByText("Waitlist is open")).toBeDefined()
-    expect(getByText("100 Open Waitlist Slots")).toBeDefined()
-    expect(getByText("Submit an application for an open slot on the waitlist.")).toBeDefined()
-    expect(queryByText("Vacant Units Available")).toBeNull()
+    expect(view.queryByText("Applications Closed")).toBeNull()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Waitlist")).toBeDefined()
+    expect(view.getByText("Waitlist is open")).toBeDefined()
+    expect(view.queryByText("Open Waitlist Slots")).toBeNull()
+    expect(view.getByText("Application Due:", { exact: false })).toBeDefined()
+    expect(view.getByText(dayjs(dueDate).format("MMM DD, YYYY"), { exact: false })).toBeDefined()
+    expect(view.getByText("Submit an application for an open slot on the waitlist.")).toBeDefined()
   })
-  it("shows availability while listing is open with no spots entered", () => {
-    const { queryByText } = render(
+
+  it("shows correct data for closed waitlist listing, no due date, no spots", () => {
+    const view = render(
       <Availability
         listing={{
           ...listing,
-          reservedCommunityDescription: null,
-          reservedCommunityTypes: null,
           reviewOrderType: ReviewOrderTypeEnum.waitlist,
-          status: ListingsStatusEnum.active,
-          unitsAvailable: null,
+          status: ListingsStatusEnum.closed,
           waitlistOpenSpots: null,
+          applicationDueDate: null,
         }}
         jurisdiction={jurisdiction}
       />
     )
-    expect(queryByText("Waitlist Slot", { exact: false })).toBeNull()
-    expect(queryByText("Vacant Unit", { exact: false })).toBeNull()
+    expect(view.getByText("Applications Closed")).toBeDefined()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Waitlist")).toBeDefined()
+    expect(view.queryByText("Waitlist is open")).toBeNull()
+    expect(view.queryByText("Open Waitlist Slots")).toBeNull()
+    expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
+    expect(view.queryByText("Submit an application for an open slot on the waitlist.")).toBeNull()
+  })
+
+  it("shows correct data for open waitlist listing, no due date, no spots", () => {
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+          status: ListingsStatusEnum.active,
+          waitlistOpenSpots: null,
+          applicationDueDate: null,
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
+    expect(view.queryByText("Applications Closed")).toBeNull()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Waitlist")).toBeDefined()
+    expect(view.getByText("Waitlist is open")).toBeDefined()
+    expect(view.queryByText("Open Waitlist Slots")).toBeNull()
+    expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
+    expect(view.getByText("Applications Open")).toBeDefined()
+    expect(view.getByText("Submit an application for an open slot on the waitlist.")).toBeDefined()
+  })
+
+  it("shows correct data for closed waitlist listing, with spots", () => {
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+          status: ListingsStatusEnum.closed,
+          waitlistOpenSpots: 50,
+          applicationDueDate: null,
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
+    expect(view.getByText("Applications Closed")).toBeDefined()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Waitlist")).toBeDefined()
+    expect(view.queryByText("Waitlist is open")).toBeNull()
+    expect(view.getByText("50 Open Waitlist Slots")).toBeDefined()
+    expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
+    expect(view.queryByText("Submit an application for an open slot on the waitlist.")).toBeNull()
+  })
+
+  it("shows correct data for open waitlist listing, with spots", () => {
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+          status: ListingsStatusEnum.active,
+          waitlistOpenSpots: 50,
+          applicationDueDate: null,
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
+    expect(view.queryByText("Applications Closed")).toBeNull()
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getByText("Waitlist")).toBeDefined()
+    expect(view.getByText("Waitlist is open")).toBeDefined()
+    expect(view.getByText("50 Open Waitlist Slots")).toBeDefined()
+    expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
+    expect(view.getByText("Applications Open")).toBeDefined()
+    expect(view.getByText("Submit an application for an open slot on the waitlist.")).toBeDefined()
+  })
+
+  it("shows correct data for under construction with enableMarketingStatus off", () => {
+    const dueDate = dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate()
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          status: ListingsStatusEnum.active,
+          waitlistOpenSpots: null,
+          applicationDueDate: dueDate,
+          marketingType: MarketingTypeEnum.comingSoon,
+          marketingSeason: MarketingSeasonEnum.spring,
+          marketingDate: new Date(2026, 1, 1, 10, 30, 0),
+        }}
+        jurisdiction={{
+          ...jurisdiction,
+          featureFlags: [
+            { name: FeatureFlagEnum.enableMarketingStatus, active: false } as FeatureFlag,
+          ],
+        }}
+      />
+    )
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.queryByText("Under Construction")).toBeNull()
+    expect(view.getByText("First Come First Serve")).toBeDefined()
+    expect(view.getByText("Vacant Units Available")).toBeDefined()
+    expect(view.getByText("Application Due:", { exact: false })).toBeDefined()
+    expect(
+      view.getByText(
+        "Eligible applicants will be contacted on a first come first serve basis until vacancies are filled."
+      )
+    ).toBeDefined()
+  })
+
+  it("shows correct data for under construction with enableMarketingStatus on", () => {
+    const dueDate = dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate()
+    const view = render(
+      <Availability
+        listing={{
+          ...listing,
+          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+          status: ListingsStatusEnum.active,
+          waitlistOpenSpots: null,
+          applicationDueDate: dueDate,
+          marketingType: MarketingTypeEnum.comingSoon,
+          marketingSeason: MarketingSeasonEnum.spring,
+          marketingDate: new Date(2026, 1, 1, 10, 30, 0),
+        }}
+        jurisdiction={{
+          ...jurisdiction,
+          featureFlags: [
+            { name: FeatureFlagEnum.enableMarketingStatus, active: true } as FeatureFlag,
+          ],
+        }}
+      />
+    )
+    expect(view.getByText("Availability")).toBeDefined()
+    expect(view.getAllByText("Under Construction").length).toBe(2)
+    expect(view.queryByText("First Come First Serve")).toBeNull()
+    expect(view.queryByText("Vacant Units Available")).toBeNull()
+    expect(view.queryByText("Application Due:", { exact: false })).toBeNull()
+    expect(
+      view.getByText(
+        "Eligible applicants will be contacted on a first come first serve basis until vacancies are filled."
+      )
+    ).toBeDefined()
   })
 })

--- a/sites/public/__tests__/components/listing/listing_sections/MainDetails.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/MainDetails.test.tsx
@@ -1,23 +1,22 @@
 import React from "react"
 import { render, cleanup } from "@testing-library/react"
-import { listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { MainDetails } from "../../../../src/components/listing/listing_sections/MainDetails"
 import { oneLineAddress } from "@bloom-housing/shared-helpers"
-import {
-  MarketingTypeEnum,
-  ReviewOrderTypeEnum,
-} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { ReviewOrderTypeEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 afterEach(cleanup)
 
 describe("<MainDetails>", () => {
   it("shows nothing if no listing", () => {
-    const { queryByText } = render(<MainDetails listing={null} dueDateContent={[]} />)
+    const { queryByText } = render(
+      <MainDetails listing={null} dueDateContent={[]} jurisdiction={jurisdiction} />
+    )
     expect(queryByText(listing.name)).toBeNull()
   })
   it("shows all content", () => {
     const { getByText, getByRole, getByAltText } = render(
-      <MainDetails listing={listing} dueDateContent={[]} />
+      <MainDetails listing={listing} dueDateContent={[]} jurisdiction={jurisdiction} />
     )
     expect(getByRole("heading", { level: 1 })).toHaveTextContent(listing.name)
     expect(getByText(oneLineAddress(listing.listingsBuildingAddress))).toBeDefined()
@@ -34,6 +33,7 @@ describe("<MainDetails>", () => {
           reservedCommunityTypes: null,
         }}
         dueDateContent={[]}
+        jurisdiction={jurisdiction}
       />
     )
     expect(queryByTestId("listing-tags")).toBeNull()
@@ -47,48 +47,10 @@ describe("<MainDetails>", () => {
           reservedCommunityTypes: { id: "id", name: "veteran" },
         }}
         dueDateContent={[]}
+        jurisdiction={jurisdiction}
       />
     )
     expect(getByTestId("listing-tags")).toBeDefined()
     expect(getAllByText("Veteran").length).toBeGreaterThan(0)
-  })
-  it("shows units available tag for fcfs", () => {
-    const { getByTestId, getByText } = render(
-      <MainDetails
-        listing={{
-          ...listing,
-          reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
-        }}
-        dueDateContent={[]}
-      />
-    )
-    expect(getByTestId("listing-tags")).toBeDefined()
-    expect(getByText("Available Units")).toBeDefined()
-  })
-  it("shows open waitlist tag", () => {
-    const { getByTestId, getByText } = render(
-      <MainDetails
-        listing={{
-          ...listing,
-          reviewOrderType: ReviewOrderTypeEnum.waitlist,
-        }}
-        dueDateContent={[]}
-      />
-    )
-    expect(getByTestId("listing-tags")).toBeDefined()
-    expect(getByText("Open Waitlist")).toBeDefined()
-  })
-  it("shows under construction tag", () => {
-    const { getByTestId, getByText } = render(
-      <MainDetails
-        listing={{
-          ...listing,
-          marketingType: MarketingTypeEnum.comingSoon,
-        }}
-        dueDateContent={[]}
-      />
-    )
-    expect(getByTestId("listing-tags")).toBeDefined()
-    expect(getByText("Under Construction")).toBeDefined()
   })
 })

--- a/sites/public/__tests__/lib/helpers.test.tsx
+++ b/sites/public/__tests__/lib/helpers.test.tsx
@@ -1,0 +1,245 @@
+import React from "react"
+import dayjs from "dayjs"
+import { render } from "@testing-library/react"
+import {
+  ListingsStatusEnum,
+  MarketingSeasonEnum,
+  MarketingTypeEnum,
+  ReviewOrderTypeEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { listing, jurisdiction } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import {
+  getListingStatusMessage,
+  getListingStatusMessageContent,
+  getStatusPrefix,
+} from "../../src/lib/helpers"
+
+describe("helpers", () => {
+  describe("getStatusPrefix", () => {
+    it("should return correctly for closed listings", () => {
+      expect(getStatusPrefix({ ...listing, status: ListingsStatusEnum.closed }, false)).toEqual({
+        label: "Applications Closed",
+        variant: "secondary-inverse",
+      })
+    })
+    it("should not show under construction if toggle is off", () => {
+      expect(
+        getStatusPrefix(
+          {
+            ...listing,
+            reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+            status: ListingsStatusEnum.active,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+            marketingType: MarketingTypeEnum.comingSoon,
+          },
+          false
+        )
+      ).toEqual({
+        label: "First Come First Serve",
+        variant: "primary",
+      })
+    })
+    it("should show under construction if toggle is on", () => {
+      expect(
+        getStatusPrefix(
+          {
+            ...listing,
+            reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+            status: ListingsStatusEnum.active,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+            marketingType: MarketingTypeEnum.comingSoon,
+          },
+          true
+        )
+      ).toEqual({
+        label: "Under Construction",
+        variant: "warn",
+      })
+    })
+    it("should show closed on an active listing if due date is in the past", () => {
+      expect(
+        getStatusPrefix(
+          {
+            ...listing,
+            reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+            status: ListingsStatusEnum.active,
+          },
+          false
+        )
+      ).toEqual({
+        label: "Applications Closed",
+        variant: "secondary-inverse",
+      })
+    })
+    it("should return correctly for lottery listings", () => {
+      expect(
+        getStatusPrefix(
+          {
+            ...listing,
+            reviewOrderType: ReviewOrderTypeEnum.lottery,
+            status: ListingsStatusEnum.active,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+          },
+          false
+        )
+      ).toEqual({
+        label: "Lottery",
+        variant: "primary",
+      })
+    })
+    it("should return correctly for waitlist listings", () => {
+      expect(
+        getStatusPrefix(
+          {
+            ...listing,
+            reviewOrderType: ReviewOrderTypeEnum.waitlist,
+            status: ListingsStatusEnum.active,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+          },
+          false
+        )
+      ).toEqual({
+        label: "Open Waitlist",
+        variant: "secondary",
+      })
+    })
+  })
+
+  describe("getListingStatusMessageContent", () => {
+    it("should return correctly with under construction and marketing enabled", () => {
+      expect(
+        getListingStatusMessageContent(
+          ListingsStatusEnum.active,
+          dayjs(new Date()).add(5, "days").toDate(),
+          true,
+          MarketingTypeEnum.comingSoon,
+          MarketingSeasonEnum.spring,
+          new Date(2026, 1, 1),
+          false
+        )
+      ).toEqual("Residents should apply in Spring 2026")
+    })
+    it("should return correctly under with construction and marketing disabled", () => {
+      const result = getListingStatusMessageContent(
+        ListingsStatusEnum.active,
+        dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate(),
+        false,
+        MarketingTypeEnum.comingSoon,
+        MarketingSeasonEnum.spring,
+        new Date(2026, 1, 1, 10, 30, 0),
+        false
+      )
+      expect(result).toContain("Application Due:")
+      expect(result).toContain("10:30AM")
+    })
+    it("should return date but hide time", () => {
+      const result = getListingStatusMessageContent(
+        ListingsStatusEnum.active,
+        dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate(),
+        false,
+        MarketingTypeEnum.comingSoon,
+        MarketingSeasonEnum.spring,
+        new Date(2026, 1, 1, 10, 30, 0),
+        true
+      )
+      expect(result).toContain("Application Due:")
+      expect(result).not.toContain("10:30AM")
+    })
+  })
+  it("should return correctly for closed listing", () => {
+    expect(
+      getListingStatusMessageContent(
+        ListingsStatusEnum.closed,
+        dayjs(new Date()).subtract(5, "days").toDate(),
+        false,
+        null,
+        null,
+        null,
+        false
+      )
+    ).toEqual("")
+  })
+  it("should return correctly for active listing with no due date", () => {
+    expect(
+      getListingStatusMessageContent(
+        ListingsStatusEnum.active,
+        null,
+        false,
+        null,
+        null,
+        null,
+        false
+      )
+    ).toEqual("Applications Open")
+  })
+
+  describe("getListingStatusMessage", () => {
+    it("should return correctly for closed listing", () => {
+      const view = render(
+        getListingStatusMessage(
+          {
+            ...listing,
+            applicationDueDate: dayjs(new Date()).subtract(5, "days").toDate(),
+            status: ListingsStatusEnum.closed,
+          },
+          jurisdiction,
+          null,
+          false,
+          false
+        )
+      )
+      expect(view.getByText("Applications Closed")).toBeDefined()
+    })
+  })
+  it("should return correctly for open listing with date", () => {
+    const view = render(
+      getListingStatusMessage(
+        {
+          ...listing,
+          applicationDueDate: dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate(),
+          status: ListingsStatusEnum.active,
+        },
+        jurisdiction,
+        null,
+        false,
+        false
+      )
+    )
+    expect(view.getByText("10:30AM", { exact: false })).toBeDefined()
+  })
+  it("should return correctly for open listing without date", () => {
+    const view = render(
+      getListingStatusMessage(
+        {
+          ...listing,
+          applicationDueDate: dayjs(new Date()).add(5, "days").hour(10).minute(30).toDate(),
+          status: ListingsStatusEnum.active,
+        },
+        jurisdiction,
+        null,
+        false,
+        true
+      )
+    )
+    expect(view.queryByText("10:30AM", { exact: false })).toBeNull()
+  })
+  it("should return correctly for null listing", () => {
+    expect(getListingStatusMessage(null, jurisdiction, null, false, false)).toBeUndefined()
+  })
+  it("should render custom content", () => {
+    const view = render(
+      getListingStatusMessage(
+        {
+          ...listing,
+          applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+          status: ListingsStatusEnum.active,
+        },
+        jurisdiction,
+        <div>Custom content</div>,
+        false,
+        false
+      )
+    )
+    expect(view.getByText("Custom content")).toBeDefined()
+  })
+})

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bloom-housing/shared-helpers": "^7.7.1",
     "@bloom-housing/ui-components": "12.4.0",
-    "@bloom-housing/ui-seeds": "1.19.0",
+    "@bloom-housing/ui-seeds": "1.19.1",
     "@heroicons/react": "^2.1.1",
     "@mapbox/mapbox-sdk": "^0.13.0",
     "@sentry/nextjs": "^7.61.0",

--- a/sites/public/src/components/browse/ListingBrowse.tsx
+++ b/sites/public/src/components/browse/ListingBrowse.tsx
@@ -45,13 +45,30 @@ export const ListingBrowse = (props: ListingBrowseProps) => {
           {/* TODO: Show both open and closed listings once we have designs for pagination: Issue #4448 */}
           <>
             {props.openListings.length > 0 ? (
-              <ul>
-                {props.openListings.map((listing, index) => {
-                  return (
-                    <ListingCard listing={listing} key={index} jurisdiction={props.jurisdiction} />
-                  )
-                })}
-              </ul>
+              <>
+                <ul>
+                  {props.openListings.map((listing, index) => {
+                    return (
+                      <ListingCard
+                        listing={listing}
+                        key={index}
+                        jurisdiction={props.jurisdiction}
+                      />
+                    )
+                  })}
+                </ul>
+                <ul className={"seeds-m-bs-content"}>
+                  {props.closedListings.map((listing, index) => {
+                    return (
+                      <ListingCard
+                        listing={listing}
+                        key={index}
+                        jurisdiction={props.jurisdiction}
+                      />
+                    )
+                  })}
+                </ul>
+              </>
             ) : (
               <div className={styles["empty-state"]}>
                 <Heading size={"xl"} priority={2} className={styles["empty-heading"]}>

--- a/sites/public/src/components/browse/ListingBrowse.tsx
+++ b/sites/public/src/components/browse/ListingBrowse.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext } from "react"
 import Head from "next/head"
 import { Heading } from "@bloom-housing/ui-seeds"
-import { Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { Jurisdiction, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { AuthContext, ListingList, pushGtmEvent } from "@bloom-housing/shared-helpers"
 import { PageHeader, t } from "@bloom-housing/ui-components"
 import { MetaTags } from "../../components/shared/MetaTags"
@@ -13,6 +13,7 @@ import styles from "./ListingBrowse.module.scss"
 export interface ListingBrowseProps {
   openListings: Listing[]
   closedListings: Listing[]
+  jurisdiction: Jurisdiction
 }
 
 export const ListingBrowse = (props: ListingBrowseProps) => {
@@ -46,7 +47,9 @@ export const ListingBrowse = (props: ListingBrowseProps) => {
             {props.openListings.length > 0 ? (
               <ul>
                 {props.openListings.map((listing, index) => {
-                  return <ListingCard listing={listing} key={index} />
+                  return (
+                    <ListingCard listing={listing} key={index} jurisdiction={props.jurisdiction} />
+                  )
                 })}
               </ul>
             ) : (

--- a/sites/public/src/components/browse/ListingCard.module.scss
+++ b/sites/public/src/components/browse/ListingCard.module.scss
@@ -84,30 +84,6 @@
         .unit-table {
           margin-block-start: var(--seeds-s3);
         }
-
-        .due-date {
-          --common-message-link-gap: 0;
-          --common-message-font: var(--seeds-font-alt-sans);
-          --message-border: var(--seeds-border-2) solid var(--seeds-color-primary-light);
-          --message-max-width: 100%;
-          --message-border-radius: var(--seeds-rounded);
-          margin-block-start: var(--seeds-s3);
-          background-color: var(--seeds-color-primary-lighter);
-
-          .primary-color-icon {
-            color: var(--seeds-color-primary-dark);
-          }
-
-          .date-review-order {
-            font-weight: var(--seeds-font-weight-bold);
-            color: var(--seeds-color-primary-dark);
-          }
-
-          .due-date-content {
-            display: flex;
-            flex-direction: column;
-          }
-        }
       }
 
       .action-button {

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -1,35 +1,22 @@
 import React from "react"
-import InfoIcon from "@heroicons/react/24/solid/InformationCircleIcon"
-import {
-  Listing,
-  ListingsStatusEnum,
-  ReviewOrderTypeEnum,
-} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { Jurisdiction, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { imageUrlFromListing, oneLineAddress, ClickableCard } from "@bloom-housing/shared-helpers"
 import { StackedTable, t } from "@bloom-housing/ui-components"
-import { Card, Heading, Icon, Link, Message, Tag } from "@bloom-housing/ui-seeds"
-import { getListingApplicationStatus, getListingStackedTableData } from "../../lib/helpers"
+import { Card, Heading, Link, Tag } from "@bloom-housing/ui-seeds"
+import {
+  getListingApplicationStatus,
+  getListingStackedTableData,
+  getListingStatusMessage,
+} from "../../lib/helpers"
 import { getListingTags } from "../listing/listing_sections/MainDetails"
 import styles from "./ListingCard.module.scss"
 
 export interface ListingCardProps {
   listing: Listing
+  jurisdiction: Jurisdiction
 }
 
-export const getMessageData = (reviewOrder: ReviewOrderTypeEnum): string => {
-  switch (reviewOrder) {
-    case ReviewOrderTypeEnum.lottery:
-      return t("listings.lottery")
-    case ReviewOrderTypeEnum.firstComeFirstServe:
-      return t("listings.applicationFCFS")
-    case ReviewOrderTypeEnum.waitlist:
-      return t("listings.waitlist.open")
-    default:
-      return ""
-  }
-}
-
-export const ListingCard = ({ listing }: ListingCardProps) => {
+export const ListingCard = ({ listing, jurisdiction }: ListingCardProps) => {
   const imageUrl = imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))[0]
   const listingTags = getListingTags(listing, true)
   const status = getListingApplicationStatus(listing, true, true)
@@ -77,27 +64,9 @@ export const ListingCard = ({ listing }: ListingCardProps) => {
                 </div>
               )}
               {!!status?.content && (
-                <Message
-                  className={`${styles["due-date"]}`}
-                  customIcon={
-                    <Icon size="md" className={styles["primary-color-icon"]}>
-                      <InfoIcon />
-                    </Icon>
-                  }
-                  variant={"primary"}
-                >
-                  <div className={styles["due-date-content"]}>
-                    <span>
-                      {listing.status === ListingsStatusEnum.active && (
-                        <span className={styles["date-review-order"]}>
-                          {getMessageData(listing.reviewOrderType)}
-                          {`: `}
-                        </span>
-                      )}
-                      {status.content}
-                    </span>
-                  </div>
-                </Message>
+                <div className={"seeds-m-bs-3"}>
+                  {getListingStatusMessage(listing, jurisdiction, true)}
+                </div>
               )}
               <div className={styles["unit-table"]}>
                 <StackedTable

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -65,7 +65,7 @@ export const ListingCard = ({ listing, jurisdiction }: ListingCardProps) => {
               )}
               {!!status?.content && (
                 <div className={"seeds-m-bs-3"}>
-                  {getListingStatusMessage(listing, jurisdiction, true)}
+                  {getListingStatusMessage(listing, jurisdiction, null, true)}
                 </div>
               )}
               <div className={styles["unit-table"]}>

--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -10,7 +10,7 @@ import { t } from "@bloom-housing/ui-components"
 import { pdfUrlFromListingEvents } from "@bloom-housing/shared-helpers"
 import { Heading } from "@bloom-housing/ui-seeds"
 import { ErrorPage } from "../../pages/_error"
-import { getListingApplicationStatus, getListingStatusMessage } from "../../lib/helpers"
+import { getListingApplicationStatus } from "../../lib/helpers"
 import {
   getAdditionalInformation,
   getAmiValues,
@@ -25,7 +25,6 @@ import { AdditionalInformation } from "./listing_sections/AdditionalInformation"
 import { Apply } from "./listing_sections/Apply"
 import { Availability } from "./listing_sections/Availability"
 import { DateSection } from "./listing_sections/DateSection"
-import { DueDate } from "./listing_sections/DueDate"
 import { Eligibility } from "./listing_sections/Eligibility"
 import { Features } from "./listing_sections/Features"
 import { FurtherInformation } from "./listing_sections/FurtherInformation"
@@ -145,8 +144,8 @@ export const ListingViewSeeds = ({ jurisdiction, listing, preview }: ListingProp
         )}
         lotteryResultsEvent={lotteryResultsEvent}
       />
-      {OpenHouses}
       <Apply listing={listing} preview={preview} setShowDownloadModal={setShowDownloadModal} />
+      {OpenHouses}
       {LotteryEvent}
       {ReferralApplication}
       {WhatToExpect}
@@ -168,6 +167,7 @@ export const ListingViewSeeds = ({ jurisdiction, listing, preview }: ListingProp
           <MainDetails
             listing={listing}
             dueDateContent={[statusContent?.content, statusContent?.subContent]}
+            jurisdiction={jurisdiction}
           />
           <RentSummary
             amiValues={getAmiValues(listing)}
@@ -187,15 +187,7 @@ export const ListingViewSeeds = ({ jurisdiction, listing, preview }: ListingProp
           </div>
         </div>
         <div className={`${styles["right-bar"]} ${styles["hide-mobile"]}`}>
-          {getListingStatusMessage(listing, jurisdiction, false)}
-          <Availability
-            reservedCommunityDescription={listing.reservedCommunityDescription}
-            reservedCommunityType={listing.reservedCommunityTypes}
-            reviewOrder={listing.reviewOrderType}
-            status={listing.status}
-            unitsAvailable={listing.unitsAvailable}
-            waitlistOpenSpots={listing.waitlistOpenSpots}
-          />
+          <Availability listing={listing} jurisdiction={jurisdiction} />
           {ApplyBar}
         </div>
       </div>

--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -5,13 +5,12 @@ import {
   Listing,
   ListingEventsTypeEnum,
   ListingsStatusEnum,
-  MarketingTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { t } from "@bloom-housing/ui-components"
 import { pdfUrlFromListingEvents } from "@bloom-housing/shared-helpers"
 import { Heading } from "@bloom-housing/ui-seeds"
 import { ErrorPage } from "../../pages/_error"
-import { getApplicationSeason, getListingApplicationStatus } from "../../lib/helpers"
+import { getListingApplicationStatus, getListingStatusMessage } from "../../lib/helpers"
 import {
   getAdditionalInformation,
   getAmiValues,
@@ -188,11 +187,7 @@ export const ListingViewSeeds = ({ jurisdiction, listing, preview }: ListingProp
           </div>
         </div>
         <div className={`${styles["right-bar"]} ${styles["hide-mobile"]}`}>
-          {listing.marketingType === MarketingTypeEnum.comingSoon ? (
-            <DueDate content={[getApplicationSeason(listing)]} />
-          ) : (
-            <DueDate content={[statusContent?.content, statusContent?.subContent]} />
-          )}
+          {getListingStatusMessage(listing, jurisdiction, false)}
           <Availability
             reservedCommunityDescription={listing.reservedCommunityDescription}
             reservedCommunityType={listing.reservedCommunityTypes}

--- a/sites/public/src/components/listing/listing_sections/Availability.module.scss
+++ b/sites/public/src/components/listing/listing_sections/Availability.module.scss
@@ -3,3 +3,9 @@
     font-weight: var(--seeds-font-weight-semibold);
   }
 }
+
+.bold-subheader {
+  margin-block-start: var(--seeds-spacer-label);
+  color: var(--seeds-text-color-light);
+  font-weight: 700;
+}

--- a/sites/public/src/components/listing/listing_sections/Availability.module.scss
+++ b/sites/public/src/components/listing/listing_sections/Availability.module.scss
@@ -1,11 +1,11 @@
-.emphasized-heading-group {
-  p {
-    font-weight: var(--seeds-font-weight-semibold);
-  }
-}
-
 .bold-subheader {
   margin-block-start: var(--seeds-spacer-label);
   color: var(--seeds-text-color-light);
   font-weight: 700;
+}
+
+.status-messages {
+  @media (--sm-only) {
+    margin-inline: var(--seeds-s4);
+  }
 }

--- a/sites/public/src/components/listing/listing_sections/Availability.tsx
+++ b/sites/public/src/components/listing/listing_sections/Availability.tsx
@@ -29,9 +29,7 @@ export const getAvailabilitySubheading = (
     return `${waitlistOpenSpots} ${t("listings.waitlist.openSlots")}`
   }
   if (unitsAvailable) {
-    return `${unitsAvailable} ${
-      unitsAvailable === 1 ? t("listings.vacantUnit") : t("listings.vacantUnits")
-    }`
+    return `${unitsAvailable} ${unitsAvailable === 1 ? t("t.unit") : t("t.units")}`
   }
   return null
 }
@@ -62,10 +60,11 @@ export const getAvailabilityHeading = (reviewOrderType: ReviewOrderTypeEnum) => 
 }
 
 export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
+  const enableMarketingStatus = isFeatureFlagOn(jurisdiction, "enableMarketingStatus")
   const statusMessage = getListingStatusMessageContent(
     listing.status,
     listing.applicationDueDate,
-    isFeatureFlagOn(jurisdiction, "enableMarketingStatus"),
+    enableMarketingStatus,
     listing.marketingType,
     listing.marketingSeason,
     listing.marketingDate,
@@ -74,12 +73,15 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
   const content = getAvailabilityContent(listing.reviewOrderType, listing.status)
   const subheading = getAvailabilitySubheading(listing.waitlistOpenSpots, listing.unitsAvailable)
 
+  const hideAvailabilityDetails =
+    listing.status === ListingsStatusEnum.closed ||
+    (enableMarketingStatus && listing.marketingType === MarketingTypeEnum.comingSoon)
   return (
     <>
       <div className={styles["status-messages"]}>
-        {listing.status === ListingsStatusEnum.closed && (
+        {hideAvailabilityDetails && (
           <div className={"seeds-m-be-content"}>
-            {getListingStatusMessage(listing, jurisdiction)}
+            {getListingStatusMessage(listing, jurisdiction, null, false, true)}
           </div>
         )}
       </div>
@@ -92,11 +94,11 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
 
         <Card.Section divider={"flush"}>
           <Heading priority={3} size={"md"}>
-            {listing.marketingType === MarketingTypeEnum.comingSoon
+            {enableMarketingStatus && listing.marketingType === MarketingTypeEnum.comingSoon
               ? t("listings.underConstruction")
               : getAvailabilityHeading(listing.reviewOrderType)}
           </Heading>
-          {listing.status !== ListingsStatusEnum.closed && (
+          {!hideAvailabilityDetails && (
             <p className={styles["bold-subheader"]}>
               {listing.reviewOrderType === ReviewOrderTypeEnum.waitlist
                 ? t("listings.waitlist.isOpen")

--- a/sites/public/src/components/listing/listing_sections/Availability.tsx
+++ b/sites/public/src/components/listing/listing_sections/Availability.tsx
@@ -4,13 +4,17 @@ import {
   Jurisdiction,
   Listing,
   ListingsStatusEnum,
+  MarketingTypeEnum,
   ReviewOrderTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { t } from "@bloom-housing/ui-components"
-import { getReservedTitle } from "../ListingViewSeedsHelpers"
 import listingStyles from "../ListingViewSeeds.module.scss"
-import { getListingStatusMessageContent, isFeatureFlagOn } from "../../../lib/helpers"
-import { jurisdiction } from "../../../../../../shared-helpers/__tests__/testHelpers"
+import {
+  getListingStatusMessage,
+  getListingStatusMessageContent,
+  isFeatureFlagOn,
+} from "../../../lib/helpers"
+import styles from "./Availability.module.scss"
 
 type AvailabilityProps = {
   listing: Listing
@@ -43,26 +47,42 @@ export const getAvailabilityContent = (reviewOrderType: ReviewOrderTypeEnum) => 
   }
 }
 
-export const Availability = ({ listing }: AvailabilityProps) => {
-  if (listing.status === ListingsStatusEnum.closed && !listing.reservedCommunityTypes) return
+export const getAvailabilityHeading = (reviewOrderType: ReviewOrderTypeEnum) => {
+  switch (reviewOrderType) {
+    case ReviewOrderTypeEnum.lottery:
+      return t("listings.lottery")
+    case ReviewOrderTypeEnum.waitlist:
+      return t("listings.waitlist.open")
+    default:
+      return t("listings.applicationFCFS")
+  }
+}
+
+export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
   const subheading = getAvailabilitySubheading(listing.waitlistOpenSpots, listing.unitsAvailable)
   const content = getAvailabilityContent(listing.reviewOrderType)
   return (
-    <Card className={`${listingStyles["mobile-full-width-card"]}`}>
-      <Card.Section divider="flush">
-        <Heading priority={2} size={"lg"}>
-          {t("t.availability")}
-        </Heading>
-      </Card.Section>
-      {listing.status !== ListingsStatusEnum.closed && (
+    <>
+      {(listing.marketingType === MarketingTypeEnum.comingSoon ||
+        listing.status === ListingsStatusEnum.closed) && (
+        <div className={"seeds-m-be-content"}>{getListingStatusMessage(listing, jurisdiction)}</div>
+      )}
+      <Card className={`${listingStyles["mobile-full-width-card"]}`}>
+        <Card.Section divider="flush">
+          <Heading priority={2} size={"lg"}>
+            {t("t.availability")}
+          </Heading>
+        </Card.Section>
+
         <Card.Section divider={"flush"}>
           <Heading priority={3} size={"md"}>
-            {listing.status === ListingsStatusEnum.active
-              ? listing.reviewOrderType === ReviewOrderTypeEnum.waitlist
-                ? t("listings.waitlist.isOpen")
-                : t("listings.vacantUnitsAvailable")
-              : t("account.closedApplications")}
+            {getAvailabilityHeading(listing.reviewOrderType)}
           </Heading>
+          <p className={styles["bold-subheader"]}>
+            {listing.reviewOrderType === ReviewOrderTypeEnum.waitlist
+              ? t("listings.waitlist.isOpen")
+              : t("listings.vacantUnitsAvailable")}
+          </p>
           <p className={`${listingStyles["thin-heading-sm"]} seeds-m-bs-label`}>
             {getListingStatusMessageContent(
               listing.status,
@@ -77,20 +97,20 @@ export const Availability = ({ listing }: AvailabilityProps) => {
           {content && <p className={"seeds-m-bs-label"}>{content}</p>}
           {subheading && <p className={`seeds-m-bs-label`}>{subheading}</p>}
         </Card.Section>
-      )}
-      {listing.reservedCommunityTypes && (
-        <Card.Section divider="flush">
-          <Heading size={"md"} priority={3}>
-            {getReservedTitle(listing.reservedCommunityTypes)}
-          </Heading>
-          <p className={`${listingStyles["thin-heading-sm"]} seeds-m-bs-label`}>
-            {t(`listings.reservedCommunityTypes.${listing.reservedCommunityTypes.name}`)}
-          </p>
-          {listing.reservedCommunityDescription && (
-            <p className={"seeds-m-bs-label"}>{listing.reservedCommunityDescription}</p>
-          )}
-        </Card.Section>
-      )}
-    </Card>
+        {listing.reservedCommunityTypes && (
+          <Card.Section divider="flush">
+            <Heading size={"md"} priority={3}>
+              {t("listings.reservedCommunityTitleDefault")}
+            </Heading>
+            <p className={styles["bold-subheader"]}>
+              {t(`listings.reservedCommunityTypes.${listing.reservedCommunityTypes.name}`)}
+            </p>
+            {listing.reservedCommunityDescription && (
+              <p className={"seeds-m-bs-label"}>{listing.reservedCommunityDescription}</p>
+            )}
+          </Card.Section>
+        )}
+      </Card>
+    </>
   )
 }

--- a/sites/public/src/components/listing/listing_sections/Availability.tsx
+++ b/sites/public/src/components/listing/listing_sections/Availability.tsx
@@ -76,9 +76,13 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
 
   return (
     <>
-      {listing.status === ListingsStatusEnum.closed && (
-        <div className={"seeds-m-be-content"}>{getListingStatusMessage(listing, jurisdiction)}</div>
-      )}
+      <div className={styles["status-messages"]}>
+        {listing.status === ListingsStatusEnum.closed && (
+          <div className={"seeds-m-be-content"}>
+            {getListingStatusMessage(listing, jurisdiction)}
+          </div>
+        )}
+      </div>
       <Card className={`${listingStyles["mobile-full-width-card"]}`}>
         <Card.Section divider="flush">
           <Heading priority={2} size={"lg"}>

--- a/sites/public/src/components/listing/listing_sections/Availability.tsx
+++ b/sites/public/src/components/listing/listing_sections/Availability.tsx
@@ -36,10 +36,13 @@ export const getAvailabilitySubheading = (
   return null
 }
 
-export const getAvailabilityContent = (reviewOrderType: ReviewOrderTypeEnum) => {
+export const getAvailabilityContent = (
+  reviewOrderType: ReviewOrderTypeEnum,
+  status: ListingsStatusEnum
+) => {
   switch (reviewOrderType) {
     case ReviewOrderTypeEnum.waitlist:
-      return t("listings.waitlist.submitForWaitlist")
+      return status !== ListingsStatusEnum.closed ? t("listings.waitlist.submitForWaitlist") : null
     case ReviewOrderTypeEnum.firstComeFirstServe:
       return t("listings.eligibleApplicants.FCFS")
     default:
@@ -52,19 +55,28 @@ export const getAvailabilityHeading = (reviewOrderType: ReviewOrderTypeEnum) => 
     case ReviewOrderTypeEnum.lottery:
       return t("listings.lottery")
     case ReviewOrderTypeEnum.waitlist:
-      return t("listings.waitlist.open")
+      return t("listings.waitlist.label")
     default:
       return t("listings.applicationFCFS")
   }
 }
 
 export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
+  const statusMessage = getListingStatusMessageContent(
+    listing.status,
+    listing.applicationDueDate,
+    isFeatureFlagOn(jurisdiction, "enableMarketingStatus"),
+    listing.marketingType,
+    listing.marketingSeason,
+    listing.marketingDate,
+    false
+  )
+  const content = getAvailabilityContent(listing.reviewOrderType, listing.status)
   const subheading = getAvailabilitySubheading(listing.waitlistOpenSpots, listing.unitsAvailable)
-  const content = getAvailabilityContent(listing.reviewOrderType)
+
   return (
     <>
-      {(listing.marketingType === MarketingTypeEnum.comingSoon ||
-        listing.status === ListingsStatusEnum.closed) && (
+      {listing.status === ListingsStatusEnum.closed && (
         <div className={"seeds-m-be-content"}>{getListingStatusMessage(listing, jurisdiction)}</div>
       )}
       <Card className={`${listingStyles["mobile-full-width-card"]}`}>
@@ -76,24 +88,22 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
 
         <Card.Section divider={"flush"}>
           <Heading priority={3} size={"md"}>
-            {getAvailabilityHeading(listing.reviewOrderType)}
+            {listing.marketingType === MarketingTypeEnum.comingSoon
+              ? t("listings.underConstruction")
+              : getAvailabilityHeading(listing.reviewOrderType)}
           </Heading>
-          <p className={styles["bold-subheader"]}>
-            {listing.reviewOrderType === ReviewOrderTypeEnum.waitlist
-              ? t("listings.waitlist.isOpen")
-              : t("listings.vacantUnitsAvailable")}
-          </p>
-          <p className={`${listingStyles["thin-heading-sm"]} seeds-m-bs-label`}>
-            {getListingStatusMessageContent(
-              listing.status,
-              listing.applicationDueDate,
-              isFeatureFlagOn(jurisdiction, "enableMarketingStatus"),
-              listing.marketingType,
-              listing.marketingSeason,
-              listing.marketingDate,
-              false
-            )}
-          </p>
+          {listing.status !== ListingsStatusEnum.closed && (
+            <p className={styles["bold-subheader"]}>
+              {listing.reviewOrderType === ReviewOrderTypeEnum.waitlist
+                ? t("listings.waitlist.isOpen")
+                : t("listings.vacantUnitsAvailable")}
+            </p>
+          )}
+          {statusMessage && (
+            <p className={`${listingStyles["thin-heading-sm"]} seeds-m-bs-label`}>
+              {statusMessage}
+            </p>
+          )}
           {content && <p className={"seeds-m-bs-label"}>{content}</p>}
           {subheading && <p className={`seeds-m-bs-label`}>{subheading}</p>}
         </Card.Section>

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import {
+  Jurisdiction,
   Listing,
   MarketingTypeEnum,
   ReviewOrderTypeEnum,
@@ -12,15 +13,14 @@ import {
   imageUrlFromListing,
   oneLineAddress,
 } from "@bloom-housing/shared-helpers"
-import { DueDate } from "./DueDate"
 import { Availability } from "./Availability"
 import listingStyles from "../ListingViewSeeds.module.scss"
 import styles from "./MainDetails.module.scss"
-import { getApplicationSeason } from "../../../lib/helpers"
 
 type MainDetailsProps = {
   dueDateContent: string[]
   listing: Listing
+  jurisdiction: Jurisdiction
 }
 
 type ListingTag = {
@@ -61,7 +61,7 @@ export const getListingTags = (listing: Listing, hideReviewTags?: boolean): List
   return listingTags
 }
 
-export const MainDetails = ({ dueDateContent, listing }: MainDetailsProps) => {
+export const MainDetails = ({ jurisdiction, listing }: MainDetailsProps) => {
   if (!listing) return
   const googleMapsHref =
     "https://www.google.com/maps/place/" + oneLineAddress(listing.listingsBuildingAddress)
@@ -119,23 +119,9 @@ export const MainDetails = ({ dueDateContent, listing }: MainDetailsProps) => {
         )}
 
         <p className={"seeds-m-bs-3"}>{listing.developer}</p>
-        <div className={`${listingStyles["hide-desktop"]} seeds-m-b-3`}>
-          {listing.marketingType === MarketingTypeEnum.comingSoon ? (
-            <DueDate content={[getApplicationSeason(listing)]} />
-          ) : (
-            <DueDate content={dueDateContent} />
-          )}
-        </div>
       </div>
-      <div className={listingStyles["hide-desktop"]}>
-        <Availability
-          reservedCommunityDescription={listing.reservedCommunityDescription}
-          reservedCommunityType={listing.reservedCommunityTypes}
-          reviewOrder={listing.reviewOrderType}
-          status={listing.status}
-          unitsAvailable={listing.unitsAvailable}
-          waitlistOpenSpots={listing.waitlistOpenSpots}
-        />
+      <div className={`${listingStyles["hide-desktop"]} seeds-m-bs-content`}>
+        <Availability listing={listing} jurisdiction={jurisdiction} />
       </div>
     </div>
   )

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -65,7 +65,7 @@ export const MainDetails = ({ dueDateContent, listing }: MainDetailsProps) => {
   if (!listing) return
   const googleMapsHref =
     "https://www.google.com/maps/place/" + oneLineAddress(listing.listingsBuildingAddress)
-  const listingTags = getListingTags(listing)
+  const listingTags = getListingTags(listing, true)
   return (
     <div>
       <ImageCard

--- a/sites/public/src/lib/helpers.module.scss
+++ b/sites/public/src/lib/helpers.module.scss
@@ -6,47 +6,47 @@
   color: var(--seeds-color-on-surface);
 
   &[data-variant="primary"] {
-    background-color: var(--seeds-color-primary-lighter);
-    --message-border: var(--seeds-border-2) solid var(--seeds-color-primary-light);
+    background-color: var(--seeds-color-blue-100);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-blue-300);
     .primary-color-icon {
-      color: var(--seeds-color-primary-dark);
+      color: var(--seeds-color-blue-700);
     }
     .date-review-order {
-      color: var(--seeds-color-primary-dark);
+      color: var(--seeds-color-blue-700);
     }
   }
 
   &[data-variant="secondary"] {
-    background-color: var(--seeds-color-secondary-lighter);
-    --message-border: var(--seeds-border-2) solid var(--seeds-color-secondary-light);
+    background-color: var(--seeds-color-gray-100);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-gray-400);
 
     .primary-color-icon {
-      color: var(--seeds-color-secondary-darker);
+      color: var(--seeds-color-gray-900);
     }
     .date-review-order {
-      color: var(--seeds-color-secondary-darker);
+      color: var(--seeds-color-gray-900);
     }
   }
 
   &[data-variant="warn"] {
-    background-color: var(--seeds-color-warn-lighter);
-    --message-border: var(--seeds-border-2) solid var(--seeds-color-warn-light);
+    background-color: var(--seeds-color-yellow-100);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-yellow-300);
     .primary-color-icon {
-      color: var(--seeds-color-warn-darker);
+      color: var(--seeds-color-yellow-900);
     }
     .date-review-order {
-      color: var(--seeds-color-warn-darker);
+      color: var(--seeds-color-yellow-900);
     }
   }
 
-  &[data-variant="alert"] {
-    background-color: var(--seeds-color-alert-lighter);
-    --message-border: var(--seeds-border-2) solid var(--seeds-color-alert-light);
+  &[data-variant="secondary-inverse"] {
+    background-color: var(--seeds-color-black);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-black);
     .primary-color-icon {
-      color: var(--seeds-color-alert-darker);
+      color: var(--seeds-color-white);
     }
     .date-review-order {
-      color: var(--seeds-color-alert-darker);
+      color: var(--seeds-color-white);
     }
   }
 

--- a/sites/public/src/lib/helpers.module.scss
+++ b/sites/public/src/lib/helpers.module.scss
@@ -6,36 +6,36 @@
   color: var(--seeds-color-on-surface);
 
   &[data-variant="primary"] {
-    background-color: var(--seeds-color-blue-100);
-    --message-border: var(--seeds-border-2) solid var(--seeds-color-blue-300);
+    background-color: var(--seeds-color-primary-lighter);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-primary-light);
     .primary-color-icon {
-      color: var(--seeds-color-blue-700);
+      color: var(--seeds-color-primary-dark);
     }
     .date-review-order {
-      color: var(--seeds-color-blue-700);
+      color: var(--seeds-color-primary-dark);
     }
   }
 
   &[data-variant="secondary"] {
-    background-color: var(--seeds-color-gray-100);
-    --message-border: var(--seeds-border-2) solid var(--seeds-color-gray-400);
+    background-color: var(--seeds-color-secondary-lighter);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-secondary-light);
 
     .primary-color-icon {
-      color: var(--seeds-color-gray-900);
+      color: var(--seeds-color-secondary-darker);
     }
     .date-review-order {
-      color: var(--seeds-color-gray-900);
+      color: var(--seeds-color-secondary-darker);
     }
   }
 
   &[data-variant="warn"] {
-    background-color: var(--seeds-color-yellow-100);
-    --message-border: var(--seeds-border-2) solid var(--seeds-color-yellow-300);
+    background-color: var(--seeds-color-warn-lighter);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-warn-light);
     .primary-color-icon {
-      color: var(--seeds-color-yellow-900);
+      color: var(--seeds-color-warn-darker);
     }
     .date-review-order {
-      color: var(--seeds-color-yellow-900);
+      color: var(--seeds-color-warn-darker);
     }
   }
 

--- a/sites/public/src/lib/helpers.module.scss
+++ b/sites/public/src/lib/helpers.module.scss
@@ -1,0 +1,61 @@
+.status-bar {
+  --common-message-link-gap: 0;
+  --common-message-font: var(--seeds-font-alt-sans);
+  --message-max-width: 100%;
+  --message-border-radius: var(--seeds-rounded);
+  color: var(--seeds-color-on-surface);
+
+  &[data-variant="primary"] {
+    background-color: var(--seeds-color-primary-lighter);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-primary-light);
+    .primary-color-icon {
+      color: var(--seeds-color-primary-dark);
+    }
+    .date-review-order {
+      color: var(--seeds-color-primary-dark);
+    }
+  }
+
+  &[data-variant="secondary"] {
+    background-color: var(--seeds-color-secondary-lighter);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-secondary-light);
+
+    .primary-color-icon {
+      color: var(--seeds-color-secondary-darker);
+    }
+    .date-review-order {
+      color: var(--seeds-color-secondary-darker);
+    }
+  }
+
+  &[data-variant="warn"] {
+    background-color: var(--seeds-color-warn-lighter);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-warn-light);
+    .primary-color-icon {
+      color: var(--seeds-color-warn-darker);
+    }
+    .date-review-order {
+      color: var(--seeds-color-warn-darker);
+    }
+  }
+
+  &[data-variant="alert"] {
+    background-color: var(--seeds-color-alert-lighter);
+    --message-border: var(--seeds-border-2) solid var(--seeds-color-alert-light);
+    .primary-color-icon {
+      color: var(--seeds-color-alert-darker);
+    }
+    .date-review-order {
+      color: var(--seeds-color-alert-darker);
+    }
+  }
+
+  .date-review-order {
+    font-weight: var(--seeds-font-weight-bold);
+  }
+
+  .due-date-content {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -144,7 +144,7 @@ export const getStatusPrefix = (
     listing.status === ListingsStatusEnum.closed ||
     (listing.applicationDueDate && dayjs() > dayjs(listing.applicationDueDate))
   ) {
-    return { label: t("listings.applicationsClosed"), variant: "alert" }
+    return { label: t("listings.applicationsClosed"), variant: "secondary-inverse" }
   }
   switch (listing.reviewOrderType) {
     case ReviewOrderTypeEnum.lottery:
@@ -197,13 +197,15 @@ export const getListingStatusMessageContent = (
 export const getListingStatusMessage = (
   listing: Listing,
   jurisdiction: Jurisdiction,
+  content?: React.ReactNode,
   hideTime?: boolean
 ) => {
   if (!listing) return
 
-  listing.applicationDueDate
   const enableMarketingStatus = isFeatureFlagOn(jurisdiction, "enableMarketingStatus")
   const prefix = getStatusPrefix(listing, enableMarketingStatus)
+
+  console.log({ prefix })
 
   return (
     <Message
@@ -215,20 +217,24 @@ export const getListingStatusMessage = (
       }
       variant={prefix.variant}
     >
-      <div className={styles["due-date-content"]}>
-        <div className={styles["date-review-order"]}>{prefix.label}</div>
-        <div>
-          {getListingStatusMessageContent(
-            listing.status,
-            listing.applicationDueDate,
-            enableMarketingStatus,
-            listing.marketingType,
-            listing.marketingSeason,
-            listing.marketingDate,
-            hideTime
-          )}
+      {content ? (
+        content
+      ) : (
+        <div className={styles["due-date-content"]}>
+          <div className={styles["date-review-order"]}>{prefix.label}</div>
+          <div>
+            {getListingStatusMessageContent(
+              listing.status,
+              listing.applicationDueDate,
+              enableMarketingStatus,
+              listing.marketingType,
+              listing.marketingSeason,
+              listing.marketingDate,
+              hideTime
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </Message>
   )
 }

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -205,8 +205,6 @@ export const getListingStatusMessage = (
   const enableMarketingStatus = isFeatureFlagOn(jurisdiction, "enableMarketingStatus")
   const prefix = getStatusPrefix(listing, enableMarketingStatus)
 
-  console.log({ prefix })
-
   return (
     <Message
       className={styles["status-bar"]}

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -138,14 +138,15 @@ export const getStatusPrefix = (
   listing: Listing,
   enableMarketingStatus: boolean
 ): { label: string; variant: CommonMessageVariant } => {
-  if (enableMarketingStatus && listing.marketingType === MarketingTypeEnum.comingSoon)
-    return { label: t("listings.underConstruction"), variant: "warn" }
   if (
     listing.status === ListingsStatusEnum.closed ||
     (listing.applicationDueDate && dayjs() > dayjs(listing.applicationDueDate))
   ) {
     return { label: t("listings.applicationsClosed"), variant: "secondary-inverse" }
   }
+  if (enableMarketingStatus && listing.marketingType === MarketingTypeEnum.comingSoon)
+    return { label: t("listings.underConstruction"), variant: "warn" }
+
   switch (listing.reviewOrderType) {
     case ReviewOrderTypeEnum.lottery:
       return { label: t("listings.lottery"), variant: "primary" }
@@ -198,7 +199,8 @@ export const getListingStatusMessage = (
   listing: Listing,
   jurisdiction: Jurisdiction,
   content?: React.ReactNode,
-  hideTime?: boolean
+  hideTime?: boolean,
+  hideDate?: boolean
 ) => {
   if (!listing) return
 
@@ -220,17 +222,19 @@ export const getListingStatusMessage = (
       ) : (
         <div className={styles["due-date-content"]}>
           <div className={styles["date-review-order"]}>{prefix.label}</div>
-          <div>
-            {getListingStatusMessageContent(
-              listing.status,
-              listing.applicationDueDate,
-              enableMarketingStatus,
-              listing.marketingType,
-              listing.marketingSeason,
-              listing.marketingDate,
-              hideTime
-            )}
-          </div>
+          {!hideDate && (
+            <div>
+              {getListingStatusMessageContent(
+                listing.status,
+                listing.applicationDueDate,
+                enableMarketingStatus,
+                listing.marketingType,
+                listing.marketingSeason,
+                listing.marketingDate,
+                hideTime
+              )}
+            </div>
+          )}
         </div>
       )}
     </Message>

--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -1,19 +1,24 @@
 import React from "react"
-import { Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { fetchClosedListings, fetchOpenListings } from "../lib/hooks"
+import { Jurisdiction, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { fetchClosedListings, fetchJurisdictionByName, fetchOpenListings } from "../lib/hooks"
 import { ListingBrowse } from "../components/browse/ListingBrowse"
 import { ListingBrowseDeprecated } from "../components/browse/ListingBrowseDeprecated"
 
 export interface ListingsProps {
   openListings: Listing[]
   closedListings: Listing[]
+  jurisdiction: Jurisdiction
 }
 
 export default function ListingsPage(props: ListingsProps) {
   return (
     <>
       {process.env.showNewSeedsDesigns ? (
-        <ListingBrowse openListings={props.openListings} closedListings={props.closedListings} />
+        <ListingBrowse
+          openListings={props.openListings}
+          closedListings={props.closedListings}
+          jurisdiction={props.jurisdiction}
+        />
       ) : (
         <ListingBrowseDeprecated
           openListings={props.openListings}
@@ -28,8 +33,13 @@ export default function ListingsPage(props: ListingsProps) {
 export async function getServerSideProps(context: { req: any }) {
   const openListings = fetchOpenListings(context.req)
   const closedListings = fetchClosedListings(context.req)
+  const jurisdiction = fetchJurisdictionByName(context.req)
 
   return {
-    props: { openListings: await openListings, closedListings: await closedListings },
+    props: {
+      openListings: await openListings,
+      closedListings: await closedListings,
+      jurisdiction: await jurisdiction,
+    },
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,10 +2021,10 @@
     tailwindcss-rtl "^0.9.0"
     typesafe-actions "^5.1.0"
 
-"@bloom-housing/ui-seeds@1.19.0":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-seeds/-/ui-seeds-1.19.0.tgz#c5e41f6fa99ed33c933efc0e8b6163fa16a35435"
-  integrity sha512-uNPR6ywmSiFdypRcMHfI+jO/Zy7qeSG1cofkP2tzVFi2dF3sMza5G6IXUZ0fMAFq4hzIvKauuI8b+ikXTmQgIQ==
+"@bloom-housing/ui-seeds@1.19.1":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-seeds/-/ui-seeds-1.19.1.tgz#7ebb17f1c07c5e59f126fafd0442479be0206d72"
+  integrity sha512-+cPy67q/UaGpAi71Uf4i38wDfT3U2wTXgqk5wCyFftaDlbw38kVd0m6dS0tVt+eMLZlmWSX2s3RWPcHkT/Ahjw==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.3.0"
     "@fortawesome/react-fontawesome" "^0.2.0"


### PR DESCRIPTION
This PR addresses #4710

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

We ended up with some inconsistencies in listing statuses between the browse and detail pages in Seeds, and the introduction of the under construction status complicated things. This PR makes two updates, to:
1. The colors of the listing type messages on the browse page
2. The availability section at the top of the right rail on the detail page

This PR also temporarily updates just the Seeds browse page to also show closed listings until we have tabs, so that we can test that state.

## How Can This Be Tested/Reviewed?

You can compare [this deploy preview](https://deploy-preview-4689--bloom-public-seeds.netlify.app/listings) to the [core Seeds environment](https://bloom-public-seeds.netlify.app/listings).

For the browse page:
* The `Lottery` and `FCFS` review types are still primary, the `Open Waitlist` is now inverse secondary, `Under construction` is warn, and `Closed` is black. (Design here in terms of colors, it's the first set of options).
* The text is now on two lines instead of one.

For the detail page:
[Here are screenshots of every possible state](https://www.figma.com/board/pREQaXV5UnMBCaMr2WXFR8/Confirmed-Availability?node-id=0-1&p=f&t=lIq6xE4H9LLxSAXq-0), which has been approved by design.
* The availability section at the top of the right rail has a new design, but the content is the same - just reordered.
* The reserved community type, if it exists, was moved to be second instead of first.
* The only detail pages that should still have a status at the top are if the listing is closed or under construction.
* The review order type tags were removed from the detail view (`Available Units` or `Open Waitlist`) because that data shows up in this Availability section.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
