### PR TITLE
feat: add new feature flag UI

### DIFF
--- a/api/prisma/migrations/27_add_super_admin/migration.sql
+++ b/api/prisma/migrations/27_add_super_admin/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE
+    "user_roles"
+ADD
+    COLUMN "is_super_admin" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -873,6 +873,8 @@ model UserRoles {
   isAdmin               Boolean      @default(false) @map("is_admin")
   isJurisdictionalAdmin Boolean      @default(false) @map("is_jurisdictional_admin")
   isPartner             Boolean      @default(false) @map("is_partner")
+  // Role for maintainers of the code base. Should have access to everything as well as developer specific pages
+  isSuperAdmin          Boolean      @default(false) @map("is_super_admin")
   userId                String       @id() @map("user_id") @db.Uuid
   userAccounts          UserAccounts @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/api/prisma/seed-helpers/user-factory.ts
+++ b/api/prisma/seed-helpers/user-factory.ts
@@ -65,6 +65,7 @@ export const userFactory = async (optionalParams?: {
       isJurisdictionalAdmin:
         optionalParams?.roles?.isJurisdictionalAdmin || false,
       isPartner: optionalParams?.roles?.isPartner || false,
+      isSuperAdmin: optionalParams?.roles?.isSuperAdmin || false,
     },
   },
 });

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -121,6 +121,22 @@ export const stagingSeed = async (
       featureFlags: [],
     }),
   });
+  // create super admin user
+  await prismaClient.userAccounts.create({
+    data: await userFactory({
+      roles: { isSuperAdmin: true, isAdmin: true },
+      email: 'superadmin@example.com',
+      confirmedAt: new Date(),
+      jurisdictionIds: [
+        mainJurisdiction.id,
+        lakeviewJurisdiction.id,
+        bridgeBayJurisdiction.id,
+        nadaHill.id,
+      ],
+      acceptedTerms: true,
+      password: 'abcdef',
+    }),
+  });
   // create admin user
   await prismaClient.userAccounts.create({
     data: await userFactory({

--- a/api/src/dtos/users/user-role.dto.ts
+++ b/api/src/dtos/users/user-role.dto.ts
@@ -18,4 +18,9 @@ export class UserRole {
   @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional()
   isPartner?: boolean;
+
+  @Expose()
+  @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
+  @ApiPropertyOptional()
+  isSuperAdmin?: boolean;
 }

--- a/shared-helpers/src/auth/AuthContext.ts
+++ b/shared-helpers/src/auth/AuthContext.ts
@@ -34,6 +34,7 @@ import {
   SuccessDTO,
   LotteryService,
   LanguagesEnum,
+  FeatureFlagsService,
 } from "../types/backend-swagger"
 import { getListingRedirectUrl } from "../utilities/getListingRedirectUrl"
 import { useRouter } from "next/router"
@@ -48,6 +49,7 @@ type ContextProps = {
   authService: AuthService
   multiselectQuestionsService: MultiselectQuestionsService
   unitTypesService: UnitTypesService
+  featureFlagService: FeatureFlagsService
   reservedCommunityTypeService: ReservedCommunityTypesService
   unitPriorityService: UnitAccessibilityPriorityTypesService
   mapLayersService: MapLayersService
@@ -230,6 +232,7 @@ export const AuthProvider: FunctionComponent<React.PropsWithChildren> = ({ child
     reservedCommunityTypeService: new ReservedCommunityTypesService(),
     unitPriorityService: new UnitAccessibilityPriorityTypesService(),
     unitTypesService: new UnitTypesService(),
+    featureFlagService: new FeatureFlagsService(),
     loading: state.loading,
     initialStateLoaded: state.initialStateLoaded,
     profile: state.profile,

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -6407,6 +6407,9 @@ export interface UserRole {
 
   /**  */
   isPartner?: boolean
+
+  /**  */
+  isSuperAdmin?: boolean
 }
 
 export interface User {

--- a/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
+++ b/sites/partners/__tests__/components/listings/ListingFormActions.test.tsx
@@ -598,7 +598,6 @@ describe("<ListingFormActions>", () => {
 
         await userEvent.click(screen.getByRole("button", { name: "Approve & Publish" }))
         expect(submitMock).toBeCalledWith("redirect", ListingsStatusEnum.active)
-        screen.debug()
       })
     })
     describe("as a jurisdictional admin", () => {

--- a/sites/partners/__tests__/pages/admin/index.test.tsx
+++ b/sites/partners/__tests__/pages/admin/index.test.tsx
@@ -122,12 +122,12 @@ describe("admin", () => {
     render(<Admin />)
     await screen.findByRole("cell", { name: "jurisdiction 1" })
     expect(screen.getByRole("heading", { level: 1, name: "Administration" })).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: "By Jurisdiction" })).toBeInTheDocument()
-    expect(screen.getByRole("tabpanel", { name: "By Jurisdiction" })).toBeInTheDocument()
-    expect(screen.getByRole("tab", { name: "By Feature Flag" })).toBeInTheDocument()
-    expect(screen.getByRole("tabpanel", { name: "By Feature Flag" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "By jurisdiction" })).toBeInTheDocument()
+    expect(screen.getByRole("tabpanel", { name: "By jurisdiction" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "By feature flag" })).toBeInTheDocument()
+    expect(screen.getByRole("tabpanel", { name: "By feature flag" })).toBeInTheDocument()
 
-    expect(screen.getByRole("button", { name: "Add All New Feature Flags" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Add all new feature flags" })).toBeInTheDocument()
 
     // Table
     const table = screen.getByRole("table")
@@ -145,15 +145,15 @@ describe("admin", () => {
     // Validate first row
     const [jurisdiction, actions] = within(rows[0]).getAllByRole("cell")
     expect(jurisdiction).toHaveTextContent("jurisdiction 1")
-    expect(actions).toHaveTextContent("Edit")
+    expect(within(actions).getByRole("button", { name: "Edit" })).toBeInTheDocument()
     // Validate second row
     const [jurisdiction2, actions2] = within(rows[1]).getAllByRole("cell")
     expect(jurisdiction2).toHaveTextContent("jurisdiction 2")
-    expect(actions2).toHaveTextContent("Edit")
+    expect(within(actions2).getByRole("button", { name: "Edit" })).toBeInTheDocument()
     // Validate third row
     const [jurisdiction3, actions3] = within(rows[2]).getAllByRole("cell")
     expect(jurisdiction3).toHaveTextContent("jurisdiction 3")
-    expect(actions3).toHaveTextContent("Edit")
+    expect(within(actions3).getByRole("button", { name: "Edit" })).toBeInTheDocument()
   })
 
   it("should display the feature flag page when superadmin for by feature flag", async () => {
@@ -183,7 +183,7 @@ describe("admin", () => {
     await screen.findByRole("cell", { name: "jurisdiction 1" })
 
     // Switch to the "by feature flag" tab
-    fireEvent.click(screen.getByRole("tab", { name: "By Feature Flag" }))
+    fireEvent.click(screen.getByRole("tab", { name: "By feature flag" }))
 
     await screen.findByRole("cell", { name: "featureFlag1" })
 
@@ -205,17 +205,17 @@ describe("admin", () => {
     const [featureFlag, description, actions] = within(rows[0]).getAllByRole("cell")
     expect(featureFlag).toHaveTextContent("featureFlag1")
     expect(description).toHaveTextContent("featureFlag1 description")
-    expect(actions).toHaveTextContent("Edit")
+    expect(within(actions).getByRole("button", { name: "Edit" })).toBeInTheDocument()
     // Validate second row
     const [featureFlag2, description2, actions2] = within(rows[1]).getAllByRole("cell")
     expect(featureFlag2).toHaveTextContent("featureFlag2")
     expect(description2).toHaveTextContent("featureFlag2 description")
-    expect(actions2).toHaveTextContent("Edit")
+    expect(within(actions2).getByRole("button", { name: "Edit" })).toBeInTheDocument()
     // Validate third row
     const [featureFlag3, description3, actions3] = within(rows[2]).getAllByRole("cell")
     expect(featureFlag3).toHaveTextContent("featureFlag3")
     expect(description3).toHaveTextContent("featureFlag3 description")
-    expect(actions3).toHaveTextContent("Edit")
+    expect(within(actions3).getByRole("button", { name: "Edit" })).toBeInTheDocument()
   })
 
   it("should open and associate feature flag for jurisdiction", async () => {
@@ -334,7 +334,7 @@ describe("admin", () => {
     await screen.findByRole("cell", { name: "jurisdiction 1" })
 
     // Switch to the "by feature flag" tab
-    fireEvent.click(screen.getByRole("tab", { name: "By Feature Flag" }))
+    fireEvent.click(screen.getByRole("tab", { name: "By feature flag" }))
 
     fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0])
 

--- a/sites/partners/__tests__/pages/admin/index.test.tsx
+++ b/sites/partners/__tests__/pages/admin/index.test.tsx
@@ -120,14 +120,14 @@ describe("admin", () => {
       })
     )
     render(<Admin />)
-    await screen.findByRole("heading", { level: 1, name: "Administration" })
+    await screen.findByRole("cell", { name: "jurisdiction 1" })
+    expect(screen.getByRole("heading", { level: 1, name: "Administration" })).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: "By Jurisdiction" })).toBeInTheDocument()
     expect(screen.getByRole("tabpanel", { name: "By Jurisdiction" })).toBeInTheDocument()
     expect(screen.getByRole("tab", { name: "By Feature Flag" })).toBeInTheDocument()
     expect(screen.getByRole("tabpanel", { name: "By Feature Flag" })).toBeInTheDocument()
 
     expect(screen.getByRole("button", { name: "Add All New Feature Flags" })).toBeInTheDocument()
-    await screen.findByRole("cell", { name: "jurisdiction 1" })
 
     // Table
     const table = screen.getByRole("table")

--- a/sites/partners/__tests__/pages/admin/index.test.tsx
+++ b/sites/partners/__tests__/pages/admin/index.test.tsx
@@ -1,0 +1,371 @@
+import React from "react"
+import { setupServer } from "msw/lib/node"
+import { fireEvent, mockNextRouter, render, screen, waitFor, within } from "../../testUtils"
+import Admin from "../../../src/pages/admin"
+import { rest } from "msw"
+
+const server = setupServer()
+
+beforeAll(() => {
+  server.listen()
+  mockNextRouter()
+})
+
+afterEach(() => {
+  server.resetHandlers()
+  window.sessionStorage.clear()
+})
+
+afterAll(() => server.close())
+
+const featureFlags = [
+  {
+    id: "featureFlag1Id",
+    name: "featureFlag1",
+    description: "featureFlag1 description",
+    jurisdictions: [
+      { id: "juris1", name: "jurisdiction 1" },
+      { id: "juris2", name: "jurisdiction 2" },
+    ],
+  },
+  {
+    id: "featureFlag2Id",
+    name: "featureFlag2",
+    description: "featureFlag2 description",
+    jurisdictions: [{ id: "juris1", name: "jurisdiction 1" }],
+  },
+  {
+    id: "featureFlag3Id",
+    name: "featureFlag3",
+    description: "featureFlag3 description",
+    jurisdictions: [
+      { id: "juris1", name: "jurisdiction 1" },
+      { id: "juris2", name: "jurisdiction 2" },
+      { id: "juris3", name: "jurisdiction 3" },
+    ],
+  },
+]
+
+const jurisdictions = [
+  {
+    id: "juris1",
+    name: "jurisdiction 1",
+    featureFlags: [
+      { id: "featureFlag1Id", name: "featureFlag1" },
+      { id: "featureFlag2Id", name: "featureFlag2" },
+      { id: "featureFlag3Id", name: "featureFlag3" },
+    ],
+  },
+  {
+    id: "juris2",
+    name: "jurisdiction 2",
+    featureFlags: [
+      { id: "featureFlag1Id", name: "featureFlag1" },
+      { id: "featureFlag3Id", name: "featureFlag3" },
+    ],
+  },
+  {
+    id: "juris3",
+    name: "jurisdiction 3",
+    featureFlags: [{ id: "featureFlag3Id", name: "featureFlag3" }],
+  },
+]
+
+describe("admin", () => {
+  it("should show unauthorized if user is not a superAdmin", () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({ id: "user1", roles: { id: "user1", isAdmin: true, isPartner: false } })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      }),
+      rest.get("http://localhost:3100/featureFlags", (_req, res, ctx) => {
+        return res(ctx.json([]))
+      })
+    )
+    render(<Admin />)
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /uh oh, you are not allowed to access this page./i,
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("should display the feature flag page when superadmin for by jurisdiction", async () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            userRoles: { id: "user1", isAdmin: true, isPartner: false, isSuperAdmin: true },
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      }),
+      rest.get("http://localhost:3100/featureFlags", (_req, res, ctx) => {
+        return res(ctx.json(featureFlags))
+      }),
+      rest.get("http://localhost/api/adapter/jurisdictions", (_req, res, ctx) => {
+        return res(ctx.json(jurisdictions))
+      })
+    )
+    render(<Admin />)
+    await screen.findByRole("heading", { level: 1, name: "Administration" })
+    expect(screen.getByRole("tab", { name: "By Jurisdiction" })).toBeInTheDocument()
+    expect(screen.getByRole("tabpanel", { name: "By Jurisdiction" })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: "By Feature Flag" })).toBeInTheDocument()
+    expect(screen.getByRole("tabpanel", { name: "By Feature Flag" })).toBeInTheDocument()
+
+    expect(screen.getByRole("button", { name: "Add All New Feature Flags" })).toBeInTheDocument()
+    await screen.findByRole("cell", { name: "jurisdiction 1" })
+
+    // Table
+    const table = screen.getByRole("table")
+    const headAndBody = within(table).getAllByRole("rowgroup")
+    expect(headAndBody).toHaveLength(2)
+    const [head, body] = headAndBody
+
+    const columnHeaders = within(head).getAllByRole("columnheader")
+    expect(columnHeaders).toHaveLength(2)
+    expect(columnHeaders[0]).toHaveTextContent("Jurisdiction")
+    expect(columnHeaders[1]).toHaveTextContent("Actions")
+
+    const rows = within(body).getAllByRole("row")
+    expect(rows).toHaveLength(3)
+    // Validate first row
+    const [jurisdiction, actions] = within(rows[0]).getAllByRole("cell")
+    expect(jurisdiction).toHaveTextContent("jurisdiction 1")
+    expect(actions).toHaveTextContent("Edit")
+    // Validate second row
+    const [jurisdiction2, actions2] = within(rows[1]).getAllByRole("cell")
+    expect(jurisdiction2).toHaveTextContent("jurisdiction 2")
+    expect(actions2).toHaveTextContent("Edit")
+    // Validate third row
+    const [jurisdiction3, actions3] = within(rows[2]).getAllByRole("cell")
+    expect(jurisdiction3).toHaveTextContent("jurisdiction 3")
+    expect(actions3).toHaveTextContent("Edit")
+  })
+
+  it("should display the feature flag page when superadmin for by feature flag", async () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            userRoles: { id: "user1", isAdmin: true, isPartner: false, isSuperAdmin: true },
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      }),
+      rest.get("http://localhost:3100/featureFlags", (_req, res, ctx) => {
+        return res(ctx.json(featureFlags))
+      }),
+      rest.get("http://localhost/api/adapter/jurisdictions", (_req, res, ctx) => {
+        return res(ctx.json(jurisdictions))
+      })
+    )
+    render(<Admin />)
+
+    await screen.findByRole("cell", { name: "jurisdiction 1" })
+
+    // Switch to the "by feature flag" tab
+    fireEvent.click(screen.getByRole("tab", { name: "By Feature Flag" }))
+
+    await screen.findByRole("cell", { name: "featureFlag1" })
+
+    // Table
+    const table = screen.getByRole("table")
+    const headAndBody = within(table).getAllByRole("rowgroup")
+    expect(headAndBody).toHaveLength(2)
+    const [head, body] = headAndBody
+
+    const columnHeaders = within(head).getAllByRole("columnheader")
+    expect(columnHeaders).toHaveLength(3)
+    expect(columnHeaders[0]).toHaveTextContent("Feature Flag")
+    expect(columnHeaders[1]).toHaveTextContent("Description")
+    expect(columnHeaders[2]).toHaveTextContent("Actions")
+
+    const rows = within(body).getAllByRole("row")
+    expect(rows).toHaveLength(3)
+    // Validate first row
+    const [featureFlag, description, actions] = within(rows[0]).getAllByRole("cell")
+    expect(featureFlag).toHaveTextContent("featureFlag1")
+    expect(description).toHaveTextContent("featureFlag1 description")
+    expect(actions).toHaveTextContent("Edit")
+    // Validate second row
+    const [featureFlag2, description2, actions2] = within(rows[1]).getAllByRole("cell")
+    expect(featureFlag2).toHaveTextContent("featureFlag2")
+    expect(description2).toHaveTextContent("featureFlag2 description")
+    expect(actions2).toHaveTextContent("Edit")
+    // Validate third row
+    const [featureFlag3, description3, actions3] = within(rows[2]).getAllByRole("cell")
+    expect(featureFlag3).toHaveTextContent("featureFlag3")
+    expect(description3).toHaveTextContent("featureFlag3 description")
+    expect(actions3).toHaveTextContent("Edit")
+  })
+
+  it("should open and associate feature flag for jurisdiction", async () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    // Watch the associate call to make sure it's called
+    const requestSpy = jest.fn()
+    server.events.on("request:start", (request) => {
+      if (request.method === "PUT" && request.url.href.includes("associateJurisdictions")) {
+        requestSpy(request.body)
+      }
+    })
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            userRoles: { id: "user1", isAdmin: true, isPartner: false, isSuperAdmin: true },
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      }),
+      rest.get("http://localhost:3100/featureFlags", (_req, res, ctx) => {
+        return res(ctx.json(featureFlags))
+      }),
+      rest.get("http://localhost/api/adapter/featureFlags", (_req, res, ctx) => {
+        return res(ctx.json(featureFlags))
+      }),
+      rest.get("http://localhost/api/adapter/jurisdictions", (_req, res, ctx) => {
+        return res(ctx.json(jurisdictions))
+      }),
+      rest.put(
+        "http://localhost/api/adapter/featureFlags/associateJurisdictions",
+        (_req, res, ctx) => {
+          return res(ctx.json("success"))
+        }
+      )
+    )
+    render(<Admin />)
+    await screen.findByRole("cell", { name: "jurisdiction 1" })
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[1])
+
+    expect(screen.getByRole("heading", { level: 1, name: "jurisdiction 2" })).toBeInTheDocument()
+    // only the appropriate feature flags should be selected
+    expect(screen.getByRole("checkbox", { name: "featureFlag1 description" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "featureFlag2 description" })).not.toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "featureFlag3 description" })).toBeChecked()
+
+    // uncheck a feature flag
+    fireEvent.click(screen.getByRole("checkbox", { name: "featureFlag1 description" }))
+    expect(screen.getByRole("checkbox", { name: "featureFlag1 description" })).not.toBeChecked()
+    // verify the call to remove jurisdiction from feature flag
+    await waitFor(() => {
+      expect(requestSpy).toHaveBeenCalledWith({
+        id: "featureFlag1Id",
+        associate: [],
+        remove: ["juris2"],
+      })
+    })
+
+    // check a feature flag
+    fireEvent.click(screen.getByRole("checkbox", { name: "featureFlag2 description" }))
+    expect(screen.getByRole("checkbox", { name: "featureFlag2 description" })).toBeChecked()
+    // verify the call to remove jurisdiction from feature flag
+    await waitFor(() => {
+      expect(requestSpy).toHaveBeenCalledWith({
+        id: "featureFlag2Id",
+        associate: ["juris2"],
+        remove: [],
+      })
+    })
+  })
+
+  it("should open and associate feature flag for feature flag", async () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    // Watch the associate call to make sure it's called
+    const requestSpy = jest.fn()
+    server.events.on("request:start", (request) => {
+      if (request.method === "PUT" && request.url.href.includes("associateJurisdictions")) {
+        requestSpy(request.body)
+      }
+    })
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            userRoles: { id: "user1", isAdmin: true, isPartner: false, isSuperAdmin: true },
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      }),
+      rest.get("http://localhost:3100/featureFlags", (_req, res, ctx) => {
+        return res(ctx.json(featureFlags))
+      }),
+      rest.get("http://localhost/api/adapter/featureFlags", (_req, res, ctx) => {
+        return res(ctx.json(featureFlags))
+      }),
+      rest.get("http://localhost/api/adapter/jurisdictions", (_req, res, ctx) => {
+        return res(ctx.json(jurisdictions))
+      }),
+      rest.put(
+        "http://localhost/api/adapter/featureFlags/associateJurisdictions",
+        (_req, res, ctx) => {
+          return res(ctx.json("success"))
+        }
+      )
+    )
+    render(<Admin />)
+    await screen.findByRole("cell", { name: "jurisdiction 1" })
+
+    // Switch to the "by feature flag" tab
+    fireEvent.click(screen.getByRole("tab", { name: "By Feature Flag" }))
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Edit" })[0])
+
+    expect(screen.getByRole("heading", { level: 1, name: "featureFlag1" })).toBeInTheDocument()
+    // only the appropriate feature flags should be selected
+    expect(screen.getByRole("checkbox", { name: "jurisdiction 1" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "jurisdiction 2" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "jurisdiction 3" })).not.toBeChecked()
+
+    // uncheck a feature flag
+    fireEvent.click(screen.getByRole("checkbox", { name: "jurisdiction 1" }))
+    expect(screen.getByRole("checkbox", { name: "jurisdiction 1" })).not.toBeChecked()
+    // verify the call to remove jurisdiction from feature flag
+    await waitFor(() => {
+      expect(requestSpy).toHaveBeenCalledWith({
+        id: "featureFlag1Id",
+        associate: [],
+        remove: ["juris1"],
+      })
+    })
+
+    // check a feature flag
+    fireEvent.click(screen.getByRole("checkbox", { name: "jurisdiction 3" }))
+    expect(screen.getByRole("checkbox", { name: "jurisdiction 3" })).toBeChecked()
+    // verify the call to remove jurisdiction from feature flag
+    await waitFor(() => {
+      expect(requestSpy).toHaveBeenCalledWith({
+        id: "featureFlag1Id",
+        associate: ["juris3"],
+        remove: [],
+      })
+    })
+  })
+})

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -550,6 +550,7 @@
   "t.export": "Export",
   "t.exportSuccess": "File exported successfully",
   "t.exportToCSV": "Export to CSV",
+  "t.featureFlag": "Feature Flag",
   "t.fileName": "File Name",
   "t.filter": "Filter",
   "t.formSubmitted": "Submitting form, wait",

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -526,6 +526,7 @@
   "t.addItem": "Add item",
   "t.addItemsToEdit": "Add items to edit",
   "t.addNotes": "Add notes",
+  "t.administration": "Administration",
   "t.areYouSure": "Are you sure?",
   "t.automatic": "Automatic",
   "t.cancel": "Cancel",

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -1,6 +1,9 @@
 {
   "t.selectLanguage": "Select language",
   "actions.copy": "Copy",
+  "admin.addFeatureFlags": "Add all new feature flags",
+  "admin.byJurisdiction": "By jurisdiction",
+  "admin.byFeatureFlag": "By feature flag",
   "application.add.addHouseholdMember": "Add Household Member",
   "application.add.applicationAddError": "You’ll need to resolve any errors before moving on.",
   "application.add.applicationSubmitted": "Application Submitted",
@@ -557,6 +560,7 @@
   "t.hide": "hide",
   "t.invite": "Invite",
   "t.jurisdiction": "Jurisdiction",
+  "t.jurisdictions": "Jurisdictions",
   "t.label": "Label",
   "t.language": "Language",
   "t.link": "Link",

--- a/sites/partners/src/pages/admin/index.tsx
+++ b/sites/partners/src/pages/admin/index.tsx
@@ -1,8 +1,9 @@
 import { useContext, useEffect, useMemo, useState } from "react"
 import Head from "next/head"
 import { AuthContext } from "@bloom-housing/shared-helpers"
+import PencilSquareIcon from "@heroicons/react/24/solid/PencilSquareIcon"
 import { Field, Hero, MinimalTable, t } from "@bloom-housing/ui-components"
-import { Button, Card, Drawer, Heading, Tabs } from "@bloom-housing/ui-seeds"
+import { Button, Card, Drawer, Heading, Icon, Tabs } from "@bloom-housing/ui-seeds"
 import Layout from "../../layouts"
 import { NavigationHeader } from "../../components/shared/NavigationHeader"
 
@@ -61,9 +62,17 @@ const Admin = () => {
         },
         actions: {
           content: (
-            <Button size="sm" onClick={() => setSelectedJurisdiction(juris.id)}>
-              Edit
-            </Button>
+            <div className={"flex justify-end gap-5"}>
+              <button
+                className="text-primary"
+                onClick={() => setSelectedJurisdiction(juris.id)}
+                aria-label={"Edit"}
+              >
+                <Icon size="md">
+                  <PencilSquareIcon />
+                </Icon>
+              </button>
+            </div>
           ),
         },
       }
@@ -81,9 +90,17 @@ const Admin = () => {
         },
         actions: {
           content: (
-            <Button size="sm" onClick={() => setSelectedFeatureFlag(flag.id)}>
-              Edit
-            </Button>
+            <div className={"flex justify-end gap-5"}>
+              <button
+                className="text-primary"
+                onClick={() => setSelectedFeatureFlag(flag.id)}
+                aria-label={"Edit"}
+              >
+                <Icon size="md">
+                  <PencilSquareIcon />
+                </Icon>
+              </button>
+            </div>
           ),
         },
       }
@@ -139,54 +156,50 @@ const Admin = () => {
                 setViewBy(value)
               }}
               selectedIndex={viewBy}
+              className={"seeds-m-be-content"}
             >
               <Tabs.TabList>
-                <Tabs.Tab>{"By Jurisdiction"}</Tabs.Tab>
-                <Tabs.Tab>{"By Feature Flag"}</Tabs.Tab>
+                <Tabs.Tab>{"By jurisdiction"}</Tabs.Tab>
+                <Tabs.Tab>{"By feature flag"}</Tabs.Tab>
               </Tabs.TabList>
 
               <Tabs.TabPanel>
-                <Card>
-                  <Card.Header>
-                    <Heading size="2xl">Feature Flags</Heading>
-                  </Card.Header>
-                  <Card.Section>
-                    <MinimalTable
-                      headers={{ jurisdiction: "t.jurisdiction", actions: "" }}
-                      data={jurisdictionTableData}
-                      cellClassName={"px-5 py-3"}
-                      flushRight={true}
-                    ></MinimalTable>
-                  </Card.Section>
-                  <Card.Footer>
-                    <Button onClick={onAddAll}>Add All New Feature Flags</Button>
-                  </Card.Footer>
-                </Card>
+                <Card.Header className={"seeds-m-be-header"}>
+                  <Heading size="2xl" priority={2}>
+                    Feature flags
+                  </Heading>
+                </Card.Header>
+                <Card.Section>
+                  <MinimalTable
+                    headers={{ jurisdiction: "t.jurisdiction", actions: "" }}
+                    data={jurisdictionTableData}
+                    cellClassName={"px-5 py-3"}
+                    flushRight={true}
+                  />
+                </Card.Section>
               </Tabs.TabPanel>
               <Tabs.TabPanel>
-                <Card>
-                  <Card.Header>
-                    <Heading size="2xl">Jurisdictions</Heading>
-                  </Card.Header>
-                  <Card.Section>
-                    {viewBy === TabsIndexEnum.featureFlag && (
-                      <MinimalTable
-                        headers={{
-                          featureFlag: "t.featureFlag",
-                          description: "t.descriptionTitle",
-                          actions: "",
-                        }}
-                        data={featureFlagTableData}
-                        cellClassName={"px-5 py-3"}
-                      ></MinimalTable>
-                    )}
-                  </Card.Section>
-                  <Card.Footer>
-                    <Button onClick={onAddAll}>Add All New Feature Flags</Button>
-                  </Card.Footer>
-                </Card>
+                <Card.Header className={"seeds-m-be-header"}>
+                  <Heading size="2xl" priority={2}>
+                    Jurisdictions
+                  </Heading>
+                </Card.Header>
+                <Card.Section>
+                  {viewBy === TabsIndexEnum.featureFlag && (
+                    <MinimalTable
+                      headers={{
+                        featureFlag: "t.featureFlag",
+                        description: "t.descriptionTitle",
+                        actions: "",
+                      }}
+                      data={featureFlagTableData}
+                      cellClassName={"px-5 py-3"}
+                    />
+                  )}
+                </Card.Section>
               </Tabs.TabPanel>
             </Tabs>
+            <Button onClick={onAddAll}>Add all new feature flags</Button>
           </article>
         </section>
       </Layout>
@@ -197,8 +210,8 @@ const Admin = () => {
         <Drawer.Content>
           <div>
             {featureFlags.map((flag) => (
-              <div key={flag.id}>
-                <legend>{flag.name}</legend>
+              <div key={flag.id} className={"seeds-m-be-content"}>
+                <legend className={"seeds-m-be-text"}>{flag.name}</legend>
                 <Field
                   type="checkbox"
                   id={flag.id}
@@ -224,7 +237,7 @@ const Admin = () => {
         <Drawer.Content>
           <div>
             {jurisdictions.map((juris) => (
-              <div key={juris.id}>
+              <div key={juris.id} className={"seeds-m-be-content"}>
                 <Field
                   type="checkbox"
                   id={juris.id}

--- a/sites/partners/src/pages/admin/index.tsx
+++ b/sites/partners/src/pages/admin/index.tsx
@@ -1,24 +1,247 @@
-import { useContext } from "react"
+import { useContext, useEffect, useMemo, useState } from "react"
 import Head from "next/head"
 import { AuthContext } from "@bloom-housing/shared-helpers"
-import { t } from "@bloom-housing/ui-components"
+import { Field, Hero, MinimalTable, t } from "@bloom-housing/ui-components"
+import { Button, Card, Drawer, Heading, Tabs } from "@bloom-housing/ui-seeds"
 import Layout from "../../layouts"
 import { NavigationHeader } from "../../components/shared/NavigationHeader"
 
-const Admin = () => {
-  const { profile } = useContext(AuthContext)
+export enum TabsIndexEnum {
+  jurisdiction,
+  featureFlag,
+}
 
-  if (!profile || !profile?.userRoles?.isSuperAdmin) {
-    console.log("HERE")
+const Admin = () => {
+  const { profile, featureFlagService, jurisdictionsService } = useContext(AuthContext)
+  const [isLoading, setIsLoading] = useState(true)
+  const [featureFlags, setFeatureFlags] = useState([])
+  const [jurisdictions, setJurisdictions] = useState([])
+  const [selectedJurisdiction, setSelectedJurisdiction] = useState("")
+  const [selectedFeatureFlags, setSelectedFeatureFlags] = useState([])
+  const [selectedJurisdictions, setSelectedJurisdictions] = useState([])
+  const [selectedFeatureFlag, setSelectedFeatureFlag] = useState("")
+  const [viewBy, setViewBy] = useState(TabsIndexEnum.jurisdiction)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const retrievedFeatureFlags = await featureFlagService.list()
+      setFeatureFlags(retrievedFeatureFlags)
+      const retrievedJurisdictions = await jurisdictionsService.list()
+      setJurisdictions(retrievedJurisdictions)
+      setIsLoading(false)
+    }
+    if (isLoading) {
+      void fetchData()
+    }
+  }, [featureFlagService, jurisdictionsService, isLoading])
+
+  useEffect(() => {
+    if (selectedJurisdiction) {
+      const selected = jurisdictions.find((juris) => juris.id === selectedJurisdiction)
+      setSelectedFeatureFlags(selected?.featureFlags)
+    } else {
+      setSelectedFeatureFlags([])
+    }
+  }, [selectedJurisdiction, jurisdictions, featureFlags])
+
+  useEffect(() => {
+    if (selectedFeatureFlag) {
+      const selected = featureFlags.find((flag) => flag.id === selectedFeatureFlag)
+      setSelectedJurisdictions(selected?.jurisdictions?.map((juris) => juris.id))
+    } else {
+      setSelectedJurisdictions([])
+    }
+  }, [selectedFeatureFlag, jurisdictions, featureFlags])
+
+  const jurisdictionTableData = useMemo(() => {
+    return jurisdictions?.map((juris) => {
+      return {
+        jurisdiction: {
+          content: juris.name,
+        },
+        actions: {
+          content: (
+            <Button size="sm" onClick={() => setSelectedJurisdiction(juris.id)}>
+              Edit
+            </Button>
+          ),
+        },
+      }
+    })
+  }, [jurisdictions])
+
+  const featureFlagTableData = useMemo(() => {
+    return featureFlags?.map((flag) => {
+      return {
+        featureFlag: {
+          content: <b>{flag.name}</b>,
+        },
+        description: {
+          content: flag.description,
+        },
+        actions: {
+          content: (
+            <Button size="sm" onClick={() => setSelectedFeatureFlag(flag.id)}>
+              Edit
+            </Button>
+          ),
+        },
+      }
+    })
+  }, [featureFlags])
+
+  const onAddAll = async () => {
+    await featureFlagService.addAllNewFeatureFlags()
   }
 
+  const onFeatureFlagChange = async (featureFlagId: string, jurisdiction: string) => {
+    const foundFeatureFlag = featureFlags.find((flag) => flag.id === featureFlagId)
+    const shouldRemove = foundFeatureFlag.jurisdictions.some((juris) => juris.id === jurisdiction)
+    await featureFlagService.associateJurisdictions({
+      body: {
+        id: featureFlagId,
+        associate: !shouldRemove ? [jurisdiction] : [],
+        remove: shouldRemove ? [jurisdiction] : [],
+      },
+    })
+    setIsLoading(true)
+  }
+
+  if (!profile || !profile?.userRoles?.isSuperAdmin) {
+    return (
+      <Layout>
+        <Head>
+          <title>{t("nav.siteTitlePartners")}</title>
+        </Head>
+        <Hero title={t("t.administration")}>{t("errors.unauthorized.message")}</Hero>
+      </Layout>
+    )
+  }
+
+  const selectedJurisdictionName = selectedJurisdiction
+    ? jurisdictions.find((juris) => juris.id === selectedJurisdiction)?.name
+    : ""
+  const selectedFeatureFlagName = selectedFeatureFlag
+    ? featureFlags.find((flag) => flag.id === selectedFeatureFlag)?.name
+    : ""
+
   return (
-    <Layout>
-      <Head>
-        <title>{t("nav.siteTitlePartners")}</title>
-      </Head>
-      <NavigationHeader className="relative" title={t("t.administration")} />
-    </Layout>
+    <>
+      <Layout>
+        <Head>
+          <title>{t("nav.siteTitlePartners")}</title>
+        </Head>
+        <NavigationHeader className="relative" title={t("t.administration")} />
+        <section>
+          <article className="flex-row flex-wrap relative max-w-screen-xl mx-auto py-8 px-4">
+            <Tabs
+              onSelect={(value) => {
+                setViewBy(value)
+              }}
+              selectedIndex={viewBy}
+            >
+              <Tabs.TabList>
+                <Tabs.Tab>{"By Jurisdiction"}</Tabs.Tab>
+                <Tabs.Tab>{"By Feature Flag"}</Tabs.Tab>
+              </Tabs.TabList>
+
+              <Tabs.TabPanel>
+                <Card>
+                  <Card.Header>
+                    <Heading size="2xl">Feature Flags</Heading>
+                  </Card.Header>
+                  <Card.Section>
+                    <MinimalTable
+                      headers={{ jurisdiction: "t.jurisdiction", actions: "" }}
+                      data={jurisdictionTableData}
+                      cellClassName={"px-5 py-3"}
+                      flushRight={true}
+                    ></MinimalTable>
+                  </Card.Section>
+                  <Card.Footer>
+                    <Button onClick={onAddAll}>Add All New Feature Flags</Button>
+                  </Card.Footer>
+                </Card>
+              </Tabs.TabPanel>
+              <Tabs.TabPanel>
+                <Card>
+                  <Card.Header>
+                    <Heading size="2xl">Jurisdictions</Heading>
+                  </Card.Header>
+                  <Card.Section>
+                    {viewBy === TabsIndexEnum.featureFlag && (
+                      <MinimalTable
+                        headers={{
+                          featureFlag: "t.featureFlag",
+                          description: "t.descriptionTitle",
+                          actions: "",
+                        }}
+                        data={featureFlagTableData}
+                        cellClassName={"px-5 py-3"}
+                      ></MinimalTable>
+                    )}
+                  </Card.Section>
+                  <Card.Footer>
+                    <Button onClick={onAddAll}>Add All New Feature Flags</Button>
+                  </Card.Footer>
+                </Card>
+              </Tabs.TabPanel>
+            </Tabs>
+          </article>
+        </section>
+      </Layout>
+
+      {/* Edit by jurisdiction Drawer */}
+      <Drawer isOpen={!!selectedJurisdiction} onClose={() => setSelectedJurisdiction("")}>
+        <Drawer.Header>{selectedJurisdictionName}</Drawer.Header>
+        <Drawer.Content>
+          <div>
+            {featureFlags.map((flag) => (
+              <div key={flag.id}>
+                <legend>{flag.name}</legend>
+                <Field
+                  type="checkbox"
+                  id={flag.id}
+                  name={flag.name}
+                  label={flag.description}
+                  inputProps={{
+                    defaultChecked: selectedFeatureFlags.some(
+                      (selected) => selected.id === flag.id
+                    ),
+                  }}
+                  bordered
+                  onChange={() => onFeatureFlagChange(flag.id, selectedJurisdiction)}
+                />
+              </div>
+            ))}
+          </div>
+        </Drawer.Content>
+      </Drawer>
+
+      {/* Edit by feature flag Drawer */}
+      <Drawer isOpen={!!selectedFeatureFlag} onClose={() => setSelectedFeatureFlag("")}>
+        <Drawer.Header>{selectedFeatureFlagName}</Drawer.Header>
+        <Drawer.Content>
+          <div>
+            {jurisdictions.map((juris) => (
+              <div key={juris.id}>
+                <Field
+                  type="checkbox"
+                  id={juris.id}
+                  name={juris.name}
+                  label={juris.name}
+                  inputProps={{
+                    defaultChecked: selectedJurisdictions.some((selected) => selected === juris.id),
+                  }}
+                  bordered
+                  onChange={() => onFeatureFlagChange(selectedFeatureFlag, juris.id)}
+                />
+              </div>
+            ))}
+          </div>
+        </Drawer.Content>
+      </Drawer>
+    </>
   )
 }
 

--- a/sites/partners/src/pages/admin/index.tsx
+++ b/sites/partners/src/pages/admin/index.tsx
@@ -1,0 +1,25 @@
+import { useContext } from "react"
+import Head from "next/head"
+import { AuthContext } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
+import Layout from "../../layouts"
+import { NavigationHeader } from "../../components/shared/NavigationHeader"
+
+const Admin = () => {
+  const { profile } = useContext(AuthContext)
+
+  if (!profile || !profile?.userRoles?.isSuperAdmin) {
+    console.log("HERE")
+  }
+
+  return (
+    <Layout>
+      <Head>
+        <title>{t("nav.siteTitlePartners")}</title>
+      </Head>
+      <NavigationHeader className="relative" title={t("t.administration")} />
+    </Layout>
+  )
+}
+
+export default Admin

--- a/sites/partners/src/pages/admin/index.tsx
+++ b/sites/partners/src/pages/admin/index.tsx
@@ -159,14 +159,14 @@ const Admin = () => {
               className={"seeds-m-be-content"}
             >
               <Tabs.TabList>
-                <Tabs.Tab>{"By jurisdiction"}</Tabs.Tab>
-                <Tabs.Tab>{"By feature flag"}</Tabs.Tab>
+                <Tabs.Tab>{t("admin.byJurisdiction")}</Tabs.Tab>
+                <Tabs.Tab>{t("admin.byFeatureFlag")}</Tabs.Tab>
               </Tabs.TabList>
 
               <Tabs.TabPanel>
                 <Card.Header className={"seeds-m-be-header"}>
                   <Heading size="2xl" priority={2}>
-                    Feature flags
+                    {t("t.jurisdictions")}
                   </Heading>
                 </Card.Header>
                 <Card.Section>
@@ -181,7 +181,7 @@ const Admin = () => {
               <Tabs.TabPanel>
                 <Card.Header className={"seeds-m-be-header"}>
                   <Heading size="2xl" priority={2}>
-                    Jurisdictions
+                    {t("t.featureFlag")}
                   </Heading>
                 </Card.Header>
                 <Card.Section>
@@ -199,7 +199,7 @@ const Admin = () => {
                 </Card.Section>
               </Tabs.TabPanel>
             </Tabs>
-            <Button onClick={onAddAll}>Add all new feature flags</Button>
+            <Button onClick={onAddAll}>{t("admin.addFeatureFlags")}</Button>
           </article>
         </section>
       </Layout>


### PR DESCRIPTION
This PR addresses #4533 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This PR adds a new page to the partner site `/admin` which allows the toggling of feature flags for jurisdictions. This page can only be viewed by a new role "superAdmin" which must be manually added to a user. It is also not exposed as a link anywhere so you must directly hit it.

The page does the following:
* A button to add all of the new feature flags to the database "Add All New Feature Flags". When clicked the `/addAllNew` feature flag endpoint is hit
* Displays all of the jurisdictions in a table and has a button to edit the feature flags associated with it. 
* Displays all of the feature flags in a table and has a button to edit the jurisdictions associated with it

Note: No designs were used to create this page. Consider it to be an mvp so the look and feel should not matter as much as the functionality

## How Can This Be Tested/Reviewed?

The following scenarios should be tested:
### Adding feature flags that aren't currently in the database. 
1. Reseed the database
2. start up the partner site and backend
3. Login as a super admin (one is now created with a stage reseeding superadmin@example.com)
4. Add a new feature flag to `feature-flags-enum.ts` in both the enum and the `featureFlagMap`.
5. Go to `/admin` and Click the "Add all new feature flags" button
6. The new feature flag should appear in the table as well as the edit by jurisdiction drawer

###  Get an unauthorized if not a super admin
1. login as a user that doesn't have superAdmin role
2. go to `/admin`
3. You should see an unauthorized banner

### associate and unassociate feature flags to a jurisdiction
1. Reseed the database
2. start up the partner site and backend
3. Login as a super admin (one is now created with a stage reseeding superadmin@example.com)
4. Go to `/admin` 
5. Click on the "edit" button for one of the jurisdictions
6. In the opened up drawer select or unselect the feature flag you want to test
7. Validate the feature flag has been enabled/un-enabled for that jurisdiction

### associate and unassociate jurisdictions to a feature flag
1. Reseed the database
2. start up the partner site and backend
3. Login as a super admin (one is now created with a stage reseeding superadmin@example.com)
4. Go to `/admin` 
5. Click on the "By Feature Flag" tab
6. Click on the "edit" button for one of the feature flags
7. In the opened up drawer select or unselect the jurisdiction you want to test
8. Validate the feature flag has been enabled/un-enabled for that jurisdiction

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
