### PR TITLE
4747/region issues

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
@@ -206,15 +206,17 @@ const BuildingDetails = ({
                 <Select
                   name={"neighborhood"}
                   id={"neighborhood"}
-                  placeholder={t("listings.sections.neighborhoodPlaceholder")}
                   inputProps={{
                     className: "w-full",
                   }}
                   register={register}
-                  options={neighborhoodRegions.map((entry) => ({
-                    value: entry.name,
-                    label: entry.name,
-                  }))}
+                  options={[
+                    { value: undefined, label: t("listings.sections.neighborhoodPlaceholder") },
+                    ...neighborhoodRegions.map((entry) => ({
+                      value: entry.name,
+                      label: entry.name,
+                    })),
+                  ]}
                 />
               </FieldValue>
             ) : (
@@ -323,16 +325,19 @@ const BuildingDetails = ({
                 <Select
                   id="region"
                   name="region"
-                  placeholder={t("listings.sections.regionPlaceholder")}
+                  // placeholder={t("listings.sections.regionPlaceholder")}
                   register={register}
                   inputProps={{
                     className: "w-full",
                     onChange: () => setValue("neighborhood", undefined),
                   }}
-                  options={Object.keys(RegionEnum).map((entry) => ({
-                    value: entry,
-                    label: entry.toString().replace("_", " "),
-                  }))}
+                  options={[
+                    { value: undefined, label: t("listings.sections.regionPlaceholder") },
+                    ...Object.keys(RegionEnum).map((entry) => ({
+                      value: entry,
+                      label: entry.toString().replace("_", " "),
+                    })),
+                  ]}
                 />
               </FieldValue>
             ) : (

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
@@ -325,7 +325,6 @@ const BuildingDetails = ({
                 <Select
                   id="region"
                   name="region"
-                  // placeholder={t("listings.sections.regionPlaceholder")}
                   register={register}
                   inputProps={{
                     className: "w-full",

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingDetails.tsx
@@ -211,7 +211,7 @@ const BuildingDetails = ({
                   }}
                   register={register}
                   options={[
-                    { value: undefined, label: t("listings.sections.neighborhoodPlaceholder") },
+                    { value: "", label: t("listings.sections.neighborhoodPlaceholder") },
                     ...neighborhoodRegions.map((entry) => ({
                       value: entry.name,
                       label: entry.name,
@@ -332,7 +332,7 @@ const BuildingDetails = ({
                     onChange: () => setValue("neighborhood", undefined),
                   }}
                   options={[
-                    { value: undefined, label: t("listings.sections.regionPlaceholder") },
+                    { value: "", label: t("listings.sections.regionPlaceholder") },
                     ...Object.keys(RegionEnum).map((entry) => ({
                       value: entry,
                       label: entry.toString().replace("_", " "),

--- a/sites/partners/src/lib/listings/formTypes.ts
+++ b/sites/partners/src/lib/listings/formTypes.ts
@@ -156,7 +156,7 @@ export const formDefaults: FormListing = {
   householdSizeMax: 0,
   householdSizeMin: 0,
   neighborhood: undefined,
-  region: RegionEnum.Greater_Downtown,
+  region: undefined,
   petPolicy: "",
   smokingPolicy: "",
   unitsAvailable: 0,


### PR DESCRIPTION
This PR addresses #4747 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR resolves issues related to region and neighborhood selection in the partner site listing form:
- Removes the pre-selected default region ("Greater Downtown") when creating a new listing. The region field now defaults to empty.
- Adds an option to both the Region and Neighborhood dropdowns, allowing users to clear their selections.
- Implements the requirement that deselecting the Region also clears the Neighborhood selection.
- Ensures that deselecting the Neighborhood does *not* clear the Region selection.
- All other logic related to the fields remain as it was

## How Can This Be Tested/Reviewed?

1.  Navigate to the listing creationform in the partner site.
2.  When creating a *new* listing, confirm that the "Region" field is initially empty (no region is pre-selected).
3.  **Verify Region Deselect Clears Neighborhood:**
    *   Select a Neighborhood.
    *   Select a Region.
    *   Deselect the Region.
    *   Confirm that the Neighborhood field also becomes empty.
4.  **Verify Neighborhood Deselect Doesn't Clear Region:**
    *   Select a Neighborhood.
    *   Select a Region.
    *   Deselect the Neighborhood.
    *   Confirm that the Region field remains selected with its previous value.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
