### PR TITLE
feat: listing filter by mutliselect questions

### DIFF
--- a/api/src/dtos/listings/listings-filter-params.dto.ts
+++ b/api/src/dtos/listings/listings-filter-params.dto.ts
@@ -145,6 +145,15 @@ export class ListingFilterParams extends BaseFilter {
 
   @Expose()
   @ApiPropertyOptional({
+    type: Array,
+    example: ['abcdef'],
+  })
+  @IsUUID(4, { groups: [ValidationsGroupsEnum.default], each: true })
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  [ListingFilterKeys.multiselectQuestions]?: string[];
+
+  @Expose()
+  @ApiPropertyOptional({
     example: 'Coliseum',
   })
   @IsString({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/enums/listings/filter-key-enum.ts
+++ b/api/src/enums/listings/filter-key-enum.ts
@@ -13,6 +13,7 @@ export enum ListingFilterKeys {
   leasingAgent = 'leasingAgent',
   listingFeatures = 'listingFeatures',
   monthlyRent = 'monthlyRent',
+  multiselectQuestions = 'multiselectQuestions',
   name = 'name',
   neighborhood = 'neighborhood',
   regions = 'regions',

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -899,6 +899,22 @@ export class ListingService implements OnModuleInit {
             })),
           });
         }
+        if (filter[ListingFilterKeys.multiselectQuestions]) {
+          const builtFilter = buildFilter({
+            $comparison: filter.$comparison,
+            $include_nulls: false,
+            value: filter[ListingFilterKeys.multiselectQuestions],
+            key: ListingFilterKeys.multiselectQuestions,
+            caseSensitive: true,
+          });
+          filters.push({
+            OR: builtFilter.map((filt) => ({
+              listingMultiselectQuestions: {
+                some: { multiselectQuestionId: filt },
+              },
+            })),
+          });
+        }
         if (filter[ListingFilterKeys.regions]) {
           const builtFilter = buildFilter({
             $comparison: filter.$comparison,

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -8,6 +8,7 @@ import {
   ListingEventsTypeEnum,
   ListingsStatusEnum,
   MarketingTypeEnum,
+  MultiselectQuestionsApplicationSectionEnum,
   Prisma,
   RegionEnum,
   ReviewOrderTypeEnum,
@@ -557,10 +558,28 @@ describe('Listing Controller Tests', () => {
     let jurisdictionB;
     let jurisdictionC;
     let jurisdictionDWithUnitGroups;
+    let multiselectQuestionPreference;
+    let multiselectQuestionProgram;
 
     beforeAll(async () => {
       jurisdictionB = await prisma.jurisdictions.create({
         data: jurisdictionFactory(),
+      });
+      multiselectQuestionPreference = await prisma.multiselectQuestions.create({
+        data: multiselectQuestionFactory(jurisdictionB.id, {
+          multiselectQuestion: {
+            applicationSection:
+              MultiselectQuestionsApplicationSectionEnum.preferences,
+          },
+        }),
+      });
+      multiselectQuestionProgram = await prisma.multiselectQuestions.create({
+        data: multiselectQuestionFactory(jurisdictionB.id, {
+          multiselectQuestion: {
+            applicationSection:
+              MultiselectQuestionsApplicationSectionEnum.programs,
+          },
+        }),
       });
       const listing1Input = await listingFactory(jurisdictionB.id, prisma, {
         listing: {
@@ -570,6 +589,7 @@ describe('Listing Controller Tests', () => {
           region: RegionEnum.Eastside,
           section8Acceptance: false,
         } as Prisma.ListingsCreateInput,
+        multiselectQuestions: [multiselectQuestionPreference],
         optionalFeatures: {
           acInUnit: true,
         },
@@ -596,6 +616,7 @@ describe('Listing Controller Tests', () => {
           region: RegionEnum.Southwest,
           section8Acceptance: true,
         } as Prisma.ListingsCreateInput,
+        multiselectQuestions: [multiselectQuestionProgram],
         optionalFeatures: {
           acInUnit: false,
         },
@@ -1498,6 +1519,79 @@ describe('Listing Controller Tests', () => {
       expect(ids).toContain(listing4WithUnitGroups.id);
       expect(ids).toContain(listing5WithUnitGroups.id);
       expect(ids).toContain(listing6WithUnitGroups.id);
+    });
+    it('should return a listing based on filter multiselectQuestions', async () => {
+      const queryPrefence: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare.IN,
+            multiselectQuestions: [multiselectQuestionPreference.id],
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionB.id,
+          },
+        ],
+      };
+
+      const queryProgram: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare.IN,
+            multiselectQuestions: [multiselectQuestionProgram.id],
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionB.id,
+          },
+        ],
+      };
+
+      const resPreference = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(queryPrefence)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(resPreference.body.meta).toEqual({
+        currentPage: 1,
+        itemCount: 1,
+        itemsPerPage: 10,
+        totalItems: 1,
+        totalPages: 1,
+      });
+
+      expect(resPreference.body.items.length).toBeGreaterThanOrEqual(1);
+
+      const foundId1 = resPreference.body.items.some(
+        (elem) => elem.id === listing1WithUnits.id,
+      );
+      expect(foundId1).toEqual(true);
+
+      const resProgram = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(queryProgram)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(resProgram.body.meta).toEqual({
+        currentPage: 1,
+        itemCount: 1,
+        itemsPerPage: 10,
+        totalItems: 1,
+        totalPages: 1,
+      });
+
+      expect(resProgram.body.items.length).toBeGreaterThanOrEqual(1);
+
+      const foundId2 = resProgram.body.items.some(
+        (elem) => elem.id === listing2WithUnits.id,
+      );
+      expect(foundId2).toEqual(true);
     });
     it('should return a listing based on filter monthlyRent - units', async () => {
       const query: ListingsQueryBody = {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -2014,6 +2014,35 @@ describe('Testing listing service', () => {
       });
     });
 
+    it('should return a where clause for filter multiselectQuestions', () => {
+      const uuids = [randomUUID(), randomUUID()];
+      const filter = [
+        {
+          $comparison: 'IN',
+          multiselectQuestions: uuids,
+        } as ListingFilterParams,
+      ];
+      const whereClause = service.buildWhereClause(filter, '');
+
+      expect(whereClause).toStrictEqual({
+        AND: [
+          {
+            OR: [
+              {
+                listingMultiselectQuestions: {
+                  some: {
+                    multiselectQuestionId: {
+                      in: uuids,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+
     it('should return a where clause for filter name', () => {
       const name = 'listingName';
       const filter = [

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2878,6 +2878,9 @@ export interface ListingFilterParams {
   monthlyRent?: number
 
   /**  */
+  multiselectQuestions?: string[]
+
+  /**  */
   name?: string
 
   /**  */


### PR DESCRIPTION
This PR addresses [#(4764)](https://github.com/bloom-housing/bloom/issues/4764)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Detroit requires filtering by programs (aka multiselect questions (aka aka "community types" in Detroit)). To allow this, a new filter was added to the listings filter list. We can now filter listings based on associated multiselectQuestionIds, be that preferences or programs.

## How Can This Be Tested/Reviewed?

- Start up the backend.
- View the db table listingMulitselectQuestions and copy a multiselectQuestionId
- Go to http://localhost:3100/api#/listings/filterableList
- Pass in the copied id in the following format for the filter
`  "filter": [
    {
      "$comparison": "IN",
      "multiselectQuestions": ["cd7a9210-3d47-44ab-9d68-4e77c5f392cf"]
    }
  ]`
- Ensure the correct listings were returned


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
