### PR TITLE
fix: allow duplication to not copy unit groups

### DIFF
--- a/api/prisma/seed-helpers/feature-flag-factory.ts
+++ b/api/prisma/seed-helpers/feature-flag-factory.ts
@@ -8,6 +8,7 @@ export const createAllFeatureFlags = async (prismaClient: PrismaClient) => {
     data: featureFlagMap.map((flag) => {
       return { ...flag, active: true };
     }),
+    skipDuplicates: true,
   });
 };
 

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -1317,9 +1317,11 @@ export class ListingService implements OnModuleInit {
                       level.monthlyRentDeterminationType,
                     percentageOfIncomeValue: level.percentageOfIncomeValue,
                     flatRentValue: level.flatRentValue,
-                    amiChart: {
-                      connect: { id: level.amiChart.id },
-                    },
+                    amiChart: level.amiChart?.id
+                      ? {
+                          connect: { id: level.amiChart.id },
+                        }
+                      : undefined,
                   })),
                 },
                 unitAccessibilityPriorityTypes:
@@ -1499,6 +1501,7 @@ export class ListingService implements OnModuleInit {
 
     if (!dto.includeUnits) {
       delete mappedListing['units'];
+      delete mappedListing['unitGroups'];
     }
 
     const newListingData: ListingCreate = {

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -53,12 +53,17 @@ import { userFactory } from '../../prisma/seed-helpers/user-factory';
 import { unitFactorySingle } from '../../prisma/seed-helpers/unit-factory';
 import { FilterAvailabilityEnum } from '../../src/enums/listings/filter-availability-enum';
 import { unitGroupFactorySingle } from '../../prisma/seed-helpers/unit-group-factory';
+import { randomName } from '../../prisma/seed-helpers/word-generator';
+import { FeatureFlagEnum } from '../../src/enums/feature-flags/feature-flags-enum';
+import { createAllFeatureFlags } from '../../prisma/seed-helpers/feature-flag-factory';
 
 describe('Listing Controller Tests', () => {
   let app: INestApplication;
   let prisma: PrismaService;
   let jurisdictionAId: string;
   let adminAccessToken: string;
+  let unitTypeOneBed;
+  let unitTypeThreeBed;
 
   const testEmailService = {
     /* eslint-disable @typescript-eslint/no-empty-function */
@@ -113,6 +118,13 @@ describe('Listing Controller Tests', () => {
     app.use(cookieParser());
     prisma = moduleFixture.get<PrismaService>(PrismaService);
     await app.init();
+    await unitTypeFactoryAll(prisma);
+    unitTypeOneBed = await unitTypeFactorySingle(prisma, UnitTypeEnum.oneBdrm);
+    unitTypeThreeBed = await unitTypeFactorySingle(
+      prisma,
+      UnitTypeEnum.threeBdrm,
+    );
+    await createAllFeatureFlags(prisma);
     const jurisdiction = await prisma.jurisdictions.create({
       data: jurisdictionFactory(),
     });
@@ -136,7 +148,6 @@ describe('Listing Controller Tests', () => {
     adminAccessToken = res.header?.['set-cookie'].find((cookie) =>
       cookie.startsWith('access-token='),
     );
-    await unitTypeFactoryAll(prisma);
   });
 
   afterAll(async () => {
@@ -548,15 +559,6 @@ describe('Listing Controller Tests', () => {
     let jurisdictionDWithUnitGroups;
 
     beforeAll(async () => {
-      const unitTypeOneBed = await unitTypeFactorySingle(
-        prisma,
-        UnitTypeEnum.oneBdrm,
-      );
-      const unitTypeThreeBed = await unitTypeFactorySingle(
-        prisma,
-        UnitTypeEnum.threeBdrm,
-      );
-
       jurisdictionB = await prisma.jurisdictions.create({
         data: jurisdictionFactory(),
       });
@@ -1746,6 +1748,61 @@ describe('Listing Controller Tests', () => {
       expect(newDBValues[0].units).toHaveLength(2);
     });
 
+    it('should duplicate listing, include unit groups', async () => {
+      const jurisdictionWithUnitGroupsEnabled =
+        await prisma.jurisdictions.create({
+          data: jurisdictionFactory(randomName(), {
+            featureFlags: [FeatureFlagEnum.enableUnitGroups],
+          }),
+        });
+      const listingData = await listingFactory(
+        jurisdictionWithUnitGroupsEnabled.id,
+        prisma,
+        {
+          numberOfUnits: 0,
+          unitGroups: [
+            unitGroupFactorySingle(unitTypeThreeBed),
+            unitGroupFactorySingle(unitTypeOneBed),
+            unitGroupFactorySingle(unitTypeOneBed),
+          ],
+        },
+      );
+      const listing = await prisma.listings.create({
+        data: listingData,
+        include: {
+          units: true,
+          unitGroups: true,
+        },
+      });
+
+      const newName = `${listing.name} duplicate`;
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: true,
+          name: newName,
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', adminAccessToken)
+        .expect(201);
+
+      expect(res.body.name).toEqual(newName);
+      expect(res.body.unitGroups.length).toBe(listing.unitGroups.length);
+
+      const newDBValues = await prisma.listings.findMany({
+        include: {
+          unitGroups: true,
+        },
+        where: { name: newName },
+      });
+      expect(newDBValues.length).toBeGreaterThanOrEqual(1);
+      expect(newDBValues[0].unitGroups).toHaveLength(3);
+    });
+
     it('should duplicate listing, exclude units', async () => {
       const jurisdictionA = await prisma.jurisdictions.create({
         data: jurisdictionFactory(),
@@ -1777,6 +1834,50 @@ describe('Listing Controller Tests', () => {
 
       expect(res.body.name).toEqual(newName);
       expect(res.body.units).toEqual([]);
+
+      const newListing = await prisma.listings.findFirst({
+        select: {
+          copyOfId: true,
+        },
+        where: { id: res.body.id },
+      });
+      expect(newListing.copyOfId).toEqual(listing.id);
+    });
+
+    it('should duplicate listing, exclude units with unit groups', async () => {
+      const jurisdictionA = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdictionA.id, prisma);
+      const listingData = await listingFactory(jurisdictionA.id, prisma, {
+        numberOfUnits: 0,
+        unitGroups: [unitGroupFactorySingle(unitTypeThreeBed)],
+      });
+      const listing = await prisma.listings.create({
+        data: listingData,
+        include: {
+          units: true,
+          unitGroups: true,
+        },
+      });
+      const newName = 'duplicate name 2';
+
+      const res = await request(app.getHttpServer())
+        .post('/listings/duplicate')
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .send({
+          includeUnits: false,
+          name: newName,
+          storedListing: {
+            id: listing.id,
+          },
+        })
+        .set('Cookie', adminAccessToken)
+        .expect(201);
+
+      expect(res.body.name).toEqual(newName);
+      expect(res.body.units).toEqual([]);
+      expect(res.body.unitGroups).toEqual([]);
 
       const newListing = await prisma.listings.findFirst({
         select: {


### PR DESCRIPTION
This PR addresses #4751 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The duplication (copy) of listings already works for listings that use unit groups instead of units. However, if you don't want to copy the units a small change was needed.

* Note: open question. Do we require a language change from "include units" to "include unit groups" when it is a unit group jurisdiction

## How Can This Be Tested/Reviewed?

To Copy with units groups
* Seed the staging data
* open up one of the "lakeview" listings in the partner site
* Click "copy" for the listing
* Enter a new listing name and submit
* Verify the listing along with the unit groups were transferred.

To copy without unit groups
* Seed the staging data
* open up one of the "lakeview" listings in the partner site
* Click "copy" for the listing
* uncheck the "include units" checkbox
* Click submit
* Verify the listing was copied, but the unit groups were not

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
