### PR TITLE
fix: common app selection

### DIFF
--- a/sites/partners/cypress/e2e/default/03-listing.spec.ts
+++ b/sites/partners/cypress/e2e/default/03-listing.spec.ts
@@ -82,11 +82,11 @@ describe("Listing Management Tests", () => {
     cy.fixture("listing").then((listing) => {
       fillOutListing(cy, listing)
       verifyDetails(cy, listing)
+      verifyAutofill(cy, listing)
       verifyOpenListingWarning(cy, listing)
     })
   })
 
-  // Fill out a First Come, First Serve (FCFS) listing
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function fillOutListing(cy: Cypress.cy, listing: any): void {
     cy.intercept("GET", "/geocoding/v5/**", { fixture: "address" })
@@ -197,14 +197,9 @@ describe("Listing Management Tests", () => {
       .click()
     cy.getByID("addPreferenceSaveButton").contains("Save").click()
     cy.getByID("selectAndOrderSaveButton").contains("Save").click()
-
     cy.getByID("applicationFee").type(listing["applicationFee"])
-    cy.getByID("depositMin").type(listing["depositMin"])
-    cy.getByID("depositMax").type(listing["depositMax"])
-    cy.getByID("costsNotIncluded").type(listing["costsNotIncluded"])
-    cy.getByID("applicationFee").type(listing["applicationFee"])
-    cy.getByID("depositMin").type(listing["depositMin"])
-    cy.getByID("depositMax").type(listing["depositMax"])
+    cy.getByID("depositMin").clear().type(listing["depositMin"])
+    cy.getByID("depositMax").clear().type(listing["depositMax"])
     cy.getByID("costsNotIncluded").type(listing["costsNotIncluded"])
     if (listing["utilities"]) {
       listing["utilities"].forEach((utility: string) => {
@@ -342,8 +337,6 @@ describe("Listing Management Tests", () => {
     cy.getByID("preferenceTable").contains("Work in the city")
     cy.getByID("preferenceTable").contains("At least one member of my household works in the city")
     cy.getByID("applicationFee").contains(listing["applicationFee"])
-    cy.getByID("applicationFee").contains(listing["applicationFee"])
-    cy.getByID("applicationFee").contains(listing["applicationFee"])
     cy.getByID("depositMin").contains(listing["depositMin"])
     cy.getByID("depositMax").contains(listing["depositMax"])
     cy.getByID("costsNotIncluded").contains(listing["costsNotIncluded"])
@@ -420,6 +413,153 @@ describe("Listing Management Tests", () => {
     cy.getByID("openhouseHeader").contains("10/04/2022")
     cy.getByID("openhouseHeader").contains("10:04 AM")
     cy.getByID("openhouseHeader").contains("11:05 PM")
+  }
+
+  function verifyAutofill(cy: Cypress.cy, listing: any): void {
+    cy.findAndOpenListing(listing["name"])
+    cy.getByID("listingEditButton").contains("Edit").click()
+    cy.getByID("jurisdictions.id")
+      .find("option:selected")
+      .should("have.text", listing["jurisdiction.id"])
+
+    cy.getByID("name").should("have.value", listing["name"])
+    cy.getByID("developer").should("have.value", listing["developer"])
+    cy.getByID("listingsBuildingAddress.street").should(
+      "have.value",
+      listing["buildingAddress.street"]
+    )
+    cy.getByID("neighborhood").should("have.value", listing["neighborhood"])
+    cy.getByID("listingsBuildingAddress.city").should("have.value", listing["buildingAddress.city"])
+    cy.getByID("listingsBuildingAddress.state")
+      .find("option:selected")
+      .should("have.text", listing["buildingAddress.state"])
+    cy.getByID("listingsBuildingAddress.zipCode").should(
+      "have.value",
+      listing["buildingAddress.zipCode"]
+    )
+    cy.getByID("yearBuilt").should("have.value", listing["yearBuilt"])
+    cy.getByID("reservedCommunityTypes.id")
+      .find("option:selected")
+      .should("have.text", listing["reservedCommunityType.id"])
+
+    cy.getByID("reservedCommunityDescription").should(
+      "have.value",
+      listing["reservedCommunityDescription"]
+    )
+    cy.getByID("includeCommunityDisclaimerYes").should("be.checked")
+    cy.getByID("communityDisclaimerTitle").should("have.value", listing["communityDisclaimerTitle"])
+    cy.getByID("communityDisclaimerDescription").should(
+      "have.value",
+      listing["communityDisclaimerDescription"]
+    )
+    cy.getByTestId("unit-types").should("be.checked")
+    cy.getByTestId("listingAvailability.availableUnits").should("be.checked")
+    if (listing["homeType"]) {
+      cy.getByID("homeType").find("option:selected").should("have.text", listing["homeType"])
+    }
+    // TODO Test unit drawer
+    // TODO Test preferences
+    cy.getByID("applicationFee").should("have.value", listing["applicationFee"])
+    cy.getByID("depositMin").should("have.value", listing["depositMin"])
+    cy.getByID("depositMax").should("have.value", listing["depositMax"])
+    cy.getByID("costsNotIncluded").should("have.value", listing["costsNotIncluded"])
+    if (listing["utilities"]) {
+      listing["utilities"].forEach((utility: string) => {
+        cy.getByID(utility.toLowerCase()).should("be.checked")
+      })
+    }
+    cy.getByID("amenities").should("have.value", listing["amenities"])
+    cy.getByID("accessibility").should("have.value", listing["accessibility"])
+    cy.getByID("unitAmenities").should("have.value", listing["unitAmenities"])
+    cy.getByID("smokingPolicy").should("have.value", listing["smokingPolicy"])
+    cy.getByID("petPolicy").should("have.value", listing["petPolicy"])
+    cy.getByID("servicesOffered").should("have.value", listing["servicesOffered"])
+    if (listing["accessibilityFeatures"]) {
+      listing["accessibilityFeatures"].forEach((feature: string[]) => {
+        cy.getByID(feature[0]).should("be.checked")
+      })
+    }
+    cy.getByID("creditHistory").should("have.value", listing["creditHistory"])
+    cy.getByID("rentalHistory").should("have.value", listing["rentalHistory"])
+    cy.getByID("criminalBackground").should("have.value", listing["criminalBackground"])
+    cy.getByID("buildingSelectionCriteriaTable").contains(listing["buildingSelectionCriteriaURL"])
+    cy.getByID("requiredDocuments").should("have.value", listing["requiredDocuments"])
+    cy.getByID("programRules").should("have.value", listing["programRules"])
+    cy.getByID("specialNotes").should("have.value", listing["specialNotes"])
+    cy.get("button").contains("Application Process").click()
+    cy.getByID("reviewOrderFCFS").should("be.checked")
+    cy.getByID("waitlistOpenNo").should("be.checked")
+    cy.getByID("leasingAgentName").should("have.value", listing["leasingAgentName"])
+    cy.getByID("leasingAgentEmail").should("have.value", listing["leasingAgentEmail"])
+    cy.getByID("leasingAgentPhone").should("have.value", "(520) 245-8811")
+    cy.getByID("leasingAgentTitle").should("have.value", listing["leasingAgentTitle"])
+    cy.getByID("leasingAgentOfficeHours").should("have.value", listing["leasingAgentOfficeHours"])
+    cy.getByID("digitalApplicationChoiceYes").should("be.checked")
+    cy.getByID("commonDigitalApplicationChoiceNo").should("be.checked")
+    cy.getByID("customOnlineApplicationUrl").should("have.value", listing["url"])
+    cy.getByID("paperApplicationNo").should("be.checked")
+    cy.getByID("referralOpportunityYes").should("be.checked")
+    cy.getByID("referralContactPhone").should("have.value", "(520) 245-8811")
+    cy.getByID("listingsLeasingAgentAddress.street").should(
+      "have.value",
+      listing["leasingAgentAddress.street"]
+    )
+    cy.getByID("listingsLeasingAgentAddress.street2").should(
+      "have.value",
+      listing["leasingAgentAddress.street2"]
+    )
+    cy.getByID("listingsLeasingAgentAddress.city").should(
+      "have.value",
+      listing["leasingAgentAddress.city"]
+    )
+    cy.getByID("listingsLeasingAgentAddress.zipCode").should(
+      "have.value",
+      listing["leasingAgentAddress.zipCode"]
+    )
+    cy.getByID("listingsLeasingAgentAddress.state")
+      .find("option:selected")
+      .should("have.text", listing["leasingAgentAddress.state"])
+    cy.getByID("applicationsMailedInYes").should("be.checked")
+    cy.getByID("mailInAnotherAddress").should("be.checked")
+    cy.getByTestId("mailing-address-street").should(
+      "have.value",
+      listing["leasingAgentAddress.street"]
+    )
+    cy.getByTestId("mailing-address-street2").should(
+      "have.value",
+      listing["leasingAgentAddress.street2"]
+    )
+    cy.getByTestId("mailing-address-city").should("have.value", listing["leasingAgentAddress.city"])
+    cy.getByTestId("mailing-address-zip").should(
+      "have.value",
+      listing["leasingAgentAddress.zipCode"]
+    )
+    cy.getByTestId("mailing-address-state")
+      .find("option:selected")
+      .should("have.text", listing["leasingAgentAddress.state"])
+    cy.getByID("applicationsPickedUpNo").should("be.checked")
+    cy.getByID("applicationsDroppedOffNo").should("be.checked")
+    cy.getByID("postmarksConsideredYes").should("be.checked")
+    cy.getByTestId("postmark-date-field-month").should("have.value", "12")
+    cy.getByTestId("postmark-date-field-day").should("have.value", "17")
+    cy.getByTestId("postmark-date-field-year").should("have.value", "2022")
+    cy.getByTestId("postmark-time-field-hours").should("have.value", "05")
+    cy.getByTestId("postmark-time-field-minutes").should("have.value", "45")
+    cy.getByTestId("postmark-time-field-period").should("have.value", "pm")
+    cy.getByID("additionalApplicationSubmissionNotes").should(
+      "have.value",
+      listing["additionalApplicationSubmissionNotes"]
+    )
+    // TODO Test Open house events
+    cy.getByID("applicationDueDateField.month").should("have.value", listing["date.month"])
+    cy.getByID("applicationDueDateField.day").should("have.value", listing["date.day"])
+    cy.getByID("applicationDueDateField.year").should(
+      "have.value",
+      (new Date().getFullYear() + 1).toString()
+    )
+    cy.getByID("applicationDueTimeField.hours").should("have.value", listing["startTime.hours"])
+    cy.getByID("applicationDueTimeField.minutes").should("have.value", listing["startTime.minutes"])
+    cy.getByID("applicationDueTimeField.period").should("have.value", "pm")
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sites/partners/cypress/fixtures/listing.json
+++ b/sites/partners/cypress/fixtures/listing.json
@@ -41,7 +41,7 @@
   "programRules": "Basic program rules",
   "specialNotes": "basic special notes",
   "leasingAgentName": "Basic Agent Name",
-  "leasingAgentEmail": "basicAgent@email.com",
+  "leasingAgentEmail": "basicagent@email.com",
   "leasingAgentPhone": "520-245-8811",
   "leasingAgentTitle": "Basic Agent Title",
   "leasingAgentOfficeHours": "Basic Agent Office Hours",

--- a/sites/partners/cypress/fixtures/minimalListing.json
+++ b/sites/partners/cypress/fixtures/minimalListing.json
@@ -9,7 +9,7 @@
   "number": "2",
   "unitType.id": "One Bedroom",
   "leasingAgentName": "Basic Agent Name",
-  "leasingAgentEmail": "basicAgent@email.com",
+  "leasingAgentEmail": "basicagent@email.com",
   "leasingAgentPhone": "520-245-8811",
   "date.month": "10",
   "date.day": "04",

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationTypes.tsx
@@ -36,6 +36,36 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
   const { register, setValue, watch, errors, getValues } = useFormContext()
   const { doJurisdictionsHaveFeatureFlagOn, getJurisdictionLanguages } = useContext(AuthContext)
 
+  const getDefaultMethods = () => {
+    const temp: Methods = {
+      digital: null,
+      paper: null,
+      referral: null,
+    }
+    const applicationMethods =
+      getValues()?.applicationMethods?.length > 0
+        ? getValues().applicationMethods
+        : listing?.applicationMethods
+
+    applicationMethods?.forEach((method) => {
+      switch (method.type) {
+        case ApplicationMethodsTypeEnum.Internal:
+        case ApplicationMethodsTypeEnum.ExternalLink:
+          temp["digital"] = method
+          break
+        case ApplicationMethodsTypeEnum.FileDownload:
+          temp["paper"] = method
+          break
+        case ApplicationMethodsTypeEnum.Referral:
+          temp["referral"] = method
+          break
+        default:
+          break
+      }
+    })
+    return temp
+  }
+
   // watch fields
   const jurisdiction: string = watch("jurisdictions.id")
   const digitalApplicationChoice = watch("digitalApplicationChoice")
@@ -46,11 +76,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
   /*
     Set state for methods, drawer, upload progress, and more
   */
-  const [methods, setMethods] = useState<Methods>({
-    digital: null,
-    paper: null,
-    referral: null,
-  })
+  const [methods, setMethods] = useState<Methods>(getDefaultMethods())
   const [selectedLanguage, setSelectedLanguage] = useState("")
   const [drawerState, setDrawerState] = useState(false)
   const [progressValue, setProgressValue] = useState(0)
@@ -147,41 +173,6 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
   }
 
   /**
-   * set initial methods
-   */
-  useEffect(() => {
-    // set methods here
-    const temp: Methods = {
-      digital: null,
-      paper: null,
-      referral: null,
-    }
-    const applicationMethods =
-      getValues()?.applicationMethods?.length > 0
-        ? getValues().applicationMethods
-        : listing?.applicationMethods
-
-    applicationMethods?.forEach((method) => {
-      switch (method.type) {
-        case ApplicationMethodsTypeEnum.Internal:
-        case ApplicationMethodsTypeEnum.ExternalLink:
-          temp["digital"] = method
-          break
-        case ApplicationMethodsTypeEnum.FileDownload:
-          temp["paper"] = method
-          break
-        case ApplicationMethodsTypeEnum.Referral:
-          temp["referral"] = method
-          break
-        default:
-          break
-      }
-    })
-    setMethods(temp)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  /**
    * set application methods value when any of the methods change
    */
   useEffect(() => {
@@ -225,7 +216,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                 {
                   ...yesNoRadioOptions[0],
                   id: "digitalApplicationChoiceYes",
-                  defaultChecked: listing?.digitalApplication === true ?? null,
+                  defaultChecked: listing?.digitalApplication === true,
                   inputProps: {
                     onChange: () => {
                       setMethods({
@@ -243,7 +234,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                 {
                   ...yesNoRadioOptions[1],
                   id: "digitalApplicationChoiceNo",
-                  defaultChecked: listing?.digitalApplication === false ?? null,
+                  defaultChecked: listing?.digitalApplication === false,
                   inputProps: {
                     onChange: () => {
                       setMethods({
@@ -268,8 +259,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                   {
                     ...yesNoRadioOptions[0],
                     id: "commonDigitalApplicationChoiceYes",
-                    defaultChecked:
-                      methods?.digital?.type === ApplicationMethodsTypeEnum.Internal ?? null,
+                    defaultChecked: methods.digital.type === ApplicationMethodsTypeEnum.Internal,
                     inputProps: {
                       onChange: () => {
                         setMethods({
@@ -286,7 +276,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                     ...yesNoRadioOptions[1],
                     id: "commonDigitalApplicationChoiceNo",
                     defaultChecked:
-                      methods?.digital?.type === ApplicationMethodsTypeEnum.ExternalLink ?? null,
+                      methods.digital.type === ApplicationMethodsTypeEnum.ExternalLink,
                     inputProps: {
                       onChange: () => {
                         setMethods({
@@ -358,7 +348,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                 {
                   ...yesNoRadioOptions[0],
                   id: "paperApplicationYes",
-                  defaultChecked: listing?.paperApplication === true ?? null,
+                  defaultChecked: listing?.paperApplication === true,
                   inputProps: {
                     onChange: () => {
                       setMethods({
@@ -374,7 +364,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                 {
                   ...yesNoRadioOptions[1],
                   id: "paperApplicationNo",
-                  defaultChecked: listing?.paperApplication === false ?? null,
+                  defaultChecked: listing?.paperApplication === false,
                   inputProps: {
                     onChange: () => {
                       setMethods({
@@ -466,7 +456,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                 {
                   ...yesNoRadioOptions[0],
                   id: "referralOpportunityYes",
-                  defaultChecked: listing?.referralOpportunity === true ?? null,
+                  defaultChecked: listing?.referralOpportunity === true,
                   inputProps: {
                     onChange: () => {
                       setMethods({
@@ -482,7 +472,7 @@ const ApplicationTypes = ({ listing }: { listing: FormListing }) => {
                 {
                   ...yesNoRadioOptions[1],
                   id: "referralOpportunityNo",
-                  defaultChecked: listing?.referralOpportunity === false ?? null,
+                  defaultChecked: listing?.referralOpportunity === false,
                   inputProps: {
                     onChange: () => {
                       setMethods({

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -211,7 +211,11 @@ const BuildingSelectionCriteria = () => {
           <Grid.Cell>
             {(listingCriteriaURL && listingCriteriaURL != "") ||
             (listingCriteriaFile?.fileId && listingCriteriaFile.fileId != "") ? (
-              <MinimalTable headers={criteriaTableHeaders} data={criteriaTableRows}></MinimalTable>
+              <MinimalTable
+                headers={criteriaTableHeaders}
+                data={criteriaTableRows}
+                id="buildingSelectionCriteriaTable"
+              />
             ) : (
               <Button
                 id="addBuildingSelectionCriteriaButton"

--- a/sites/public/src/pages/404.tsx
+++ b/sites/public/src/pages/404.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext } from "react"
 import Head from "next/head"
-import { Hero, t } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import Layout from "../layouts/application"
 import { Content404 } from "../components/page/Content404"


### PR DESCRIPTION
This PR addresses #5002

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The "Are you using the common digital application?" has stopped autofilling.

The commit that "caused" it had a UIC upgrade that ended up including 10 UIC commits - [this is the UIC commit](https://github.com/bloom-housing/ui-components/pull/169) that causes the issue but I still don't know why. It did include a few package upgrades that might have had some unexpected effects.

## How Can This Be Tested/Reviewed?

Create or update a listing with a value for `Are you using the common digital application?` which appears after selecting `Yes` to `Is there a digital application?` and ensure the value re-populates after saving and reopening the form.

I updated our listing Cypress test to also re-open an entered listing to make sure all of the fields populate as expected, as we've had lots of bugs around this.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
