### PR TITLE
feat: preview listing will now show the Seeds version

### DIFF
--- a/sites/public/src/pages/preview/listings/[id].tsx
+++ b/sites/public/src/pages/preview/listings/[id].tsx
@@ -1,14 +1,16 @@
-import React from "react"
+import React, { useContext } from "react"
 import Head from "next/head"
 import axios from "axios"
-import { AlertBox, t } from "@bloom-housing/ui-components"
-import { imageUrlFromListing } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
+import { AuthContext, imageUrlFromListing } from "@bloom-housing/shared-helpers"
 
 import Layout from "../../../layouts/application"
+import { ListingViewSeeds } from "../../../components/listing/ListingViewSeeds"
 import { ListingView } from "../../../components/listing/ListingView"
 import { MetaTags } from "../../../components/shared/MetaTags"
 import { fetchJurisdictionByName } from "../../../lib/hooks"
 import { Jurisdiction, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { Alert } from "@bloom-housing/ui-seeds"
 
 interface ListingProps {
   listing: Listing
@@ -17,6 +19,7 @@ interface ListingProps {
 
 export default function ListingPage(props: ListingProps) {
   const { listing } = props
+  const { profile } = useContext(AuthContext)
   const pageTitle = `${listing.name} - ${t("nav.siteTitle")}`
   const metaDescription = t("pageDescription.listing", {
     regionName: t("region.name"),
@@ -30,16 +33,19 @@ export default function ListingPage(props: ListingProps) {
         <title>{pageTitle}</title>
       </Head>
       <MetaTags title={listing.name} image={metaImage} description={metaDescription} />
-      <AlertBox
-        className="pt-6 pb-4 bg-red-500 font-bold text-xs"
-        type="alert"
-        boundToLayoutWidth
-        inverted
-        closeable
-      >
+      <Alert variant="alert-inverse" fullwidth className="fullscreen-alert">
         {t("listings.listingPreviewOnly")}
-      </AlertBox>
-      <ListingView listing={listing} preview={true} jurisdiction={props.jurisdiction} />
+      </Alert>
+      {process.env.showNewSeedsDesigns ? (
+        <ListingViewSeeds
+          listing={listing}
+          preview={true}
+          profile={profile}
+          jurisdiction={props.jurisdiction}
+        />
+      ) : (
+        <ListingView listing={listing} preview={true} jurisdiction={props.jurisdiction} />
+      )}
     </Layout>
   )
 }

--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -9,6 +9,10 @@
     flex-direction: column;
   }
 
+  .fullscreen-alert {
+    --alert-max-width: calc(var(--seeds-screen-lg) - var(--seeds-s20));
+  }
+
   .styled-stacked-table {
     // Temporary until we have Seeds tables to manipulate UIC StackedTable component
     [class*="stacked-table"] {


### PR DESCRIPTION
This PR addresses #4800 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

For environments with the Seeds listing design enabled, this will show a preview of the listing using the Seeds version.

## How Can This Be Tested/Reviewed?

This can be reviewed here:
https://deploy-preview-5076--bloom-lakeview.netlify.app/preview/listings/e0c9e35a-a672-4b7f-802c-faf91d0f098b

and the non-Seeds version:
https://deploy-preview-5076--bloom-exygy-dev.netlify.app/preview/listings/16815545-3a1a-4639-b2e9-94206a16ba6a

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
