### PR TITLE
chore: upgrade axios-cookiejar-support

### DIFF
--- a/shared-helpers/package.json
+++ b/shared-helpers/package.json
@@ -19,7 +19,7 @@
     "@bloom-housing/ui-components": "12.4.0",
     "@bloom-housing/ui-seeds": "1.19.0",
     "@heroicons/react": "^2.1.1",
-    "axios-cookiejar-support": "4.0.6",
+    "axios-cookiejar-support": "^5.0.5",
     "tough-cookie": "4.1.3"
   },
   "devDependencies": {

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -36,7 +36,7 @@
     "@mapbox/mapbox-sdk": "^0.13.0",
     "ag-grid-community": "^26.0.0",
     "axios": "^0.28.0",
-    "axios-cookiejar-support": "4.0.6",
+    "axios-cookiejar-support": "^5.0.5",
     "clone-deep": "^4.0.1",
     "dayjs": "^1.10.7",
     "dd-trace": "^5.30.0",

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -37,7 +37,7 @@
     "@sentry/nextjs": "^7.61.0",
     "autoprefixer": "^10.3.4",
     "axios": "^0.28.0",
-    "axios-cookiejar-support": "4.0.6",
+    "axios-cookiejar-support": "^5.0.5",
     "clone-deep": "^4.0.1",
     "dayjs": "^1.10.7",
     "dd-trace": "^5.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,12 +4355,17 @@ ag-grid-react@^26.0.0:
   dependencies:
     prop-types "^15.6.2"
 
-agent-base@6, agent-base@^6.0.2:
+agent-base@6:
   version "6.0.2"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
   integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
+
+agent-base@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.3.tgz#29435eb821bc4194633a5b89e5bc4703bafc25a1"
+  integrity sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -4802,12 +4807,12 @@ axe-core@^4.4.1:
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
 
-axios-cookiejar-support@4.0.6:
-  version "4.0.6"
-  resolved "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-4.0.6.tgz"
-  integrity sha512-lWDhgM6bc2xYAsHkXEhceLpTu9ytAeIz1VSuL5FoUgGx2lqcMNbNxTD9Hm4x5c8JF5Me0HfNrb06fhEGMC30mQ==
+axios-cookiejar-support@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/axios-cookiejar-support/-/axios-cookiejar-support-5.0.5.tgz#6030e17b438a64e3967a5ca190ee4202481c0ecf"
+  integrity sha512-jJG+p7JnOYxkVrYkCDKBrLqUmcpwHZTNQrEcIEKr5qe7YVTyPAD9nCsi1cO5LDmQpQApfS430czO+oceI3g/3g==
   dependencies:
-    http-cookie-agent "^5.0.2"
+    http-cookie-agent "^6.0.8"
 
 axios@0.21.2:
   version "0.21.2"
@@ -8130,12 +8135,12 @@ http-cache-semantics@^4.0.0:
   resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
-http-cookie-agent@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-5.0.2.tgz"
-  integrity sha512-BiBmZyIMGl5mLKmY7KH2uCVlcNUl1jexjdtWXFCUF4DFOrNZg1c5iPPTzWDzU7Ngfb6fB03DPpJQ80KQWmycsg==
+http-cookie-agent@^6.0.8:
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/http-cookie-agent/-/http-cookie-agent-6.0.8.tgz#f2635638f4172c7de0c482396ea7313e9731a62b"
+  integrity sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==
   dependencies:
-    agent-base "^6.0.2"
+    agent-base "^7.1.3"
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Related to https://github.com/metrotranscom/doorway/pull/1135 and https://github.com/metrotranscom/doorway/issues/1156

## Description

This package adds tough-cookie support to axios.

The [breaking change in version 5](https://github.com/3846masa/axios-cookiejar-support/releases/tag/v5.0.0) was to remove support for node 14/16, which does not affect us.

## How Can This Be Tested/Reviewed?

We use axios to fetch listings data on the public and partners sites, and on the partners site to upload an image. Ensure these flows work.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs (high level issue is [here](https://github.com/metrotranscom/doorway/issues/1156))
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
