### PR TITLE
fix: hide reservedCommunityTypes tags when flag turned off

### DIFF
--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -13,6 +13,7 @@ import {
   getListingStackedGroupTableData,
   getListingStackedTableData,
   getListingStatusMessage,
+  isFeatureFlagOn,
 } from "../../lib/helpers"
 import { getListingTags } from "../listing/listing_sections/MainDetails"
 import styles from "./ListingCard.module.scss"
@@ -35,11 +36,14 @@ export const ListingCard = ({
   setFavorited,
   showHomeType,
 }: ListingCardProps) => {
-  const enableIsVerified = jurisdiction.featureFlags.find(
-    (flag) => flag.name === FeatureFlagEnum.enableIsVerified
-  )?.active
   const imageUrl = imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))[0]
-  const listingTags = getListingTags(listing, true, !showHomeType, enableIsVerified)
+  const listingTags = getListingTags(
+    listing,
+    true,
+    !showHomeType,
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableIsVerified),
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.swapCommunityTypeWithPrograms)
+  )
   const status = getListingApplicationStatus(listing, true, true)
   const actions = []
 

--- a/sites/public/src/components/home/MinimalListingCard.tsx
+++ b/sites/public/src/components/home/MinimalListingCard.tsx
@@ -21,7 +21,8 @@ export const MinimalListingCard = ({ listing, jurisdiction }: MinimalListingCard
     listing,
     true,
     !isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableHomeType),
-    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableIsVerified)
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableIsVerified),
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.swapCommunityTypeWithPrograms)
   )
 
   return (

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -19,6 +19,7 @@ import FavoriteButton from "../../shared/FavoriteButton"
 import { Availability } from "./Availability"
 import listingStyles from "../ListingViewSeeds.module.scss"
 import styles from "./MainDetails.module.scss"
+import { isFeatureFlagOn } from "../../../lib/helpers"
 
 type MainDetailsProps = {
   listing: Listing
@@ -39,7 +40,8 @@ export const getListingTags = (
   listing: Listing,
   hideReviewTags?: boolean,
   hideHomeTypeTag?: boolean,
-  enableIsVerified?: boolean
+  enableIsVerified?: boolean,
+  swapCommunityTypeWithPrograms?: boolean
 ): ListingTag[] => {
   const listingTags: ListingTag[] = []
 
@@ -58,7 +60,7 @@ export const getListingTags = (
     })
   }
 
-  if (listing.reservedCommunityTypes) {
+  if (!swapCommunityTypeWithPrograms && listing.reservedCommunityTypes) {
     listingTags.push({
       title: t(`listings.reservedCommunityTypes.${listing.reservedCommunityTypes.name}`),
       variant: "highlight-warm",
@@ -98,13 +100,16 @@ export const MainDetails = ({
   showHomeType,
 }: MainDetailsProps) => {
   if (!listing) return
-  const enableIsVerified = jurisdiction.featureFlags.find(
-    (flag) => flag.name === FeatureFlagEnum.enableIsVerified
-  )?.active
 
   const googleMapsHref =
     "https://www.google.com/maps/place/" + oneLineAddress(listing.listingsBuildingAddress)
-  const listingTags = getListingTags(listing, true, !showHomeType, enableIsVerified)
+  const listingTags = getListingTags(
+    listing,
+    true,
+    !showHomeType,
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableIsVerified),
+    isFeatureFlagOn(jurisdiction, FeatureFlagEnum.swapCommunityTypeWithPrograms)
+  )
   return (
     <div>
       <ImageCard


### PR DESCRIPTION
This PR addresses #4886 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Hides `reservedCommunityTypes ` tag when `swapCommunityTypeWithPrograms` is set to `true`.

## How Can This Be Tested/Reviewed?

Add community tag with `swapCommunityTypeWithPrograms = false` (it should show that tag). then swap to `true` it should hide it

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
