### PR TITLE
fix: update navbar to match jurisdiction color

### DIFF
--- a/sites/public/src/layouts/application-form.module.scss
+++ b/sites/public/src/layouts/application-form.module.scss
@@ -41,6 +41,7 @@
     }
 
     .desktop-nav {
+      --bloom-color-primary: var(--seeds-color-primary);
       display: block;
       @media (max-width: theme("screens.sm")) {
         display: none;
@@ -48,6 +49,7 @@
     }
 
     .mobile-nav {
+      --bloom-color-primary: var(--seeds-color-primary);
       display: none;
       @media (max-width: theme("screens.sm")) {
         display: block;


### PR DESCRIPTION
This PR addresses #4897

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Set the applications process progress navbar color override to match the jurisdictions 

## How Can This Be Tested/Reviewed?

* Set app Jurisdiction to `Bloomington`
* Go to `/listings` and start the online application process
* The navigation progress bar should be in the jurisdiction color (in this case, blue)
* Switch application jurisdiction to `Lakeview`
* Repeat the application process 
* The navigation progress bar should match the new jurisdiction color (in this case, purple)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
