### PR TITLE
feat: portal of origin script

### DIFF
--- a/api/src/controllers/script-runner.controller.ts
+++ b/api/src/controllers/script-runner.controller.ts
@@ -209,4 +209,17 @@ export class ScriptRunnerController {
       req,
     );
   }
+
+  @Put('markTransferedData')
+  @ApiOperation({
+    summary:
+      'A script that marks transferred data in Doorway as externally created',
+    operationId: 'markTransferedData',
+  })
+  @ApiOkResponse({ type: SuccessDTO })
+  async markTransferedData(
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.scriptRunnerService.markTransferedData(req);
+  }
 }

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -22,6 +22,8 @@ import { AmiChartCreate } from '../dtos/ami-charts/ami-chart-create.dto';
 import { AmiChartUpdate } from '../dtos/ami-charts/ami-chart-update.dto';
 import MultiselectQuestion from '../dtos/multiselect-questions/multiselect-question.dto';
 import { AmiChartUpdateImportDTO } from '../dtos/script-runner/ami-chart-update-import.dto';
+import dayjs from 'dayjs';
+import { Compare } from '../dtos/shared/base-filter.dto';
 
 /**
   this is the service for running scripts
@@ -648,6 +650,118 @@ export class ScriptRunnerService {
       'migrate Detroit to multiselect questions',
       requestingUser,
     );
+    return { success: true };
+  }
+
+  /**
+   *
+   * @param req incoming request object
+   * @returns successDTO
+   * @description marks transferred data in Doorway as externally created
+   */
+  async markTransferedData(req: ExpressRequest): Promise<SuccessDTO> {
+    const requestingUser = mapTo(User, req['user']);
+    await this.markScriptAsRunStart('mark transfered data', requestingUser);
+
+    // Alameda ==========================================================
+    const alamedaMigrationDate = dayjs(
+      '2025-05-05 00:00',
+      'YYYY-MM-DD HH:mm Z',
+    ).toDate();
+
+    const alamedaJurisdiction =
+      await this.prisma.jurisdictions.findFirstOrThrow({
+        select: { id: true },
+        where: { name: 'Alameda' },
+      });
+
+    await this.prisma.applications.updateMany({
+      data: { wasCreatedExternally: true },
+      where: {
+        appUrl: 'https://housing.acgov.org',
+      },
+    });
+
+    await this.prisma.listings.updateMany({
+      data: { wasCreatedExternally: true },
+      where: {
+        createdAt: { lt: alamedaMigrationDate },
+        jurisdictionId: alamedaJurisdiction.id,
+      },
+    });
+
+    const alamedaMultiSelectQuestionIds = (
+      await this.multiselectQuestionService.list({
+        filter: [
+          {
+            $comparison: Compare['IN'],
+            jurisdiction: alamedaJurisdiction.id,
+          },
+        ],
+      })
+    )
+      .filter((question) => question.createdAt < alamedaMigrationDate)
+      .map((question) => question.id);
+
+    await this.prisma.multiselectQuestions.updateMany({
+      data: { wasCreatedExternally: true },
+      where: {
+        id: { in: alamedaMultiSelectQuestionIds },
+      },
+    });
+
+    console.log('Alameda data has been updated');
+
+    // San Mateo ==========================================================
+    const sanMateoBase = dayjs('2024-10-22 00:00', 'YYYY-MM-DD HH:mm Z');
+    const sanMateo22 = sanMateoBase.toDate();
+    const sanMateo24 = sanMateoBase.add(2, 'day').toDate();
+    const sanMateo25 = sanMateoBase.add(3, 'day').toDate();
+
+    const sanMateoJurisdiction =
+      await this.prisma.jurisdictions.findFirstOrThrow({
+        select: { id: true },
+        where: { name: 'San Mateo' },
+      });
+
+    await this.prisma.applications.updateMany({
+      data: { wasCreatedExternally: true },
+      where: {
+        appUrl: 'https://smc.housingbayarea.org',
+      },
+    });
+
+    await this.prisma.listings.updateMany({
+      data: { wasCreatedExternally: true },
+      where: {
+        createdAt: { lt: sanMateo25 },
+        jurisdictionId: sanMateoJurisdiction.id,
+      },
+    });
+
+    const sanMateoMultiSelectQuestionIds = (
+      await this.multiselectQuestionService.list({
+        filter: [
+          {
+            $comparison: Compare['IN'],
+            jurisdiction: sanMateoJurisdiction.id,
+          },
+        ],
+      })
+    )
+      .filter((question) => question.createdAt < sanMateo22)
+      .map((question) => question.id);
+
+    await this.prisma.multiselectQuestions.updateMany({
+      data: { wasCreatedExternally: true },
+      where: {
+        id: { in: sanMateoMultiSelectQuestionIds },
+      },
+    });
+
+    console.log('San Mateo data has been updated');
+
+    await this.markScriptAsComplete('mark transfered data', requestingUser);
     return { success: true };
   }
 

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2476,6 +2476,22 @@ export class ScriptRunnerService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * A script that marks transferred data in Doorway as externally created
+   */
+  markTransferedData(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/scriptRunner/markTransferedData"
+
+      const configs: IRequestConfig = getConfigs("put", "application/json", url, options)
+
+      let data = null
+
+      configs.data = data
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export class FeatureFlagsService {


### PR DESCRIPTION
This PR addresses #4977 

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Script to update the data in regards to the `wasCreatedExternally` columns.
Do not merge into Core, must be raised in Doorway only. Only storing here until these PRs are merged:
- https://github.com/metrotranscom/doorway/pull/1294
- https://github.com/metrotranscom/doorway/pull/1346

## How Can This Be Tested/Reviewed?

Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
