### PR TITLE
fix: undefined to null

### DIFF
--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -77,7 +77,7 @@ export async function getServerSideProps(context: { req: any; query: any }) {
     FeatureFlagEnum.swapCommunityTypeWithPrograms
   )
     ? await fetchMultiselectData(context.req, jurisdiction?.id)
-    : undefined
+    : null
 
   return {
     props: {


### PR DESCRIPTION
This PR addresses #4795 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

This is a quick follow up to #4930 since the undefined default cannot be serialized when the jurisdiction does not have swapCommunityTypesForPrograms enabled. The error below explains the simple fix
![Screenshot 2025-06-02 at 11 40 44 PM](https://github.com/user-attachments/assets/3672672f-e5a8-4f66-8f12-b217a7dd10d0)

## How Can This Be Tested/Reviewed?

Reseed, run public with Bloomington Jurisdiction, and the listings page should render without the blocking error above.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
