### PR TITLE
fix: multiselect question public hook

### DIFF
--- a/api/src/permission-configs/permission_policy.csv
+++ b/api/src/permission-configs/permission_policy.csv
@@ -16,6 +16,7 @@ p, partner, asset, true, .*
 p, admin, multiselectQuestion, true, .*
 p, jurisdictionAdmin, multiselectQuestion, true, .*
 p, partner, multiselectQuestion, true, .*
+p, anonymous, multiselectQuestion, true, read
 
 p, admin, applicationMethod, true, .*
 p, jurisdictionAdmin, applicationMethod, true, .*

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -703,12 +703,12 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
   });
 
   describe('Testing multiselect questions endpoints', () => {
-    it('should error as forbidden for list endpoint', async () => {
+    it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
         .get(`/multiselectQuestions?`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
     it('should error as forbidden for retrieve endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -711,7 +711,7 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .expect(200);
     });
 
-    it('should error as forbidden for retrieve endpoint', async () => {
+    it('should succeed for retrieve endpoint', async () => {
       const multiselectQuestionA = await prisma.multiselectQuestions.create({
         data: multiselectQuestionFactory(jurisdictionId),
       });
@@ -720,7 +720,7 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .get(`/multiselectQuestions/${multiselectQuestionA.id}`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
     it('should error as forbidden for create endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -755,12 +755,12 @@ describe('Testing Permissioning of endpoints as public user', () => {
   });
 
   describe('Testing multiselect questions endpoints', () => {
-    it('should error as forbidden for list endpoint', async () => {
+    it('should succeed for list endpoint', async () => {
       await request(app.getHttpServer())
         .get(`/multiselectQuestions?`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
     it('should error as forbidden for retrieve endpoint', async () => {

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -763,7 +763,7 @@ describe('Testing Permissioning of endpoints as public user', () => {
         .expect(200);
     });
 
-    it('should error as forbidden for retrieve endpoint', async () => {
+    it('should succeed for retrieve endpoint', async () => {
       const multiselectQuestionA = await prisma.multiselectQuestions.create({
         data: multiselectQuestionFactory(jurisdictionAId),
       });
@@ -772,7 +772,7 @@ describe('Testing Permissioning of endpoints as public user', () => {
         .get(`/multiselectQuestions/${multiselectQuestionA.id}`)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
     it('should error as forbidden for create endpoint', async () => {

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -1,14 +1,18 @@
 import { useContext, useEffect, useState } from "react"
 import axios from "axios"
 import { useRouter } from "next/router"
+import qs from "qs"
 import {
   EnumListingFilterParamsComparison,
+  EnumMultiselectQuestionFilterParamsComparison,
   FeatureFlagEnum,
   Jurisdiction,
   Listing,
   ListingFilterParams,
   ListingOrderByKeys,
   ListingsStatusEnum,
+  MultiselectQuestionsApplicationSectionEnum,
+  MultiselectQuestionFilterParams,
   OrderByEnum,
   PaginatedListing,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
@@ -239,4 +243,42 @@ export async function fetchJurisdictionByName(req?: any) {
   }
 
   return jurisdiction
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function fetchMultiselectData(req: any, jurisdictionId: string) {
+  try {
+    const headers = {
+      passkey: process.env.API_PASS_KEY,
+    }
+    if (req) {
+      headers["x-forwarded-for"] = req.headers["x-forwarded-for"] ?? req.socket.remoteAddress
+    }
+
+    const params: {
+      filter: MultiselectQuestionFilterParams[]
+    } = {
+      filter: [
+        {
+          $comparison: EnumMultiselectQuestionFilterParamsComparison["="],
+          applicationSection: MultiselectQuestionsApplicationSectionEnum.programs,
+        },
+        {
+          $comparison: EnumMultiselectQuestionFilterParamsComparison["IN"],
+          jurisdiction: jurisdictionId && jurisdictionId !== "" ? jurisdictionId : undefined,
+        },
+      ],
+    }
+
+    const paramsString = qs.stringify(params)
+
+    const multiselectDataResponse = await axios.get(
+      `${process.env.backendApiBase}/multiselectQuestions?${paramsString}`,
+      {
+        headers,
+      }
+    )
+    return multiselectDataResponse?.data
+  } catch (error) {
+    console.log("error = ", error)
+  }
 }

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -244,6 +244,7 @@ export async function fetchJurisdictionByName(req?: any) {
 
   return jurisdiction
 }
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function fetchMultiselectData(req: any, jurisdictionId: string) {
   try {

--- a/sites/public/src/pages/listings-closed.tsx
+++ b/sites/public/src/pages/listings-closed.tsx
@@ -1,13 +1,15 @@
 import React from "react"
-import { fetchClosedListings, fetchJurisdictionByName } from "../lib/hooks"
-import { ListingBrowse, TabsIndexEnum } from "../components/browse/ListingBrowse"
-import { ListingsProps } from "./listings"
+import { useRouter } from "next/router"
+import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import {
   decodeQueryToFilterData,
   encodeFilterDataToBackendFilters,
   isFiltered,
 } from "../components/browse/FilterDrawerHelpers"
-import { useRouter } from "next/router"
+import { ListingBrowse, TabsIndexEnum } from "../components/browse/ListingBrowse"
+import { isFeatureFlagOn } from "../lib/helpers"
+import { fetchClosedListings, fetchJurisdictionByName, fetchMultiselectData } from "../lib/hooks"
+import { ListingsProps } from "./listings"
 
 export default function ListingsPageClosed(props: ListingsProps) {
   const router = useRouter()
@@ -39,12 +41,19 @@ export async function getServerSideProps(context: { req: any; query: any }) {
     closedListings = await fetchClosedListings(context.req, Number(context.query.page) || 1)
   }
   const jurisdiction = await fetchJurisdictionByName(context.req)
+  const multiselectData = isFeatureFlagOn(
+    jurisdiction,
+    FeatureFlagEnum.swapCommunityTypeWithPrograms
+  )
+    ? await fetchMultiselectData(context.req, jurisdiction?.id)
+    : undefined
 
   return {
     props: {
       closedListings: closedListings?.items || [],
       paginationData: closedListings?.items?.length ? closedListings.meta : null,
       jurisdiction: jurisdiction,
+      multiselectData: multiselectData,
     },
   }
 }

--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -6,13 +6,13 @@ import {
   Listing,
   MultiselectQuestion,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { ListingBrowse, TabsIndexEnum } from "../components/browse/ListingBrowse"
-import { ListingBrowseDeprecated } from "../components/browse/ListingBrowseDeprecated"
 import {
   decodeQueryToFilterData,
   encodeFilterDataToBackendFilters,
   isFiltered,
 } from "../components/browse/FilterDrawerHelpers"
+import { ListingBrowse, TabsIndexEnum } from "../components/browse/ListingBrowse"
+import { ListingBrowseDeprecated } from "../components/browse/ListingBrowseDeprecated"
 import { isFeatureFlagOn } from "../lib/helpers"
 import {
   fetchClosedListings,

--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -6,12 +6,6 @@ import {
   Listing,
   MultiselectQuestion,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import {
-  fetchClosedListings,
-  fetchJurisdictionByName,
-  fetchMultiselectData,
-  fetchOpenListings,
-} from "../lib/hooks"
 import { ListingBrowse, TabsIndexEnum } from "../components/browse/ListingBrowse"
 import { ListingBrowseDeprecated } from "../components/browse/ListingBrowseDeprecated"
 import {
@@ -20,6 +14,12 @@ import {
   isFiltered,
 } from "../components/browse/FilterDrawerHelpers"
 import { isFeatureFlagOn } from "../lib/helpers"
+import {
+  fetchClosedListings,
+  fetchJurisdictionByName,
+  fetchMultiselectData,
+  fetchOpenListings,
+} from "../lib/hooks"
 
 export interface ListingsProps {
   openListings: Listing[]

--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { useRouter } from "next/router"
 import {
   FeatureFlagEnum,
   Jurisdiction,
@@ -18,7 +19,6 @@ import {
   encodeFilterDataToBackendFilters,
   isFiltered,
 } from "../components/browse/FilterDrawerHelpers"
-import { useRouter } from "next/router"
 import { isFeatureFlagOn } from "../lib/helpers"
 
 export interface ListingsProps {


### PR DESCRIPTION
This PR addresses #4795 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

As part of adding filtering by community type (detroit's version so functionally programs in the backend), we had to update the permissioning and add a new hook to the public side.

## How Can This Be Tested/Reviewed?

This can be tested by adding a console log for props.multiselectData and ensure the appropiate community types are coming through on a jurisdiction with swapCommunityTypeWithPrograms enabled.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
