### PR TITLE
feat: public fe listing verification tag

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -765,6 +765,7 @@
   "listings.vacantUnit": "Unidad vacante",
   "listings.vacantUnits": "Unidades vacantes",
   "listings.vacantUnitsAvailable": "Unidades vacantes disponibles",
+  "listings.verifiedListing": "Confirmado según propiedad",
   "listings.waitlist.closed": "Lista de espera cerrada",
   "listings.waitlist.currentSize": "Tamaño de la lista de espera actual",
   "listings.waitlist.finalSize": "Tamaño final de la lista de espera",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -772,6 +772,7 @@
   "listings.vacantUnit": "Vacant Unit",
   "listings.vacantUnits": "Vacant Units",
   "listings.vacantUnitsAvailable": "Vacant Units Available",
+  "listings.verifiedListing": "Confirmed by Property",
   "listings.waitlist.closed": "Waitlist Closed",
   "listings.waitlist.currentSize": "Current Waitlist Size",
   "listings.waitlist.finalSize": "Final Waitlist Size",

--- a/sites/public/src/components/browse/ListingCard.module.scss
+++ b/sites/public/src/components/browse/ListingCard.module.scss
@@ -78,6 +78,9 @@
             &:not(:last-child) {
               margin-inline-end: var(--seeds-s2);
             }
+            svg {
+              margin-inline-end: var(--seeds-s1);
+            }
           }
         }
 

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -6,7 +6,7 @@ import {
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { imageUrlFromListing, oneLineAddress, ClickableCard } from "@bloom-housing/shared-helpers"
 import { StackedTable, t } from "@bloom-housing/ui-components"
-import { Card, Heading, Link, Tag } from "@bloom-housing/ui-seeds"
+import { Card, Heading, Link, Tag, Icon } from "@bloom-housing/ui-seeds"
 import {
   getListingApplicationStatus,
   getListingStackedGroupTableData,
@@ -74,7 +74,10 @@ export const ListingCard = ({
                   {listingTags.map((tag, index) => {
                     return (
                       <Tag variant={tag.variant} key={index} className={styles["tag"]}>
-                        {tag.title}
+                        <span>
+                          {tag.icon && <Icon>{tag.icon}</Icon>}
+                          {tag.title}
+                        </span>
                       </Tag>
                     )
                   })}

--- a/sites/public/src/components/listing/listing_sections/MainDetails.module.scss
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.module.scss
@@ -28,10 +28,13 @@
 
 .listing-tags {
   margin-bottom: calc(-1 * var(--seeds-s1));
-  span {
-    margin-bottom: var(--seeds-s1);
+  .tag {
+    margin-block-end: var(--seeds-s1);
     &:not(:last-child) {
       margin-inline-end: var(--seeds-s2);
+    }
+    svg {
+      margin-inline-end: var(--seeds-s1);
     }
   }
 }

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -17,6 +17,7 @@ import FavoriteButton from "../../shared/FavoriteButton"
 import { Availability } from "./Availability"
 import listingStyles from "../ListingViewSeeds.module.scss"
 import styles from "./MainDetails.module.scss"
+import { CheckIcon } from "@heroicons/react/20/solid"
 
 type MainDetailsProps = {
   listing: Listing
@@ -30,6 +31,7 @@ type MainDetailsProps = {
 type ListingTag = {
   title: string
   variant: TagVariant
+  icon?: React.ReactNode
 }
 
 export const getListingTags = (
@@ -38,6 +40,14 @@ export const getListingTags = (
   hideHomeTypeTag?: boolean
 ): ListingTag[] => {
   const listingTags: ListingTag[] = []
+
+  if (listing.isVerified) {
+    listingTags.push({
+      title: t("listings.verifiedListing"),
+      variant: "warn-inverse",
+      icon: <CheckIcon />,
+    })
+  }
 
   if (!hideHomeTypeTag && listing.homeType) {
     listingTags.push({

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -5,7 +5,7 @@ import {
   MarketingTypeEnum,
   ReviewOrderTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { Heading, Link, Tag } from "@bloom-housing/ui-seeds"
+import { Heading, Link, Tag, Icon } from "@bloom-housing/ui-seeds"
 import { TagVariant } from "@bloom-housing/ui-seeds/src/text/Tag"
 import { ImageCard, t } from "@bloom-housing/ui-components"
 import {
@@ -144,8 +144,11 @@ export const MainDetails = ({
           <div className={`${styles["listing-tags"]} seeds-m-bs-3`} data-testid={"listing-tags"}>
             {listingTags.map((tag, index) => {
               return (
-                <Tag variant={tag.variant} key={index}>
-                  {tag.title}
+                <Tag variant={tag.variant} key={index} className={styles["tag"]}>
+                  <span>
+                    {tag.icon && <Icon>{tag.icon}</Icon>}
+                    {tag.title}
+                  </span>
                 </Tag>
               )
             })}


### PR DESCRIPTION
This PR addresses #4772 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds tag that will be displayed when `isVerified` is set to true.

## How Can This Be Tested/Reviewed?

Set `isVerified` for listing. Then check if its visible for `/listings` and `/listings/[:id]` pages.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
