### PR TITLE
docs: add bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_bug.md
+++ b/.github/ISSUE_TEMPLATE/03_bug.md
@@ -1,0 +1,22 @@
+---
+name: Bug
+about: Bug Writeup
+title: "[Issue Title]"
+labels: ''
+assignees: ''
+---
+- [ ] General
+- [ ] Backend
+- [ ] Public
+- [ ] Partners
+
+## Observed Behavior
+*Description of how the application is currently behaving*
+## Expected Behavior
+*Description of how the application is expected to behave*
+## Steps to Replicate
+*List of steps one could take to witness the observed buggy behavior*
+## Environment Notes
+*Any additional information about the environment*
+### Site/Url 
+*The specific site or base url of the site where the bug was observed*


### PR DESCRIPTION
~This PR addresses #(insert-number-here)~ This is an adhoc addition

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description
Adhoc PR to add a github issue template which is selectable on zenhub for reporting buggy behavior. 

## How Can This Be Tested/Reviewed?
Feel free to add any suggestions on any additional information you'd find helpful for a bug ticket.

After merge a new template should appear in the zenhub app along with the General Issue template
<img width="432" height="343" alt="Screenshot 2025-07-10 at 10 52 46 AM" src="https://github.com/user-attachments/assets/1fca6f25-abda-412d-8f65-119986158e61" />

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
