### PR TITLE
fix: fix last updated at missing value

### DIFF
--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -171,18 +171,19 @@ export const ListingViewSeeds = ({ listing, jurisdiction, profile, preview }: Li
 
   const ListingUpdatedAt = (
     <>
-      {isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableListingUpdatedAt) && (
-        <Card
-          className={`${styles["mobile-full-width-card"]} ${styles["mobile-no-bottom-border"]}`}
-        >
-          <Card.Section>
-            <p>
-              {t("listings.listingUpdated")}:{" "}
-              {getDateString(listing.contentUpdatedAt, "MMM DD, YYYY")}
-            </p>
-          </Card.Section>
-        </Card>
-      )}
+      {isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableListingUpdatedAt) &&
+        listing.contentUpdatedAt && (
+          <Card
+            className={`${styles["mobile-full-width-card"]} ${styles["mobile-no-bottom-border"]}`}
+          >
+            <Card.Section>
+              <p>
+                {t("listings.listingUpdated")}:{" "}
+                {getDateString(listing.contentUpdatedAt, "MMM DD, YYYY")}
+              </p>
+            </Card.Section>
+          </Card>
+        )}
     </>
   )
 


### PR DESCRIPTION
This PR addresses #5079 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Update the `ListingUpdatedAt` subcomponent rendering logic, i.e., don't show if the `enableListingUpdatedAt` is disabled or the `contentUpdatedAt` value is empty. 

## How Can This Be Tested/Reviewed?

* Go to Prisma Studio'
* Enable the `enableListingUpdatedAt` feature flag for the currently configured 
* Select any listing that will be available on the currently configured public site
* Find and clear the `contentUpdatedAt` cell value
* Go to `/listings` on the public site
* Select the previously altered listing
* The `Last Updated At` card in the listing sidebar should not be visible

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
