### PR TITLE
feat: remove disableCommonApplication flag in staging seed

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -73,7 +73,6 @@ export const stagingSeed = async (
   const lakeviewJurisdiction = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Lakeview', {
       featureFlags: [
-        FeatureFlagEnum.disableCommonApplication,
         FeatureFlagEnum.disableJurisdictionalAdmin,
         FeatureFlagEnum.enableAccessibilityFeatures,
         FeatureFlagEnum.enableAdditionalResources,


### PR DESCRIPTION
This PR addresses #4895

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

A simple change, just removes setting the `disableCommonApplication` flag for the Lakeview test jurisdiction.

## How Can This Be Tested/Reviewed?

Reseed, then set the public app jurisdiction in `.env` to `Lakeview`, then see that you can apply to one of the listings. Of if you log in, you can access My Applications.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
