### PR TITLE
feat: add unit groups unit types to paper form

### DIFF
--- a/sites/partners/__tests__/components/applications/sections/FormHouseholdDetails.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormHouseholdDetails.test.tsx
@@ -219,55 +219,6 @@ describe("<FormHouseholdDetails>", () => {
     expect(oneBedroomLabels).toHaveLength(1)
   })
 
-  it("handles unit groups with no unit types", () => {
-    render(
-      <FormProviderWrapper>
-        <FormHouseholdDetails
-          listingUnits={[]}
-          applicationUnitTypes={[]}
-          applicationAccessibilityFeatures={{
-            id: "id",
-            createdAt: new Date(),
-            updatedAt: new Date(),
-            mobility: true,
-            vision: true,
-            hearing: true,
-          }}
-          listingUnitGroups={[
-            {
-              id: "group1",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-              unitTypes: [], // Empty unit types
-            },
-            {
-              id: "group2",
-              createdAt: new Date(),
-              updatedAt: new Date(),
-              unitTypes: [
-                {
-                  id: "studio-type",
-                  createdAt: new Date(),
-                  updatedAt: new Date(),
-                  numBedrooms: 0,
-                  name: UnitTypeEnum.studio,
-                },
-              ],
-            },
-          ]}
-          enableUnitGroups={true}
-        />
-      </FormProviderWrapper>
-    )
-
-    expect(screen.getByText(/preferred unit sizes/i)).toBeInTheDocument()
-    expect(screen.getByRole("checkbox", { name: "Studio" })).toBeInTheDocument()
-    const unitTypeCheckboxes = screen
-      .getAllByRole("checkbox")
-      .filter((checkbox) => checkbox.getAttribute("name") === "application.preferredUnit")
-    expect(unitTypeCheckboxes).toHaveLength(1)
-  })
-
   it("displays all available unit types when unit groups contain all types", () => {
     render(
       <FormProviderWrapper>

--- a/sites/partners/__tests__/components/applications/sections/FormHouseholdDetails.test.tsx
+++ b/sites/partners/__tests__/components/applications/sections/FormHouseholdDetails.test.tsx
@@ -33,6 +33,8 @@ describe("<FormHouseholdDetails>", () => {
             vision: true,
             hearing: true,
           }}
+          listingUnitGroups={[]}
+          enableUnitGroups={false}
         />
       </FormProviderWrapper>
     )
@@ -59,5 +61,312 @@ describe("<FormHouseholdDetails>", () => {
     expect(screen.getByText(/household includes student or member nearing 18/i)).toBeInTheDocument()
     expect(screen.getAllByLabelText(/yes/i)).toHaveLength(2)
     expect(screen.getAllByLabelText(/no/i)).toHaveLength(2)
+  })
+
+  it("renders the form with unit groups when enabled", () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdDetails
+          listingUnits={[]}
+          applicationUnitTypes={[]}
+          applicationAccessibilityFeatures={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            mobility: true,
+            vision: true,
+            hearing: true,
+          }}
+          listingUnitGroups={[
+            {
+              id: "group1",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [
+                {
+                  id: "studio-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 0,
+                  name: UnitTypeEnum.studio,
+                },
+                {
+                  id: "one-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 1,
+                  name: UnitTypeEnum.oneBdrm,
+                },
+              ],
+            },
+            {
+              id: "group2",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [
+                {
+                  id: "two-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 2,
+                  name: UnitTypeEnum.twoBdrm,
+                },
+                {
+                  id: "three-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 3,
+                  name: UnitTypeEnum.threeBdrm,
+                },
+              ],
+            },
+          ]}
+          enableUnitGroups={true}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: /household details/i })
+    ).toBeInTheDocument()
+
+    expect(screen.getByText(/preferred unit sizes/i)).toBeInTheDocument()
+    expect(screen.getByLabelText("Studio")).toBeInTheDocument()
+    expect(screen.getByLabelText("1 Bedroom")).toBeInTheDocument()
+    expect(screen.getByLabelText("2 Bedroom")).toBeInTheDocument()
+    expect(screen.getByLabelText("3 Bedroom")).toBeInTheDocument()
+
+    expect(screen.getByText(/ada priorities selected/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/mobility impairments/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/vision impairments/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/hearing impairments/i)).toBeInTheDocument()
+
+    expect(screen.getByText(/expecting household changes/i)).toBeInTheDocument()
+    expect(screen.getByText(/household includes student or member nearing 18/i)).toBeInTheDocument()
+    expect(screen.getAllByLabelText(/yes/i)).toHaveLength(2)
+    expect(screen.getAllByLabelText(/no/i)).toHaveLength(2)
+  })
+
+  it("handles unit groups with duplicate unit types", () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdDetails
+          listingUnits={[]}
+          applicationUnitTypes={[]}
+          applicationAccessibilityFeatures={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            mobility: true,
+            vision: true,
+            hearing: true,
+          }}
+          listingUnitGroups={[
+            {
+              id: "group1",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [
+                {
+                  id: "studio-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 0,
+                  name: UnitTypeEnum.studio,
+                },
+                {
+                  id: "one-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 1,
+                  name: UnitTypeEnum.oneBdrm,
+                },
+              ],
+            },
+            {
+              id: "group2",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [
+                {
+                  id: "one-bdrm-type", // Duplicate - should only appear once
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 1,
+                  name: UnitTypeEnum.oneBdrm,
+                },
+                {
+                  id: "studio-type", // Duplicate - should only appear once
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 0,
+                  name: UnitTypeEnum.studio,
+                },
+              ],
+            },
+          ]}
+          enableUnitGroups={true}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByText(/preferred unit sizes/i)).toBeInTheDocument()
+
+    const studioLabels = screen.getAllByRole("checkbox", { name: "Studio" })
+    const oneBedroomLabels = screen.getAllByRole("checkbox", { name: "1 Bedroom" })
+
+    expect(studioLabels).toHaveLength(1)
+    expect(oneBedroomLabels).toHaveLength(1)
+  })
+
+  it("handles unit groups with no unit types", () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdDetails
+          listingUnits={[]}
+          applicationUnitTypes={[]}
+          applicationAccessibilityFeatures={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            mobility: true,
+            vision: true,
+            hearing: true,
+          }}
+          listingUnitGroups={[
+            {
+              id: "group1",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [], // Empty unit types
+            },
+            {
+              id: "group2",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [
+                {
+                  id: "studio-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 0,
+                  name: UnitTypeEnum.studio,
+                },
+              ],
+            },
+          ]}
+          enableUnitGroups={true}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByText(/preferred unit sizes/i)).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "Studio" })).toBeInTheDocument()
+    const unitTypeCheckboxes = screen
+      .getAllByRole("checkbox")
+      .filter((checkbox) => checkbox.getAttribute("name") === "application.preferredUnit")
+    expect(unitTypeCheckboxes).toHaveLength(1)
+  })
+
+  it("displays all available unit types when unit groups contain all types", () => {
+    render(
+      <FormProviderWrapper>
+        <FormHouseholdDetails
+          listingUnits={[]}
+          applicationUnitTypes={[]}
+          applicationAccessibilityFeatures={{
+            id: "id",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            mobility: true,
+            vision: true,
+            hearing: true,
+          }}
+          listingUnitGroups={[
+            {
+              id: "group1",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [
+                {
+                  id: "studio-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 0,
+                  name: UnitTypeEnum.studio,
+                },
+                {
+                  id: "one-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 1,
+                  name: UnitTypeEnum.oneBdrm,
+                },
+                {
+                  id: "two-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 2,
+                  name: UnitTypeEnum.twoBdrm,
+                },
+                {
+                  id: "three-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 3,
+                  name: UnitTypeEnum.threeBdrm,
+                },
+              ],
+            },
+            {
+              id: "group2",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              unitTypes: [
+                {
+                  id: "four-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 4,
+                  name: UnitTypeEnum.fourBdrm,
+                },
+                {
+                  id: "five-bdrm-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 5,
+                  name: UnitTypeEnum.fiveBdrm,
+                },
+                {
+                  id: "sro-type",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  numBedrooms: 0,
+                  name: UnitTypeEnum.SRO,
+                },
+              ],
+            },
+          ]}
+          enableUnitGroups={true}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(screen.getByText(/preferred unit sizes/i)).toBeInTheDocument()
+
+    // Test all unit types are displayed
+    expect(screen.getByRole("checkbox", { name: "Studio" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "1 Bedroom" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "2 Bedroom" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "3 Bedroom" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "4 Bedroom" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "5 Bedroom" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "SRO" })).toBeInTheDocument()
+
+    // Verify we have all 7 unit type checkboxes
+    const unitTypeCheckboxes = screen
+      .getAllByRole("checkbox")
+      .filter((checkbox) => checkbox.getAttribute("name") === "application.preferredUnit")
+    expect(unitTypeCheckboxes).toHaveLength(7)
   })
 })

--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -10,6 +10,7 @@ import {
   ApplicationReviewStatusEnum,
   ApplicationStatusEnum,
   ApplicationUpdate,
+  FeatureFlagEnum,
   HouseholdMember,
   MultiselectQuestionsApplicationSectionEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
@@ -40,6 +41,12 @@ type AlertErrorType = "api" | "form"
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormProps) => {
   const { listingDto } = useSingleListingData(listingId)
+  const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
+
+  const enableUnitGroups = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableUnitGroups,
+    listingDto?.jurisdictions.id
+  )
 
   const preferences = listingSectionQuestions(
     listingDto,
@@ -227,8 +234,10 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
 
                     <FormHouseholdDetails
                       listingUnits={units}
+                      listingUnitGroups={listingDto?.unitGroups}
                       applicationUnitTypes={application?.preferredUnitTypes}
                       applicationAccessibilityFeatures={application?.accessibility}
+                      enableUnitGroups={enableUnitGroups}
                     />
 
                     <FormMultiselectQuestions

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdDetails.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdDetails.tsx
@@ -2,11 +2,16 @@ import React from "react"
 import { useFormContext } from "react-hook-form"
 import { t, Field, FieldGroup } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
-import { getUniqueUnitTypes, adaFeatureKeys } from "@bloom-housing/shared-helpers"
+import {
+  getUniqueUnitTypes,
+  adaFeatureKeys,
+  getUniqueUnitGroupUnitTypes,
+} from "@bloom-housing/shared-helpers"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 import {
   Accessibility,
   Unit,
+  UnitGroup,
   UnitType,
   YesNoEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
@@ -15,22 +20,38 @@ type FormHouseholdDetailsProps = {
   listingUnits: Unit[]
   applicationUnitTypes: UnitType[]
   applicationAccessibilityFeatures: Accessibility
+  listingUnitGroups: UnitGroup[]
+  enableUnitGroups: boolean
 }
 
 const FormHouseholdDetails = ({
   listingUnits,
   applicationUnitTypes,
   applicationAccessibilityFeatures,
+  listingUnitGroups,
+  enableUnitGroups,
 }: FormHouseholdDetailsProps) => {
   const formMethods = useFormContext()
-
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register } = formMethods
 
   const unitTypes = getUniqueUnitTypes(listingUnits)
+  const unitGroupUnitTypes = getUniqueUnitGroupUnitTypes(listingUnitGroups)
 
   const preferredUnitOptions = unitTypes?.map((item) => {
-    const isChecked = !!applicationUnitTypes?.find((unit) => unit.id === item.id) ?? false
+    const isChecked = !!applicationUnitTypes?.find((unit) => unit.id === item.id)
+
+    return {
+      id: item.id,
+      label: t(`application.household.preferredUnit.options.${item.name}`),
+      value: item.id,
+      defaultChecked: isChecked,
+      dataTestId: `preferredUnit.${item.name}`,
+    }
+  })
+
+  const preferredUnitGroupOptions = unitGroupUnitTypes?.map((item) => {
+    const isChecked = !!applicationUnitTypes?.find((unit) => unit.id === item.id)
 
     return {
       id: item.id,
@@ -65,7 +86,7 @@ const FormHouseholdDetails = ({
             <FieldGroup
               type="checkbox"
               name="application.preferredUnit"
-              fields={preferredUnitOptions}
+              fields={enableUnitGroups ? preferredUnitGroupOptions : preferredUnitOptions}
               groupLabel={t("application.details.preferredUnitSizes")}
               register={register}
               fieldGroupClassName="grid grid-cols-1 mt-4"


### PR DESCRIPTION
This PR addresses #4988 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Handles unit groups for paper application on partners site

## How Can This Be Tested/Reviewed?

on listing with jurisdiction with `enableUnitGroups = true` go to applications and click add application. `/listings/[id]/applications/add`. If it has unit groups it should show unit types from it in `Preferred Unit Sizes` section.
For now when no unit groups it will show empty section, and will display all unitTypes (ewen when unit Group got `openWaitlist` set to false)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
