### PR TITLE
fix: application due date work correctly validates

### DIFF
--- a/api/src/dtos/jurisdictions/jurisdiction.dto.ts
+++ b/api/src/dtos/jurisdictions/jurisdiction.dto.ts
@@ -138,7 +138,7 @@ export class Jurisdiction extends AbstractDTO {
   featureFlags: FeatureFlag[];
 
   @Expose()
-  @ValidateNested({ groups: [ValidationsGroupsEnum.default] })
+  @IsString({ groups: [ValidationsGroupsEnum.default], each: true })
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })
   @ApiProperty({ isArray: true })
   requiredListingFields: string[];

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -210,6 +210,16 @@ class Listing extends AbstractDTO {
   @ValidateListingPublish('applicationDueDate', {
     groups: [ValidationsGroupsEnum.default],
   })
+  @ValidateIf(
+    (o) =>
+      !(
+        o.applicationDueDate == undefined &&
+        o.reviewOrderType == ReviewOrderTypeEnum.waitlist
+      ),
+    {
+      groups: [ValidationsGroupsEnum.default],
+    },
+  )
   @IsDate({ groups: [ValidationsGroupsEnum.default] })
   @Type(() => Date)
   @ApiPropertyOptional()

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -2686,8 +2686,8 @@ export class ListingService implements OnModuleInit {
     return listings.map((listing) => {
       return {
         id: listing.id,
-        lat: listing.listingsBuildingAddress.latitude,
-        lng: listing.listingsBuildingAddress.longitude,
+        lat: listing.listingsBuildingAddress?.latitude,
+        lng: listing.listingsBuildingAddress?.longitude,
       } as ListingMapMarker;
     });
   }


### PR DESCRIPTION
This PR addresses #4717

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

While pulling the #4717 changes into HBA I noticed there was a missed validation around application due date.

There is conditional validation on the applicationDueDate field for listings. It only is validated as required if the listing is not of review order type "waitlist". This was done via a `ValidateIf` on the dto. We should have this carried over for the new dynamic required fields

## How Can This Be Tested/Reviewed?

This validation will only get triggered if the `applicationDueDate` is listed in `requiredListingFields` so the following scenarios should be tested

Jurisdiction with `applicationDueDate` in `requiredListingFields`
1. Save as a draft a listing with `applicationDueDate` filled out should save correctly
2. Save as a draft a listing with `applicationDueDate` not filled out should save correctly
3. publish a listing with `applicationDueDate` not filled and select "waitlist". Should save correctly (assuming you have all other requiredListingFields filled out)
4. publish a listing with `applicationDueDate` not filled and select "open units". should fail on validation of the applicationDueDate field

jurisdiction with `applicationDueDate` *not* in `requiredListingFields`
1. publish a listing with `applicationDueDate` not filled and select "waitlist".  should save correctly (assuming you have all other requiredListingFields filled out)
2. publish a listing with `applicationDueDate` not filled and select "open units". should save correctly (assuming you have all other requiredListingFields filled out)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
