### PR TITLE
feat: adds ui load tester & getStaticProps from getServerSideProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "test:backend:new:dbsetup": "cd api && yarn db:migration:run",
     "test:backend:new:dbsetup:withseed": "cd api && yarn db:migration:run && yarn db:seed:staging --jurisdictionName Bloomington",
     "backend:new:install": "cd api && yarn install",
-    "prettier": "prettier --write \"./**/*.{js,jsx,ts,tsx,json}\""
+    "prettier": "prettier --write \"./**/*.{js,jsx,ts,tsx,json}\"",
+    "ui-load-test": "ruby ./utilities/ui-load-tester.rb"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",

--- a/sites/public/.env.template
+++ b/sites/public/.env.template
@@ -11,8 +11,6 @@ RTL_LANGUAGES=ar
 IDLE_TIMEOUT=5
 JURISDICTION_NAME=Bloomington
 CLOUDINARY_CLOUD_NAME=exygy
-# next js cache revalidate
-CACHE_REVALIDATE=60
 NEW_RELIC_APP_NAME=Bloom Public
 NEW_RELIC_LICENSE_KEY=
 SENTRY_ORG=
@@ -49,3 +47,6 @@ DD_API_KEY=
 DD_SITE=
 # DataDog Agent Version
 DD_AGENT_MAJOR_VERSION=
+
+# used to control how long we hold onto a listing detail page server side render cache (in seconds)
+CACHE_REVALIDATE=30

--- a/sites/public/next.config.js
+++ b/sites/public/next.config.js
@@ -38,7 +38,7 @@ module.exports = withBundleAnalyzer({
     gtmKey: process.env.GTM_KEY || null,
     idleTimeout: process.env.IDLE_TIMEOUT,
     jurisdictionName: process.env.JURISDICTION_NAME,
-    cacheRevalidate: process.env.CACHE_REVALIDATE ? Number(process.env.CACHE_REVALIDATE) : 60,
+    cacheRevalidate: process.env.CACHE_REVALIDATE ? Number(process.env.CACHE_REVALIDATE) : 30,
     cloudinaryCloudName: process.env.CLOUDINARY_CLOUD_NAME,
     showPublicLottery: process.env.SHOW_PUBLIC_LOTTERY === "TRUE",
     showNewSeedsDesigns: process.env.SHOW_NEW_SEEDS_DESIGNS === "TRUE",

--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -102,5 +102,8 @@ export const getStaticProps: GetStaticProps = async (context: {
   }
   const jurisdiction = fetchJurisdictionByName()
 
-  return { props: { listing: response.data, jurisdiction: await jurisdiction }, revalidate: 30 }
+  return {
+    props: { listing: response.data, jurisdiction: await jurisdiction },
+    revalidate: Number(process.env.cacheRevalidate),
+  }
 }

--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useContext } from "react"
 import Head from "next/head"
+import { GetStaticPaths, GetStaticProps } from "next"
 import axios from "axios"
 import { t } from "@bloom-housing/ui-components"
 import {
@@ -79,68 +80,27 @@ export default function ListingPage(props: ListingProps) {
     </Layout>
   )
 }
-/**
- *
- * getStaticPaths and getStaticProps with revalidation isn't actually working on netflify, so we have to use getServerSideProps until it does
- */
-/* export async function getStaticPaths(context: { locales: Array<string> }) {
-  try {
-    const response = await axios.get(process.env.listingServiceUrl, {
-      params: {
-        view: "base",
-        limit: "all",
-        filter: [
-          {
-            $comparison: "<>",
-            status: "pending",
-          },
-        ],
-      },
-      paramsSerializer: (params) => {
-        return qs.stringify(params)
-      },
-    })
 
-    return {
-      paths: response?.data?.items
-        ? context.locales.flatMap((locale: string) =>
-            response.data.items.map((listing) => ({
-              params: { id: listing.id, slug: listing.urlSlug },
-              locale: locale,
-            }))
-          )
-        : [],
-      fallback: "blocking",
-    }
-  } catch (error) {
-    console.error("listings getStaticPaths error = ", error)
-    return {
-      paths: [],
-      fallback: "blocking",
-    }
-  }
-} */
+export const getStaticPaths: GetStaticPaths = () => {
+  return { paths: [], fallback: "blocking" }
+}
 
-export async function getServerSideProps(context: {
+export const getStaticProps: GetStaticProps = async (context: {
   params: Record<string, string>
   locale: string
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  req: any
-}) {
+}) => {
   let response
   try {
     response = await axios.get(`${process.env.backendApiBase}/listings/${context.params.id}`, {
       headers: {
         language: context.locale,
         passkey: process.env.API_PASS_KEY,
-        "x-forwarded-for":
-          context.req.headers["x-forwarded-for"] ?? context.req.socket.remoteAddress,
       },
     })
   } catch (e) {
     return { notFound: true }
   }
-  const jurisdiction = fetchJurisdictionByName(context.req)
+  const jurisdiction = fetchJurisdictionByName()
 
-  return { props: { listing: response.data, jurisdiction: await jurisdiction } }
+  return { props: { listing: response.data, jurisdiction: await jurisdiction }, revalidate: 30 }
 }

--- a/ui-load-tester.rb
+++ b/ui-load-tester.rb
@@ -8,7 +8,7 @@
 #   check out how `ab` works. On mac you can run `man ab` in a terminal to get the man page for ab
 #   you can change the n arguments on these calls to increase the total number of requests
 #   you can change the c arguments on these calls to increase the throughput basically (number of requests made concurrently)
-#   you can change the url arguments on these calls to direct which url will recieve the traffic
+#   you can change the url arguments on these calls to direct which url will receive the traffic
 #   to execute once your changes are made from the root directory run `ruby tester.rb`
 #   In order to test mem usage you can attach the node debugger to either the public or partner sites and track mem usage that way 
 #   You can also track cpu usage, or track it through a cpu activity monitor

--- a/ui-load-tester.rb
+++ b/ui-load-tester.rb
@@ -1,0 +1,29 @@
+# What is this:
+#   This is a ruby script to load test any of our front end urls
+
+# Why is this written in ruby?
+#   Ruby supports multithreading much better natively than node/js does
+
+# How to use:
+#   check out how `ab` works. On mac you can run `man ab` in a terminal to get the man page for ab
+#   you can change the n arguments on these calls to increase the total number of requests
+#   you can change the c arguments on these calls to increase the throughput basically (number of requests made concurrently)
+#   you can change the url arguments on these calls to direct which url will recieve the traffic
+#   to execute once your changes are made from the root directory run `ruby tester.rb`
+#   In order to test mem usage you can attach the node debugger to either the public or partner sites and track mem usage that way 
+#   You can also track cpu usage, or track it through a cpu activity monitor
+
+def main()
+  # call main page english
+  spawnProcess(100, 10, "http://localhost:3000/")
+end
+  
+  # n: the number of requests
+  # c:  the number of calls made concurrently
+  # url: the url you are trying to hit
+  def spawnProcess(n, c, url)
+    spawn("ab -n #{n} -c #{c} \"#{url}\"")
+  end
+  
+  main()
+  

--- a/utilities/ui-load-tester.rb
+++ b/utilities/ui-load-tester.rb
@@ -5,11 +5,12 @@
 #   Ruby supports multithreading much better natively than node/js does
 
 # How to use:
-#   check out how `ab` works. On mac you can run `man ab` in a terminal to get the man page for ab
+#   `ab` is a benchmarking utility, its used here to mock traffic to whatever url you pass along
+#   You can check out how `ab` works separately. On mac you can run `man ab` in a terminal to get the manual for ab
 #   you can change the n arguments on these calls to increase the total number of requests
 #   you can change the c arguments on these calls to increase the throughput basically (number of requests made concurrently)
 #   you can change the url arguments on these calls to direct which url will receive the traffic
-#   to execute once your changes are made from the root directory run `ruby tester.rb`
+#   to execute once your changes are made from the root directory run `yarn ui-load-test`
 #   In order to test mem usage you can attach the node debugger to either the public or partner sites and track mem usage that way 
 #   You can also track cpu usage, or track it through a cpu activity monitor
 


### PR DESCRIPTION
This PR addresses https://github.com/metrotranscom/doorway/issues/1271

- [x] Addresses the issue in full

## Description
This adds a ui load tester script

more importantly, this changes how we get listing data for the public listing detail page from `getServerSideProps` to `getStaticProps` this should mean that instead of the server generating the HTML for the public listing detail page each time it generates it once then holds onto it for 30 seconds before rebuilding it

## How Can This Be Tested/Reviewed?
Stand up the public site locally and verify you can hit the listing detail page
Aim the load tester at your listing detail page and make sure it stands up to most load tests (it'll break down at higher ends still) 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
