### PR TITLE
chore: upgrade markdown-to-jsx

### DIFF
--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -41,7 +41,7 @@
     "dayjs": "^1.10.7",
     "dd-trace": "^5.30.0",
     "dotenv": "^8.2.0",
-    "markdown-to-jsx": "^6.11.4",
+    "markdown-to-jsx": "^7.7.4",
     "nanoid": "^3.1.12",
     "next": "^13.2.4",
     "qs": "^6.10.1",

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -42,7 +42,7 @@
     "dayjs": "^1.10.7",
     "dd-trace": "^5.30.0",
     "dotenv": "^8.2.0",
-    "markdown-to-jsx": "^6.11.4",
+    "markdown-to-jsx": "^7.7.4",
     "next": "^13.2.4",
     "qs": "^6.10.1",
     "react": "18.2.0",

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -64,7 +64,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "14.0.0",
-    "@types/markdown-to-jsx": "^6.11.2",
+    "@types/markdown-to-jsx": "^7.0.1",
     "@types/node": "^12.12.67",
     "@types/react": "^18.0.33",
     "babel-loader": "^9.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3829,6 +3829,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/markdown-to-jsx@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@types/markdown-to-jsx/-/markdown-to-jsx-7.0.1.tgz#7a7e1981323ff2fe7250b02897ced466e47a72b1"
+  integrity sha512-m9WVgoC+xggBNuaqHj/ONk6erCr2S+ok18/OdDovlqD3UCHyRA66o/y5QvTrQhm2XEeDwz/zA89jyrEykSm2wg==
+  dependencies:
+    markdown-to-jsx "*"
+
 "@types/mdx@^2.0.3":
   version "2.0.4"
   resolved "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.4.tgz"
@@ -10188,6 +10195,11 @@ mapbox-gl@^2.3.0:
     tinyqueue "^2.0.3"
     vt-pbf "^3.1.3"
 
+markdown-to-jsx@*, markdown-to-jsx@^7.7.4:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.7.4.tgz#507d17c15af72ddf970fca84a95f0243244fcfa9"
+  integrity sha512-1bSfXyBKi+EYS3YY+e0Csuxf8oZ3decdfhOav/Z7Wrk89tjudyL5FOmwZQUoy0/qVXGUl+6Q3s2SWtpDEWITfQ==
+
 markdown-to-jsx@7.1.8:
   version "7.1.8"
   resolved "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.8.tgz"
@@ -10200,11 +10212,6 @@ markdown-to-jsx@^6.11.4:
   dependencies:
     prop-types "^15.6.2"
     unquote "^1.1.0"
-
-markdown-to-jsx@^7.7.4:
-  version "7.7.4"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.7.4.tgz#507d17c15af72ddf970fca84a95f0243244fcfa9"
-  integrity sha512-1bSfXyBKi+EYS3YY+e0Csuxf8oZ3decdfhOav/Z7Wrk89tjudyL5FOmwZQUoy0/qVXGUl+6Q3s2SWtpDEWITfQ==
 
 memoize-one@^5.1.1:
   version "5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10201,6 +10201,11 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
+markdown-to-jsx@^7.7.4:
+  version "7.7.4"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.7.4.tgz#507d17c15af72ddf970fca84a95f0243244fcfa9"
+  integrity sha512-1bSfXyBKi+EYS3YY+e0Csuxf8oZ3decdfhOav/Z7Wrk89tjudyL5FOmwZQUoy0/qVXGUl+6Q3s2SWtpDEWITfQ==
+
 memoize-one@^5.1.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz"


### PR DESCRIPTION
Related to https://github.com/metrotranscom/doorway/pull/1107 and https://github.com/metrotranscom/doorway/pull/1126 and https://github.com/metrotranscom/doorway/issues/1156

## Description

[These](https://github.com/quantizor/markdown-to-jsx/releases/tag/7.0.0) are the breaking release notes, looks like just Typescript. Our current version was released in 2020.

## How Can This Be Tested/Reviewed?

We use markdown-to-jsx to display markdown content. Two example usages to check out are (1) the what to expect page (the first page of an application), and (2) the disclaimer page.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs (high level issue is [here](https://github.com/metrotranscom/doorway/issues/1156))
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
