### PR TITLE
feat: add additional waitlist size on public

### DIFF
--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -837,6 +837,7 @@
   "listings.waitlist.closed": "Waitlist Closed",
   "listings.waitlist.currentSize": "Current Waitlist Size",
   "listings.waitlist.finalSize": "Final Waitlist Size",
+  "listings.waitlist.isClosed": "Waitlist is closed",
   "listings.waitlist.isOpen": "Waitlist is open",
   "listings.waitlist.label": "Waitlist",
   "listings.waitlist.open": "Open Waitlist",

--- a/sites/public/src/components/listing/listing_sections/Availability.module.scss
+++ b/sites/public/src/components/listing/listing_sections/Availability.module.scss
@@ -9,3 +9,8 @@
     margin-inline: var(--seeds-s4);
   }
 }
+
+.bold-text {
+  font-weight: var(--seeds-font-weight-bold);
+  color: var(--seeds-text-color-light);
+}

--- a/sites/public/src/components/listing/listing_sections/Availability.tsx
+++ b/sites/public/src/components/listing/listing_sections/Availability.tsx
@@ -66,6 +66,10 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
     jurisdiction,
     FeatureFlagEnum.swapCommunityTypeWithPrograms
   )
+  const showAdditionalWaitlistFields = isFeatureFlagOn(
+    jurisdiction,
+    FeatureFlagEnum.enableWaitlistAdditionalFields
+  )
 
   const statusMessage = getListingStatusMessageContent(
     listing.status,
@@ -77,11 +81,18 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
     false
   )
   const content = getAvailabilityContent(listing.reviewOrderType, listing.status)
-  const subheading = getAvailabilitySubheading(listing.waitlistOpenSpots, listing.unitsAvailable)
+  const unitsAvailable = listing.unitGroups
+    ? listing.unitGroups.reduce((acc, curr) => acc + curr.totalAvailable, 0)
+    : listing.unitsAvailable
+  const subheading = getAvailabilitySubheading(
+    showAdditionalWaitlistFields ? null : listing.waitlistOpenSpots,
+    unitsAvailable
+  )
 
   const hideAvailabilityDetails =
     listing.status === ListingsStatusEnum.closed ||
     (enableMarketingStatus && listing.marketingType === MarketingTypeEnum.comingSoon)
+
   return (
     <>
       <div className={styles["status-messages"]}>
@@ -119,6 +130,40 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
           {content && <p className={"seeds-m-bs-label"}>{content}</p>}
           {subheading && <p className={`seeds-m-bs-label`}>{subheading}</p>}
         </Card.Section>
+        {showAdditionalWaitlistFields && (
+          <Card.Section divider="flush">
+            <Heading size={"md"} priority={3}>
+              {t("listings.waitlist.open")}
+            </Heading>
+            <p className={styles["bold-subheader"]}>
+              {listing.isWaitlistOpen
+                ? t("listings.waitlist.isOpen")
+                : t("listings.waitlist.isClosed")}
+            </p>
+            {listing.isWaitlistOpen && (
+              <p className={`${listingStyles["thin-heading-sm"]} seeds-m-b-label`}>
+                {t("listings.waitlist.submitForWaitlist")}
+              </p>
+            )}
+            {listing.waitlistCurrentSize && (
+              <p className={"seeds-m-be-text"}>
+                {`${listing.waitlistCurrentSize} ${t(
+                  "listings.waitlist.currentSize"
+                ).toLowerCase()}`}
+              </p>
+            )}
+            {listing.waitlistOpenSpots && (
+              <p className={`seeds-m-be-text ${styles["bold-text"]}`}>
+                {`${listing.waitlistOpenSpots} ${t("listings.waitlist.openSlots").toLowerCase()}`}
+              </p>
+            )}
+            {listing.waitlistMaxSize && (
+              <p>{`${listing.waitlistMaxSize} ${t(
+                "listings.waitlist.finalSize"
+              ).toLowerCase()}`}</p>
+            )}
+          </Card.Section>
+        )}
         {!swapCommunityTypeWithPrograms && listing.reservedCommunityTypes && (
           <Card.Section divider="flush">
             <Heading size={"md"} priority={3}>


### PR DESCRIPTION
This PR addresses #4776 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds open waitlist section on public listing view.
Also it modifies a bit lottery section to show sum of total units from unit Groups

## How Can This Be Tested/Reviewed?

Enable `enableWaitlistAdditionalFields` set `Do you want to show a waitlist size?` on partners site (edit listing) to yes and fill values. It should show section with set numbers

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
