### PR TITLE
fix: add more lakeview seeded data

### DIFF
--- a/api/prisma/seed-helpers/listing-data/elm-village.ts
+++ b/api/prisma/seed-helpers/listing-data/elm-village.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationMethodsTypeEnum,
+  ListingEventsTypeEnum,
   ListingsStatusEnum,
   ReviewOrderTypeEnum,
 } from '@prisma/client';
@@ -9,6 +10,16 @@ import { featuresAndUtilites } from '../listing-factory';
 export const elmVillage = {
   additionalApplicationSubmissionNotes: null,
   digitalApplication: true,
+  listingEvents: {
+    create: [
+      {
+        type: ListingEventsTypeEnum.publicLottery,
+        startDate: dayjs(new Date()).add(7, 'months').toDate(),
+        startTime: dayjs(new Date()).add(7, 'months').add(1, 'hour').toDate(),
+        endTime: dayjs(new Date()).add(7, 'months').add(2, 'hour').toDate(),
+      },
+    ],
+  },
   commonDigitalApplication: true,
   paperApplication: false,
   referralOpportunity: false,

--- a/api/prisma/seed-helpers/listing-data/hollywood-hills-heights.ts
+++ b/api/prisma/seed-helpers/listing-data/hollywood-hills-heights.ts
@@ -42,7 +42,7 @@ export const hollywoodHillsHeights = {
   leasingAgentEmail: 'bloom@exygy.com',
   leasingAgentName: 'Bloom Bloomington',
   leasingAgentOfficeHours: null,
-  leasingAgentPhone: '(555) 555-5555',
+  leasingAgentPhone: '(651) 555-5555',
   leasingAgentTitle: null,
   name: 'Hollywood Hills Heights',
   postmarkedApplicationsReceivedByDate: null,

--- a/api/prisma/seed-helpers/listing-data/lakeview-villa.ts
+++ b/api/prisma/seed-helpers/listing-data/lakeview-villa.ts
@@ -2,6 +2,7 @@ import {
   ListingsStatusEnum,
   ReviewOrderTypeEnum,
   Prisma,
+  RegionEnum,
 } from '@prisma/client';
 import dayjs from 'dayjs';
 import { yellowstoneAddress } from '../address-factory';
@@ -20,7 +21,7 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
   householdSizeMax: 0,
   householdSizeMin: 0,
   neighborhood: 'Greater Downtown area',
-  region: 'Greater_Downtown',
+  region: RegionEnum.Greater_Downtown,
   petPolicy: null,
   smokingPolicy: null,
   unitAmenities: null,

--- a/api/prisma/seed-helpers/listing-data/lakeview-villa.ts
+++ b/api/prisma/seed-helpers/listing-data/lakeview-villa.ts
@@ -47,7 +47,7 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
   leasingAgentEmail: 'bloom@exygy.com',
   leasingAgentName: 'Bloom Bloomington',
   leasingAgentOfficeHours: null,
-  leasingAgentPhone: '(555) 555-5555',
+  leasingAgentPhone: '(313) 555-5555',
   leasingAgentTitle: null,
   name: 'Lakeview Villa',
   postmarkedApplicationsReceivedByDate: null,

--- a/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
+++ b/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
@@ -4,9 +4,9 @@ import {
   Prisma,
 } from '@prisma/client';
 import dayjs from 'dayjs';
-import { yellowstoneAddress } from '../address-factory';
+import { glacierAddress } from '../address-factory';
 
-export const lakeviewVilla: Prisma.ListingsCreateInput = {
+export const sunshineFlats: Prisma.ListingsCreateInput = {
   additionalApplicationSubmissionNotes: null,
   digitalApplication: true,
   commonDigitalApplication: true,
@@ -15,19 +15,19 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
   assets: [],
   accessibility: null,
   amenities: null,
-  buildingTotalUnits: 0,
-  developer: 'Bloom',
-  householdSizeMax: 0,
-  householdSizeMin: 0,
-  neighborhood: 'Greater Downtown area',
-  region: 'Greater_Downtown',
+  buildingTotalUnits: 12,
+  developer: 'Sunny side realtors',
+  householdSizeMax: 4,
+  householdSizeMin: 1,
+  neighborhood: 'West End area',
+  region: 'Eastside',
   petPolicy: null,
   smokingPolicy: null,
   unitAmenities: null,
   servicesOffered: null,
   yearBuilt: null,
   applicationDueDate: null,
-  applicationOpenDate: dayjs(new Date()).subtract(70, 'days').toDate(),
+  applicationOpenDate: dayjs(new Date()).subtract(2, 'days').toDate(),
   applicationFee: null,
   applicationOrganization: null,
   applicationPickUpAddressOfficeHours: null,
@@ -49,7 +49,7 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
   leasingAgentOfficeHours: null,
   leasingAgentPhone: '(555) 555-5555',
   leasingAgentTitle: null,
-  name: 'Lakeview Villa',
+  name: 'Sunshine Flats',
   postmarkedApplicationsReceivedByDate: null,
   programRules: null,
   rentalAssistance:
@@ -62,7 +62,7 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
   whatToExpect:
     'Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents.',
   status: ListingsStatusEnum.active,
-  reviewOrderType: ReviewOrderTypeEnum.waitlist,
+  reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
   unitsAvailable: 0,
   displayWaitlistSize: false,
   reservedCommunityDescription: null,
@@ -74,7 +74,7 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
   contentUpdatedAt: new Date(),
   publishedAt: new Date(),
   listingsBuildingAddress: {
-    create: yellowstoneAddress,
+    create: glacierAddress,
   },
   listingsApplicationPickUpAddress: undefined,
   listingsLeasingAgentAddress: undefined,
@@ -87,19 +87,16 @@ export const lakeviewVilla: Prisma.ListingsCreateInput = {
       assets: {
         create: {
           label: 'cloudinaryBuilding',
-          fileId: 'dev/unnamed_fkxrj2',
+          fileId: 'dev/sunshine-flats_naated',
         },
       },
     },
   },
   listingNeighborhoodAmenities: {
     create: {
-      groceryStores: 'There are grocery stores',
-      pharmacies: 'There are pharmacies',
-      healthCareResources: 'There is health care',
-      parksAndCommunityCenters: 'There are parks',
-      schools: 'There are schools',
-      publicTransportation: 'There is public transportation',
+      groceryStores: 'Flower fresh',
+      schools: 'lakeview middle school',
+      publicTransportation: 'A train, Y express bus',
     },
   },
 };

--- a/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
+++ b/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
@@ -47,7 +47,7 @@ export const sunshineFlats: Prisma.ListingsCreateInput = {
   leasingAgentEmail: 'bloom@exygy.com',
   leasingAgentName: 'Bloom Bloomington',
   leasingAgentOfficeHours: null,
-  leasingAgentPhone: '(555) 555-5555',
+  leasingAgentPhone: '(313) 555-5555',
   leasingAgentTitle: null,
   name: 'Sunshine Flats',
   postmarkedApplicationsReceivedByDate: null,

--- a/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
+++ b/api/prisma/seed-helpers/listing-data/sunshine-flats.ts
@@ -95,7 +95,7 @@ export const sunshineFlats: Prisma.ListingsCreateInput = {
   listingNeighborhoodAmenities: {
     create: {
       groceryStores: 'Flower fresh',
-      schools: 'lakeview middle school',
+      schools: 'Lakeview middle school',
       publicTransportation: 'A train, Y express bus',
     },
   },

--- a/api/prisma/seed-helpers/reserved-community-type-factory.ts
+++ b/api/prisma/seed-helpers/reserved-community-type-factory.ts
@@ -4,9 +4,15 @@ import { randomInt } from 'crypto';
 const reservedCommunityTypeOptions = [
   'specialNeeds',
   'senior',
+  'senior55',
   'senior62',
+  'specialNeeds',
   'developmentalDisability',
+  'tay',
   'veteran',
+  'schoolEmployee',
+  'farmworkerHousing',
+  'housingVoucher',
 ];
 
 export const reservedCommunityTypeFactory = (
@@ -38,7 +44,7 @@ export const reservedCommunityTypeFactoryAll = async (
 
 export const reservedCommunityTypeFactoryGet = async (
   prismaClient: PrismaClient,
-  jurisdictionId: string,
+  jurisdictionId?: string,
   name?: string,
 ): Promise<ReservedCommunityTypes> => {
   // if name is not given pick one randomly from the above list
@@ -53,9 +59,11 @@ export const reservedCommunityTypeFactoryGet = async (
         name: {
           equals: chosenName,
         },
-        jurisdictionId: {
-          equals: jurisdictionId,
-        },
+        jurisdictionId: jurisdictionId
+          ? {
+              equals: jurisdictionId,
+            }
+          : undefined,
       },
     });
 
@@ -73,12 +81,11 @@ export const reservedCommunityTypesFindOrCreate = async (
 ): Promise<ReservedCommunityTypes> => {
   const reservedCommunityType = await reservedCommunityTypeFactoryGet(
     prismaClient,
-    jurisdictionId,
   );
   if (reservedCommunityType) {
-    return await reservedCommunityTypeFactoryGet(prismaClient, jurisdictionId);
+    return reservedCommunityType;
   }
 
   await reservedCommunityTypeFactoryAll(jurisdictionId, prismaClient);
-  return await reservedCommunityTypeFactoryGet(prismaClient, jurisdictionId);
+  return await reservedCommunityTypeFactoryGet(prismaClient);
 };

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -1,16 +1,13 @@
 import {
   ApplicationSubmissionTypeEnum,
   LanguagesEnum,
-  ListingsStatusEnum,
   MonthlyRentDeterminationTypeEnum,
   MultiselectQuestions,
   MultiselectQuestionsApplicationSectionEnum,
   Prisma,
   PrismaClient,
-  ReviewOrderTypeEnum,
   UserRoleEnum,
 } from '@prisma/client';
-import dayjs from 'dayjs';
 import { jurisdictionFactory } from './seed-helpers/jurisdiction-factory';
 import { listingFactory } from './seed-helpers/listing-factory';
 import { amiChartFactory } from './seed-helpers/ami-chart-factory';
@@ -18,7 +15,6 @@ import { userFactory } from './seed-helpers/user-factory';
 import { unitTypeFactoryAll } from './seed-helpers/unit-type-factory';
 import { unitAccessibilityPriorityTypeFactoryAll } from './seed-helpers/unit-accessibility-priority-type-factory';
 import { multiselectQuestionFactory } from './seed-helpers/multiselect-question-factory';
-import { yellowstoneAddress } from './seed-helpers/address-factory';
 import { applicationFactory } from './seed-helpers/application-factory';
 import { translationFactory } from './seed-helpers/translation-factory';
 import { reservedCommunityTypeFactoryAll } from './seed-helpers/reserved-community-type-factory';
@@ -37,6 +33,8 @@ import { blueSkyApartments } from './seed-helpers/listing-data/blue-sky-apartmen
 import { valleyHeightsSeniorCommunity } from './seed-helpers/listing-data/valley-heights-senior-community';
 import { littleVillageApartments } from './seed-helpers/listing-data/little-village-apartments';
 import { elmVillage } from './seed-helpers/listing-data/elm-village';
+import { lakeviewVilla } from './seed-helpers/listing-data/lakeview-villa';
+import { sunshineFlats } from './seed-helpers/listing-data/sunshine-flats';
 
 export const stagingSeed = async (
   prismaClient: PrismaClient,
@@ -737,102 +735,7 @@ export const stagingSeed = async (
     },
     {
       jurisdictionId: lakeviewJurisdiction.id,
-      listing: {
-        additionalApplicationSubmissionNotes: null,
-        digitalApplication: true,
-        commonDigitalApplication: true,
-        paperApplication: false,
-        referralOpportunity: false,
-        assets: [],
-        accessibility: null,
-        amenities: null,
-        buildingTotalUnits: 0,
-        developer: 'Bloom',
-        householdSizeMax: 0,
-        householdSizeMin: 0,
-        neighborhood: 'Hollywood',
-        petPolicy: null,
-        smokingPolicy: null,
-        unitAmenities: null,
-        servicesOffered: null,
-        yearBuilt: null,
-        applicationDueDate: null,
-        applicationOpenDate: dayjs(new Date()).subtract(70, 'days').toDate(),
-        applicationFee: null,
-        applicationOrganization: null,
-        applicationPickUpAddressOfficeHours: null,
-        applicationPickUpAddressType: null,
-        applicationDropOffAddressOfficeHours: null,
-        applicationDropOffAddressType: null,
-        applicationMailingAddressType: null,
-        buildingSelectionCriteria: null,
-        costsNotIncluded: null,
-        creditHistory: null,
-        criminalBackground: null,
-        depositMin: '0',
-        depositMax: '0',
-        depositHelperText:
-          "or one month's rent may be higher for lower credit scores",
-        disableUnitsAccordion: false,
-        leasingAgentEmail: 'bloom@exygy.com',
-        leasingAgentName: 'Bloom Bloomington',
-        leasingAgentOfficeHours: null,
-        leasingAgentPhone: '(555) 555-5555',
-        leasingAgentTitle: null,
-        name: 'Lakeview Villa',
-        postmarkedApplicationsReceivedByDate: null,
-        programRules: null,
-        rentalAssistance:
-          'Housing Choice Vouchers, Section 8 and other valid rental assistance programs will be considered for this property. In the case of a valid rental subsidy, the required minimum income will be based on the portion of the rent that the tenant pays after use of the subsidy.',
-        rentalHistory: null,
-        requiredDocuments: null,
-        specialNotes: null,
-        waitlistCurrentSize: null,
-        waitlistMaxSize: null,
-        whatToExpect:
-          'Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents.',
-        status: ListingsStatusEnum.active,
-        reviewOrderType: ReviewOrderTypeEnum.waitlist,
-        unitsAvailable: 0,
-        displayWaitlistSize: false,
-        reservedCommunityDescription: null,
-        reservedCommunityMinAge: null,
-        resultLink: null,
-        isWaitlistOpen: false,
-        waitlistOpenSpots: null,
-        customMapPin: false,
-        contentUpdatedAt: new Date(),
-        publishedAt: new Date(),
-        listingsBuildingAddress: {
-          create: yellowstoneAddress,
-        },
-        listingsApplicationPickUpAddress: undefined,
-        listingsLeasingAgentAddress: undefined,
-        listingsApplicationDropOffAddress: undefined,
-        listingsApplicationMailingAddress: undefined,
-        reservedCommunityTypes: undefined,
-        listingImages: {
-          create: {
-            ordinal: 0,
-            assets: {
-              create: {
-                label: 'cloudinaryBuilding',
-                fileId: 'dev/apartment_building_2_b7ujdd',
-              },
-            },
-          },
-        },
-        listingNeighborhoodAmenities: {
-          create: {
-            groceryStores: 'There are grocery stores',
-            pharmacies: 'There are pharmacies',
-            healthCareResources: 'There is health care',
-            parksAndCommunityCenters: 'There are parks',
-            schools: 'There are schools',
-            publicTransportation: 'There is public transportation',
-          },
-        },
-      },
+      listing: lakeviewVilla,
       unitGroups: [
         {
           floorMin: 1,
@@ -857,6 +760,64 @@ export const stagingSeed = async (
           unitTypes: {
             connect: {
               id: unitTypes[0].id,
+            },
+          },
+        },
+      ],
+    },
+    {
+      jurisdictionId: lakeviewJurisdiction.id,
+      listing: sunshineFlats,
+      unitGroups: [
+        {
+          floorMin: 1,
+          floorMax: 1,
+          maxOccupancy: 6,
+          minOccupancy: 1,
+          bathroomMin: 1,
+          bathroomMax: 2,
+          totalCount: 12,
+          totalAvailable: 12,
+          sqFeetMin: '750.00',
+          sqFeetMax: '1600.00',
+          unitGroupAmiLevels: {
+            create: {
+              amiPercentage: 45,
+              monthlyRentDeterminationType:
+                MonthlyRentDeterminationTypeEnum.percentageOfIncome,
+              percentageOfIncomeValue: 30.0,
+              amiChart: { connect: { id: amiChart.id } },
+            },
+          },
+          unitTypes: {
+            connect: {
+              id: unitTypes[1].id,
+            },
+          },
+        },
+        {
+          floorMin: 2,
+          floorMax: 2,
+          maxOccupancy: 6,
+          minOccupancy: 3,
+          bathroomMin: 2,
+          bathroomMax: 2,
+          totalCount: 6,
+          totalAvailable: 6,
+          sqFeetMin: '1200.00',
+          sqFeetMax: '1800.00',
+          unitGroupAmiLevels: {
+            create: {
+              amiPercentage: 45,
+              monthlyRentDeterminationType:
+                MonthlyRentDeterminationTypeEnum.flatRent,
+              percentageOfIncomeValue: 1800.0,
+              amiChart: { connect: { id: amiChart.id } },
+            },
+          },
+          unitTypes: {
+            connect: {
+              id: unitTypes[3].id,
             },
           },
         },

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -811,7 +811,7 @@ export const stagingSeed = async (
               amiPercentage: 45,
               monthlyRentDeterminationType:
                 MonthlyRentDeterminationTypeEnum.flatRent,
-              percentageOfIncomeValue: 1800.0,
+              flatRentValue: 1800.0,
               amiChart: { connect: { id: amiChart.id } },
             },
           },

--- a/api/test/integration/reserved-community-type.e2e-spec.ts
+++ b/api/test/integration/reserved-community-type.e2e-spec.ts
@@ -120,7 +120,7 @@ describe('ReservedCommunityType Controller Tests', () => {
       .set('Cookie', cookies)
       .expect(200);
 
-    expect(res.body.length).toEqual(5);
+    expect(res.body.length).toEqual(11);
     expect(res.body.map((body) => body.name)).toContain(
       reservedCommunityTypeA.name,
     );


### PR DESCRIPTION
#4740 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

This PR addresses the following things:
* With more jurisdictions in the system we would like to have more pre-set listings for local development. This adds an additional listing to the Lakeview jurisdiction. I would like us to continue to add listings as we develop features so that we have a good representation of the ecosystem
* Reserved Community Type is currently tied to a jurisdiction, but outside of the db we don't care what jurisdiction it is tied to. Because of that this PR now only generates one set of the community types so there aren't duplicates in the dropdown (hopefully the flaky cypress test will be more consistent now)
* Adds the community types to the seeded data that were missing 

## How Can This Be Tested/Reviewed?

All tests should pass especially the cypress ones

After running the staging seeds `yarn setup` there should be an additional listing in Lakeview jurisdiction called "Sunshine Flats" and you should only see one set of community types in the dropdown (no duplicates)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
