### PR TITLE
fix: remove token max length

### DIFF
--- a/api/src/dtos/auth/confirm.dto.ts
+++ b/api/src/dtos/auth/confirm.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, Matches, MaxLength } from 'class-validator';
+import { IsString, Matches } from 'class-validator';
 import { Expose } from 'class-transformer';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 import { passwordRegex } from '../../utilities/password-regex';
@@ -8,7 +8,6 @@ export class Confirm {
   @Expose()
   @ApiProperty()
   @IsString({ groups: [ValidationsGroupsEnum.default] })
-  @MaxLength(256, { groups: [ValidationsGroupsEnum.default] })
   token: string;
 
   @Expose()

--- a/api/src/dtos/auth/update-password.dto.ts
+++ b/api/src/dtos/auth/update-password.dto.ts
@@ -25,6 +25,5 @@ export class UpdatePassword {
   @Expose()
   @ApiProperty()
   @IsString({ groups: [ValidationsGroupsEnum.default] })
-  @MaxLength(256, { groups: [ValidationsGroupsEnum.default] })
   token: string;
 }


### PR DESCRIPTION
This PR addresses [slack conversation](https://exygy.slack.com/archives/C03PB25AVTR/p1745414853923449)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

On rare occasions confirmation tokens can be longer than 256 characters. This causes an issue when the user tries to confirm their account because we have a MaxLength of 256 on the token field

## How Can This Be Tested/Reviewed?

The confirmation and forget password flows should fully work

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
