### PR TITLE
feat: add additional partners waitlist fields

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -62,6 +62,7 @@ export const stagingSeed = async (
         FeatureFlagEnum.enablePartnerSettings,
         FeatureFlagEnum.enableListingsPagination,
         FeatureFlagEnum.enableListingFavoriting,
+        FeatureFlagEnum.enableWaitlistAdditionalFields,
       ],
     }),
   });
@@ -89,7 +90,7 @@ export const stagingSeed = async (
         FeatureFlagEnum.disableJurisdictionalAdmin,
         FeatureFlagEnum.swapCommunityTypeWithPrograms,
         FeatureFlagEnum.enableListingFavoriting,
-
+        FeatureFlagEnum.enableWaitlistAdditionalFields,
       ],
     }),
   });

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -23,6 +23,7 @@ export enum FeatureFlagEnum {
   enableUtilitiesIncluded = 'enableUtilitiesIncluded',
   hideCloseListingButton = 'hideCloseListingButton',
   swapCommunityTypeWithPrograms = 'swapCommunityTypeWithPrograms',
+  enableWaitlistAdditionalFields = 'enableWaitlistAdditionalFields',
 }
 
 // List of all of existing flags and their descriptions.
@@ -67,7 +68,7 @@ export const featureFlagMap: { name: string; description: string }[] = [
     description:
       "When true, any newly published listing will send a gov delivery email to everyone that has signed up for the 'listing alerts'",
   },
-    {
+  {
     name: FeatureFlagEnum.enableListingsPagination,
     description:
       'When true listings browser will display pagination controls section',
@@ -122,5 +123,10 @@ export const featureFlagMap: { name: string; description: string }[] = [
     name: FeatureFlagEnum.swapCommunityTypeWithPrograms,
     description:
       'When true, the programs section on the frontend is displayed as community types.',
+  },
+  {
+    name: FeatureFlagEnum.enableWaitlistAdditionalFields,
+    description:
+      'When true, the waitlist additional fields are displayed in the waitlist section of the listing form',
   },
 ];

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -817,6 +817,26 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
     if (
       doAnyJurisdictionHaveFeatureFlagSet(
         user.jurisdictions,
+        FeatureFlagEnum.enableWaitlistAdditionalFields,
+      )
+    ) {
+      headers.push({
+        path: 'waitlistMaxSize',
+        label: 'Max Waitlist Size',
+      });
+      headers.push({
+        path: 'waitlistCurrentSize',
+        label: 'How many people on the current waitlist?',
+      });
+      headers.push({
+        path: 'waitlistOpenSpots',
+        label: 'How many open spots on the waitlist?',
+      });
+    }
+
+    if (
+      doAnyJurisdictionHaveFeatureFlagSet(
+        user.jurisdictions,
         FeatureFlagEnum.enableMarketingStatus,
       )
     ) {

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -7082,6 +7082,7 @@ export enum FeatureFlagEnum {
   "enableUtilitiesIncluded" = "enableUtilitiesIncluded",
   "hideCloseListingButton" = "hideCloseListingButton",
   "swapCommunityTypeWithPrograms" = "swapCommunityTypeWithPrograms",
+  "enableWaitlistAdditionalFields" = "enableWaitlistAdditionalFields",
 }
 export enum EnumMultiselectQuestionFilterParamsComparison {
   "=" = "=",

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -561,6 +561,7 @@
   "t.updated": "Updated",
   "t.url": "URL",
   "t.view": "View",
+  "t.recommended": "Recommended",
   "users.addPassword": "Add a Password",
   "users.addUser": "Add User",
   "users.administrator": "Administrator",

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -5,13 +5,22 @@ dayjs.extend(utc)
 import { t } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { ListingContext } from "../../ListingContext"
-import { getLotteryEvent } from "@bloom-housing/shared-helpers"
-import { ReviewOrderTypeEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { AuthContext, getLotteryEvent } from "@bloom-housing/shared-helpers"
+import {
+  FeatureFlagEnum,
+  ReviewOrderTypeEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { getDetailFieldNumber, getDetailFieldString, getDetailBoolean } from "./helpers"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 
 const DetailRankingsAndResults = () => {
   const listing = useContext(ListingContext)
+  const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
+
+  const enableWaitlistAdditionalFields = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableWaitlistAdditionalFields,
+    listing.jurisdictions.id
+  )
 
   const lotteryEvent = getLotteryEvent(listing)
   const getReviewOrderType = () => {
@@ -71,6 +80,16 @@ const DetailRankingsAndResults = () => {
             </FieldValue>
           </Grid.Row>
           <Grid.Row>
+            {enableWaitlistAdditionalFields && (
+              <>
+                <FieldValue id="waitlistMaxSize" label={t("listings.waitlist.maxSize")}>
+                  {getDetailFieldNumber(listing.waitlistMaxSize)}
+                </FieldValue>
+                <FieldValue id="waitlistCurrentSize" label={t("listings.waitlist.currentSize")}>
+                  {getDetailFieldNumber(listing.waitlistCurrentSize)}
+                </FieldValue>
+              </>
+            )}
             <FieldValue id="waitlistOpenSpots" label={t("listings.waitlist.openSize")}>
               {getDetailFieldNumber(listing.waitlistOpenSpots)}
             </FieldValue>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useContext } from "react"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
 dayjs.extend(utc)
@@ -6,8 +6,9 @@ import { useFormContext, useWatch } from "react-hook-form"
 import { t, Field, FieldGroup, Textarea, DateField, TimeField } from "@bloom-housing/ui-components"
 import { Grid } from "@bloom-housing/ui-seeds"
 import { FormListing } from "../../../../lib/listings/formTypes"
-import { getLotteryEvent } from "@bloom-housing/shared-helpers"
+import { AuthContext, getLotteryEvent } from "@bloom-housing/shared-helpers"
 import {
+  FeatureFlagEnum,
   Listing,
   ReviewOrderTypeEnum,
   YesNoEnum,
@@ -21,6 +22,7 @@ type RankingsAndResultsProps = {
 
 const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
   const formMethods = useFormContext()
+  const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, setValue, watch, control, errors } = formMethods
@@ -65,6 +67,11 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
       value: YesNoEnum.no,
     },
   ]
+
+  const enableWaitlistAdditionalFields = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableWaitlistAdditionalFields,
+    listing.jurisdictions.id
+  )
 
   return (
     <>
@@ -290,6 +297,27 @@ const RankingsAndResults = ({ listing, isAdmin }: RankingsAndResultsProps) => {
         </Grid.Row>
         {waitlistOpen === YesNoEnum.yes && availabilityQuestion === "openWaitlist" && (
           <Grid.Row columns={3}>
+            {enableWaitlistAdditionalFields && (
+              <>
+                <Field
+                  name="waitlistMaxSize"
+                  id="waitlistMaxSize"
+                  register={register}
+                  label={t("listings.waitlist.maxSizeQuestion")}
+                  placeholder={t("listings.waitlist.maxSize")}
+                  type={"number"}
+                  subNote={t("t.recommended")}
+                />
+                <Field
+                  name="waitlistCurrentSize"
+                  id="waitlistCurrentSize"
+                  register={register}
+                  label={t("listings.waitlist.currentSizeQuestion")}
+                  placeholder={t("listings.waitlist.currentSize")}
+                  type={"number"}
+                />
+              </>
+            )}
             <Field
               name="waitlistOpenSpots"
               id="waitlistOpenSpots"


### PR DESCRIPTION
This PR addresses #4721 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds two fields to to waitlist. They was already on backend, so it was just partners site change

## How Can This Be Tested/Reviewed?

Either reseed data or set `enableWaitlistAdditionalFields` flag to `true`. In listing edit set in `Listing Units` section `Open Waitlist`. Then in `Rankings & Results` set `Do you want to show a waitlist size?` to true, it should show additional fields. Check if they appear on details page, and on csv export. Make sure it work as before with feature flag set to `false`

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
