### PR TITLE
fix: add rent validation for finder

### DIFF
--- a/sites/public/src/components/browse/FilterDrawerHelpers.tsx
+++ b/sites/public/src/components/browse/FilterDrawerHelpers.tsx
@@ -184,27 +184,31 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
   )
 }
 
-export const RentSection = (props: RentSectionProps) => {
-  const validateRentValues = () => {
-    const minField = `${ListingFilterKeys.monthlyRent}.minRent`
-    const maxField = `${ListingFilterKeys.monthlyRent}.maxRent`
+export const validateRentValues = (
+  getValues: UseFormMethods["getValues"],
+  clearErrors: UseFormMethods["clearErrors"],
+  setError: UseFormMethods["setError"]
+) => {
+  const minField = `${ListingFilterKeys.monthlyRent}.minRent`
+  const maxField = `${ListingFilterKeys.monthlyRent}.maxRent`
 
-    const minValue = props.getValues(minField)
-    const maxValue = props.getValues(maxField)
+  const minValue = getValues(minField)
+  const maxValue = getValues(maxField)
 
-    props.clearErrors([minField, maxField])
+  clearErrors([minField, maxField])
 
-    if (minValue && maxValue) {
-      const numericMin = parseFloat(minValue.replaceAll(",", ""))
-      const numericMax = parseFloat(maxValue.replaceAll(",", ""))
+  if (minValue && maxValue) {
+    const numericMin = parseFloat(minValue.replaceAll(",", ""))
+    const numericMax = parseFloat(maxValue.replaceAll(",", ""))
 
-      if (numericMin > numericMax) {
-        props.setError(minField, { message: t("errors.minGreaterThanMaxRentError") })
-        props.setError(maxField, { message: t("errors.maxLessThanMinRentError") })
-      }
+    if (numericMin > numericMax) {
+      setError(minField, { message: t("errors.minGreaterThanMaxRentError") })
+      setError(maxField, { message: t("errors.maxLessThanMinRentError") })
     }
   }
+}
 
+export const RentSection = (props: RentSectionProps) => {
   return (
     <fieldset className={styles["filter-section"]}>
       <legend className={styles["filter-section-label"]}>{t("t.rent")}</legend>
@@ -224,7 +228,8 @@ export const RentSection = (props: RentSectionProps) => {
               error={!!props.errors[ListingFilterKeys.monthlyRent]?.minRent}
               errorMessage={props.errors[ListingFilterKeys.monthlyRent]?.minRent?.message}
               inputProps={{
-                onBlur: validateRentValues,
+                onBlur: () =>
+                  validateRentValues(props.getValues, props.clearErrors, props.setError),
               }}
             />
           </Grid.Cell>
@@ -242,7 +247,8 @@ export const RentSection = (props: RentSectionProps) => {
               error={!!props.errors[ListingFilterKeys.monthlyRent]?.maxRent}
               errorMessage={props.errors[ListingFilterKeys.monthlyRent]?.maxRent?.message}
               inputProps={{
-                onBlur: validateRentValues,
+                onBlur: () =>
+                  validateRentValues(props.getValues, props.clearErrors, props.setError),
               }}
             />
           </Grid.Cell>

--- a/sites/public/src/components/finder/FinderRentQuestion.tsx
+++ b/sites/public/src/components/finder/FinderRentQuestion.tsx
@@ -3,6 +3,7 @@ import { useFormContext } from "react-hook-form"
 import finderStyles from "./RentalsFinder.module.scss"
 import styles from "./FinderRentQuestion.module.scss"
 import { ListingFilterKeys } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { validateRentValues } from "../browse/FilterDrawerHelpers"
 
 //TODO: Update component when new designs are available
 
@@ -10,8 +11,7 @@ export default function FinderRentQuestion() {
   const formMethods = useFormContext()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, getValues, setValue } = formMethods
-
+  const { register, getValues, setValue, clearErrors, setError, errors } = formMethods
   return (
     <>
       <div className={styles["rent-input-wrapper"]}>
@@ -25,6 +25,13 @@ export default function FinderRentQuestion() {
           label={t("finder.rent.minRent")}
           placeholder={t("finder.rent.noMinRent")}
           prepend={"$"}
+          error={!!errors[ListingFilterKeys.monthlyRent]?.minRent}
+          errorMessage={errors[ListingFilterKeys.monthlyRent]?.minRent?.message}
+          inputProps={{
+            onBlur: () => {
+              validateRentValues(getValues, clearErrors, setError)
+            },
+          }}
         />
         <Field
           id={`${ListingFilterKeys.monthlyRent}.maxRent`}
@@ -36,6 +43,11 @@ export default function FinderRentQuestion() {
           label={t("finder.rent.maxRent")}
           placeholder={t("finder.rent.noMaxRent")}
           prepend={"$"}
+          error={!!errors[ListingFilterKeys.monthlyRent]?.maxRent}
+          errorMessage={errors[ListingFilterKeys.monthlyRent]?.maxRent?.message}
+          inputProps={{
+            onBlur: () => validateRentValues(getValues, clearErrors, setError),
+          }}
         />
       </div>
       <Field

--- a/sites/public/src/components/finder/RentalsFinder.tsx
+++ b/sites/public/src/components/finder/RentalsFinder.tsx
@@ -46,7 +46,7 @@ export default function RentalsFinder({ activeFeatureFlags }: RentalsFinderProps
   const formMethods = useForm<FilterData>()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { reset, handleSubmit, getValues } = formMethods
+  const { reset, handleSubmit, getValues, errors } = formMethods
 
   const rentalFinderSections: FinderSection[] = useMemo(
     () => [
@@ -166,6 +166,7 @@ export default function RentalsFinder({ activeFeatureFlags }: RentalsFinderProps
   const isLastStep = stepIndex === rentalFinderSections[sectionIndex]?.sectionSteps.length - 1
 
   const onNextClick = useCallback(() => {
+    if (Object.keys(errors).length > 0) return
     setFormData((prev) => ({ ...prev, ...getValues() }))
     if (isLastStep) {
       setSectionIndex((prev) => prev + 1)
@@ -173,7 +174,7 @@ export default function RentalsFinder({ activeFeatureFlags }: RentalsFinderProps
     } else {
       setStepIndex((prev) => prev + 1)
     }
-  }, [isLastStep, getValues])
+  }, [errors, isLastStep, getValues])
 
   const onPreviousClick = useCallback(() => {
     if (JSON.stringify(getValues()) !== JSON.stringify(formData)) {


### PR DESCRIPTION
This PR addresses #4822

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Follow-up to [this](https://github.com/bloom-housing/bloom/pull/5057) that adds validation for finder.

## How Can This Be Tested/Reviewed?

go to `http://localhost:3000/finder` click next till you get min / max rent, now it should validate fields, and block next step when errors

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
