### PR TITLE
feat: add hmi and occupancy for unit groups

### DIFF
--- a/shared-helpers/src/views/occupancyFormatting.tsx
+++ b/shared-helpers/src/views/occupancyFormatting.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import { StandardTableData, t } from "@bloom-housing/ui-components"
-import { Listing, UnitTypeEnum } from "../types/backend-swagger"
+import { StackedTableRow, StandardTableData, t } from "@bloom-housing/ui-components"
+import { Listing, UnitType, UnitTypeEnum } from "../types/backend-swagger"
 
 export const getOccupancy = (minOcc?: number | null, maxOcc?: number | null) => {
   if (minOcc && maxOcc && minOcc < maxOcc) {
@@ -55,17 +55,68 @@ export const stackedOccupancyTable = (listing: Listing) => {
   } else return []
 }
 
-export const getOccupancyDescription = (listing: Listing) => {
-  const unitsSummarized = listing.unitsSummarized
-  if (
-    unitsSummarized &&
-    unitsSummarized.unitTypes &&
-    unitsSummarized.unitTypes.map((unitType) => unitType.name).includes(UnitTypeEnum.SRO)
-  ) {
-    return unitsSummarized.unitTypes.length == 1
-      ? t("listings.occupancyDescriptionAllSro")
-      : t("listings.occupancyDescriptionSomeSro")
+export const stackedUnitGroupsOccupancyTable = (listing: Listing) => {
+  const getUnitTypeString = (unitTypes: UnitType[]) => {
+    return unitTypes.reduce((acc, curr, index) => {
+      return index > 0
+        ? `${acc}, ${t("listings.unitTypes." + curr.name)}`
+        : t("listings.unitTypes." + curr.name)
+    }, "")
+  }
+
+  const sortedUnitGroups = listing.unitGroups
+    ?.sort((a, b) => {
+      if (a.unitTypes && b.unitTypes) {
+        return (
+          a.unitTypes.sort((c, d) => c.numBedrooms - d.numBedrooms)[0].numBedrooms -
+          b.unitTypes.sort((e, f) => e.numBedrooms - f.numBedrooms)[0].numBedrooms
+        )
+      }
+      return 0
+    })
+    .filter((unitGroup) => unitGroup.maxOccupancy || unitGroup.minOccupancy)
+
+  const tableRows = sortedUnitGroups?.reduce<Record<string, StackedTableRow>[]>((acc, curr) => {
+    const unitTypeString = getUnitTypeString(curr?.unitTypes || [])
+    const occupancyString = getOccupancy(curr.minOccupancy, curr.maxOccupancy)
+    if (occupancyString) {
+      acc.push({
+        unitType: {
+          cellText: unitTypeString,
+        },
+        occupancy: { cellText: occupancyString },
+      })
+    }
+    return acc
+  }, [])
+  return tableRows
+}
+
+export const getOccupancyDescription = (listing: Listing, enableUnitGroups: boolean) => {
+  if (enableUnitGroups) {
+    const hasSRO = listing.unitGroups?.some((unitGroup) =>
+      unitGroup.unitTypes?.some((unitType) => unitType.name === UnitTypeEnum.SRO)
+    )
+    const unitTypes = listing.unitGroups?.map((unitGroup) => unitGroup.unitTypes)
+    if (hasSRO) {
+      return unitTypes?.length == 1
+        ? t("listings.occupancyDescriptionAllSro")
+        : t("listings.occupancyDescriptionSomeSro")
+    } else {
+      return t("listings.occupancyDescriptionNoSro")
+    }
   } else {
-    return t("listings.occupancyDescriptionNoSro")
+    const unitsSummarized = listing.unitsSummarized
+    if (
+      unitsSummarized &&
+      unitsSummarized.unitTypes &&
+      unitsSummarized.unitTypes.map((unitType) => unitType.name).includes(UnitTypeEnum.SRO)
+    ) {
+      return unitsSummarized.unitTypes.length == 1
+        ? t("listings.occupancyDescriptionAllSro")
+        : t("listings.occupancyDescriptionSomeSro")
+    } else {
+      return t("listings.occupancyDescriptionNoSro")
+    }
   }
 }

--- a/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
+++ b/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
@@ -26,6 +26,7 @@ import {
   cloudinaryPdfFromId,
   getOccupancyDescription,
   stackedOccupancyTable,
+  stackedUnitGroupsOccupancyTable,
 } from "@bloom-housing/shared-helpers"
 import { downloadExternalPDF, isFeatureFlagOn } from "../../lib/helpers"
 import { CardList, ContentCardProps } from "../../patterns/CardList"
@@ -236,6 +237,50 @@ export const getStackedHmiData = (listing: Listing) => {
   )
 }
 
+export const getStackedUnitGroupsHmiData = (listing: Listing) => {
+  if (listing.unitGroups !== undefined && listing.unitGroups.length > 0) {
+    const { rows } = listing.unitGroupsSummarized.householdMaxIncomeSummary
+
+    return rows.map((row) => {
+      const obj = {}
+
+      for (const key in row) {
+        if (key === "householdSize") {
+          obj[key] = {
+            cellText: `${row[key]} ${row[key] === "1" ? t("t.person") : t("t.people")}`,
+          }
+        } else {
+          obj[key] = {
+            cellText: `$${row[key].toLocaleString("en")} ${t("t.perYear")}`,
+          }
+        }
+      }
+
+      return obj
+    })
+  }
+
+  return []
+}
+
+export const getUnitGroupsHmiHeaders = (listing: Listing): TableHeaders => {
+  const hmiHeaders: TableHeaders = {}
+
+  if (listing.unitGroups !== undefined && listing.unitGroups.length > 0) {
+    const { columns } = listing.unitGroupsSummarized.householdMaxIncomeSummary
+
+    for (const key in columns) {
+      if (key === "householdSize") {
+        hmiHeaders[key] = t(`listings.householdSize`)
+      } else {
+        hmiHeaders[key] = t("listings.percentAMIUnit", { percent: key.replace("percentage", "") })
+      }
+    }
+  }
+
+  return hmiHeaders
+}
+
 export type AddressLocation = "dropOff" | "pickUp" | "mailIn"
 
 export const getAddress = (
@@ -310,6 +355,7 @@ export const getEligibilitySections = (
     jurisdiction,
     FeatureFlagEnum.swapCommunityTypeWithPrograms
   )
+  const enableUnitGroups = isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableUnitGroups)
 
   // Reserved community type
   if (!swapCommunityTypeWithPrograms && listing.reservedCommunityTypes) {
@@ -336,8 +382,14 @@ export const getEligibilitySections = (
       : t("listings.forIncomeCalculations"),
     content: (
       <StackedTable
-        headers={(listing?.unitsSummarized?.hmi?.columns || []) as TableHeaders}
-        stackedData={getStackedHmiData(listing)}
+        headers={
+          enableUnitGroups
+            ? getUnitGroupsHmiHeaders(listing)
+            : ((listing?.unitsSummarized?.hmi?.columns || []) as TableHeaders)
+        }
+        stackedData={
+          enableUnitGroups ? getStackedUnitGroupsHmiData(listing) : getStackedHmiData(listing)
+        }
       />
     ),
   })
@@ -345,14 +397,18 @@ export const getEligibilitySections = (
   // Occupancy
   eligibilityFeatures.push({
     header: t("t.occupancy"),
-    subheader: getOccupancyDescription(listing),
+    subheader: getOccupancyDescription(listing, enableUnitGroups),
     content: (
       <StackedTable
         headers={{
           unitType: "t.unitType",
           occupancy: "t.occupancy",
         }}
-        stackedData={stackedOccupancyTable(listing)}
+        stackedData={
+          enableUnitGroups
+            ? stackedUnitGroupsOccupancyTable(listing)
+            : stackedOccupancyTable(listing)
+        }
       />
     ),
   })

--- a/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
+++ b/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
@@ -343,6 +343,7 @@ export type EligibilitySection = {
   subheader?: string
   content?: React.ReactNode
   note?: string
+  hide?: boolean
 }
 
 export const getEligibilitySections = (
@@ -392,6 +393,7 @@ export const getEligibilitySections = (
         }
       />
     ),
+    hide: enableUnitGroups && listing.unitGroups?.length === 0,
   })
 
   // Occupancy
@@ -411,6 +413,7 @@ export const getEligibilitySections = (
         }
       />
     ),
+    hide: enableUnitGroups && listing.unitGroups?.length === 0,
   })
 
   // Rental Assistance

--- a/sites/public/src/components/listing/listing_sections/Eligibility.tsx
+++ b/sites/public/src/components/listing/listing_sections/Eligibility.tsx
@@ -30,20 +30,22 @@ export const Eligibility = ({ eligibilitySections, section8Acceptance }: Eligibi
       contentClassName={styles["mobile-collapse-padding"]}
     >
       <ol>
-        {eligibilitySections.map((section, index) => {
-          return (
-            <OrderedSection
-              order={index + 1}
-              title={section.header}
-              subtitle={section.subheader}
-              note={section.note}
-              key={index}
-              divider={index < eligibilitySections.length - 1}
-            >
-              {section.content}
-            </OrderedSection>
-          )
-        })}
+        {eligibilitySections
+          .filter((section) => !section.hide)
+          .map((section, index) => {
+            return (
+              <OrderedSection
+                order={index + 1}
+                title={section.header}
+                subtitle={section.subheader}
+                note={section.note}
+                key={index}
+                divider={index < eligibilitySections.length - 1}
+              >
+                {section.content}
+              </OrderedSection>
+            )
+          })}
       </ol>
     </CollapsibleSection>
   )


### PR DESCRIPTION
This PR addresses #4887

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

It adds hmi table and occupancy for unit groups. As unit groups are not required i hide those sections when unit groups length is 0

## How Can This Be Tested/Reviewed?

with enableUnitGroups add unit groups. It should now populate data in HMI and occupancy.
make sure it works as before with units

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
