### PR TITLE
fix: change path to housing-basics

### DIFF
--- a/sites/public/src/components/assistance/Assistance.tsx
+++ b/sites/public/src/components/assistance/Assistance.tsx
@@ -33,7 +33,7 @@ const Assistance = () => {
               iconClass={styles["item-icon"]}
             >
               <Card.Section className={styles["item-link"]}>
-                <Link href={"/how-it-works"}>{t("assistance.applyToHousingLink")}</Link>
+                <Link href={"/housing-basics"}>{t("assistance.applyToHousingLink")}</Link>
               </Card.Section>
             </BloomCard>
             <BloomCard


### PR DESCRIPTION
This PR addresses #4423

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

It is request from [this comment](https://github.com/bloom-housing/bloom/issues/4423#issuecomment-2920367664)
It will change path to housing basics page (which is on detroit for now). Not sure if that should be `how-it-works` for core
i assume it was just placeholder.

## How Can This Be Tested/Reviewed?

go to `/get-assistance` page and click `Read about how it works`. It should redirect to `/housing-basics` (page itself is in bloom-detroit, so it will return 404)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
