### PR TITLE
feat: bash fixes 1

### DIFF
--- a/shared-helpers/src/utilities/photos.ts
+++ b/shared-helpers/src/utilities/photos.ts
@@ -36,5 +36,5 @@ export const imageUrlFromListing = (listing: Listing, size = 400): string[] => {
         : asset.fileId
     })
 
-  return imageUrls?.length > 0 ? imageUrls : ["/images/fallback-listing.png"]
+  return imageUrls?.length > 0 ? imageUrls : ["/images/listing-fallback.png"]
 }

--- a/sites/public/__tests__/components/listing/listing_sections/Apply.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/Apply.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import dayjs from "dayjs"
+import { screen } from "@testing-library/dom"
 import { render, cleanup, fireEvent } from "@testing-library/react"
 import {
   ApplicationMethodsTypeEnum,
@@ -16,8 +17,24 @@ import { getDateString } from "../../../../src/components/listing/ListingViewSee
 afterEach(cleanup)
 
 describe("<Apply>", () => {
+  const mockUser: User = {
+    id: "123",
+    email: "test@test.com",
+    firstName: "Test",
+    lastName: "User",
+    dob: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    jurisdictions: [],
+    mfaEnabled: false,
+    passwordUpdatedAt: new Date(),
+    passwordValidForDays: 180,
+    agreedToTermsOfService: true,
+    listings: [],
+  }
+
   it("does not render if only application method is referral", () => {
-    const { queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -39,11 +56,11 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(queryByText("How to Apply")).toBeNull()
+    expect(screen.queryByText("How to Apply")).not.toBeInTheDocument()
   })
 
   it("does not render if due date is in the past", () => {
-    const { queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -65,11 +82,11 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(queryByText("How to Apply")).toBeNull()
+    expect(screen.queryByText("How to Apply")).not.toBeInTheDocument()
   })
 
   it("does not render if listing is closed", () => {
-    const { queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -92,11 +109,11 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(queryByText("How to Apply")).toBeNull()
+    expect(screen.queryByText("How to Apply")).not.toBeInTheDocument()
   })
 
   it("shows apply online button for internal online application", () => {
-    const { getByText, getByRole, queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -118,19 +135,19 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Apply Online")).toBeDefined()
-    expect(getByRole("link", { name: "Apply Online" })).toHaveAttribute(
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Apply Online")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Apply Online" })).toHaveAttribute(
       "href",
       `/applications/start/choose-language?listingId=${listing.id}`
     )
 
-    expect(queryByText("Download Application")).toBeNull()
+    expect(screen.queryByText("Download Application")).not.toBeInTheDocument()
   })
 
   it("shows redirected apply online button for internal online application with mandated accounts on while signed out", () => {
     process.env.showMandatedAccounts = "TRUE"
-    const { getByText, getByRole, queryByText } = render(
+    render(
       <AuthContext.Provider value={{ initialStateLoaded: true, profile: null }}>
         <Apply
           listing={{
@@ -154,34 +171,19 @@ describe("<Apply>", () => {
         />
       </AuthContext.Provider>
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Apply Online")).toBeDefined()
-    expect(getByRole("link", { name: "Apply Online" })).toHaveAttribute(
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Apply Online")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Apply Online" })).toHaveAttribute(
       "href",
       `/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listing.id}`
     )
 
-    expect(queryByText("Download Application")).toBeNull()
+    expect(screen.queryByText("Download Application")).not.toBeInTheDocument()
   })
 
   it("shows not-redirected apply online button for internal online application with mandated accounts on while signed in", () => {
     process.env.showMandatedAccounts = "TRUE"
-    const mockUser: User = {
-      id: "123",
-      email: "test@test.com",
-      firstName: "Test",
-      lastName: "User",
-      dob: new Date(),
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      jurisdictions: [],
-      mfaEnabled: false,
-      passwordUpdatedAt: new Date(),
-      passwordValidForDays: 180,
-      agreedToTermsOfService: true,
-      listings: [],
-    }
-    const { getByText, getByRole, queryByText } = render(
+    render(
       <AuthContext.Provider value={{ initialStateLoaded: true, profile: mockUser }}>
         <Apply
           listing={{
@@ -205,18 +207,18 @@ describe("<Apply>", () => {
         />
       </AuthContext.Provider>
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Apply Online")).toBeDefined()
-    expect(getByRole("link", { name: "Apply Online" })).toHaveAttribute(
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Apply Online")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Apply Online" })).toHaveAttribute(
       "href",
       `/applications/start/choose-language?listingId=${listing.id}`
     )
 
-    expect(queryByText("Download Application")).toBeNull()
+    expect(screen.queryByText("Download Application")).not.toBeInTheDocument()
   })
 
   it("shows apply online button for external online application", () => {
-    const { getByText, getByRole, queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -238,14 +240,86 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Apply Online")).toBeDefined()
-    expect(getByRole("link", { name: "Apply Online" })).toHaveAttribute(
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Apply Online")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Apply Online" })).toHaveAttribute(
       "href",
       "https://www.exygy.com"
     )
 
-    expect(queryByText("Download Application")).toBeNull()
+    expect(screen.queryByText("Download Application")).not.toBeInTheDocument()
+  })
+
+  it("shows apply online button for external online application with mandated accounts on and signed out", () => {
+    process.env.showMandatedAccounts = "TRUE"
+    render(
+      <AuthContext.Provider value={{ initialStateLoaded: true, profile: null }}>
+        <Apply
+          listing={{
+            ...listing,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+            applicationMethods: [
+              {
+                id: "id",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                type: ApplicationMethodsTypeEnum.ExternalLink,
+                acceptsPostmarkedApplications: null,
+                externalReference: "https://www.exygy.com",
+                paperApplications: [],
+                phoneNumber: null,
+              },
+            ],
+          }}
+          preview={false}
+          setShowDownloadModal={() => null}
+        />
+      </AuthContext.Provider>
+    )
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Apply Online")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Apply Online" })).toHaveAttribute(
+      "href",
+      "https://www.exygy.com"
+    )
+
+    expect(screen.queryByText("Download Application")).not.toBeInTheDocument()
+  })
+
+  it("shows apply online button for external online application with mandated accounts on and signed in", () => {
+    process.env.showMandatedAccounts = "TRUE"
+    render(
+      <AuthContext.Provider value={{ initialStateLoaded: true, profile: mockUser }}>
+        <Apply
+          listing={{
+            ...listing,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+            applicationMethods: [
+              {
+                id: "id",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                type: ApplicationMethodsTypeEnum.ExternalLink,
+                acceptsPostmarkedApplications: null,
+                externalReference: "https://www.exygy.com",
+                paperApplications: [],
+                phoneNumber: null,
+              },
+            ],
+          }}
+          preview={false}
+          setShowDownloadModal={() => null}
+        />
+      </AuthContext.Provider>
+    )
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Apply Online")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Apply Online" })).toHaveAttribute(
+      "href",
+      "https://www.exygy.com"
+    )
+
+    expect(screen.queryByText("Download Application")).not.toBeInTheDocument()
   })
 
   it("shows download application button and opens modal for multiple paper applications", () => {
@@ -253,7 +327,7 @@ describe("<Apply>", () => {
     const fetchMock = jest
       .spyOn(global, "fetch")
       .mockImplementation(() => Promise.resolve(new Response()))
-    const { getByText, queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -302,13 +376,13 @@ describe("<Apply>", () => {
         setShowDownloadModal={showDownloadModalSpy}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Download Application")).toBeDefined()
-    fireEvent.click(getByText("Download Application"))
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Download Application" })).toBeInTheDocument()
+    fireEvent.click(screen.getByText("Download Application"))
     expect(showDownloadModalSpy).toHaveBeenCalled()
 
     expect(fetchMock).not.toHaveBeenCalled()
-    expect(queryByText("Apply Online")).toBeNull()
+    expect(screen.queryByText("Apply Online")).not.toBeInTheDocument()
   })
 
   it("shows download application button and does not open modal for one paper application", () => {
@@ -319,7 +393,7 @@ describe("<Apply>", () => {
       .mockImplementation(() => Promise.resolve(new Response()))
     process.env.cloudinaryCloudName = "exygy"
 
-    const { getByText, queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -355,20 +429,20 @@ describe("<Apply>", () => {
         setShowDownloadModal={showDownloadModalSpy}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Download Application")).toBeDefined()
-    fireEvent.click(getByText("Download Application"))
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Download Application" })).toBeInTheDocument()
+    fireEvent.click(screen.getByText("Download Application"))
     expect(fetchMock).toHaveBeenCalledWith(
       "https://res.cloudinary.com/exygy/image/upload/paper-application-id.pdf",
       { headers: { "Content-Type": "application/pdf" }, method: "GET" }
     )
 
-    expect(queryByText("Apply Online")).toBeNull()
+    expect(screen.queryByText("Apply Online")).not.toBeInTheDocument()
     expect(showDownloadModalSpy).not.toHaveBeenCalled()
   })
 
   it("shows apply online and download application button for online and paper", () => {
-    const { getByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -414,13 +488,13 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Apply Online")).toBeDefined()
-    expect(getByText("Download Application")).toBeDefined()
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Apply Online")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Download Application" })).toBeInTheDocument()
   })
 
   it("shows paper application and mailing / drop off / pick up addresses", () => {
-    const { getByText, queryByText, getAllByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -494,29 +568,29 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Download Application")).toBeDefined()
-    expect(getByText("Pick up an application")).toBeDefined()
-    expect(getByText("Pick up address street, Pick up address unit")).toBeDefined()
-    expect(getByText("Pick up address city, CA 67890")).toBeDefined()
-    expect(getByText("Pick up address office hours")).toBeDefined()
-    expect(getByText("Submit a Paper Application")).toBeDefined()
-    expect(getByText("Send Application by US Mail")).toBeDefined()
-    expect(getByText("Mailing address street, Mailing address unit")).toBeDefined()
-    expect(getByText("Mailing address city, CO 12345")).toBeDefined()
-    expect(getByText("Drop Off Application")).toBeDefined()
-    expect(getByText("Drop off address street, Drop off address unit")).toBeDefined()
-    expect(getByText("Drop off address city, CT 45678")).toBeDefined()
-    expect(getByText("Drop off address office hours")).toBeDefined()
-    expect(getAllByText("Get Directions").length).toBe(2)
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Download Application" })).toBeInTheDocument()
+    expect(screen.getByText("Pick up an application")).toBeInTheDocument()
+    expect(screen.getByText("Pick up address street, Pick up address unit")).toBeInTheDocument()
+    expect(screen.getByText("Pick up address city, CA 67890")).toBeInTheDocument()
+    expect(screen.getByText("Pick up address office hours")).toBeInTheDocument()
+    expect(screen.getByText("Submit a Paper Application")).toBeInTheDocument()
+    expect(screen.getByText("Send Application by US Mail")).toBeInTheDocument()
+    expect(screen.getByText("Mailing address street, Mailing address unit")).toBeInTheDocument()
+    expect(screen.getByText("Mailing address city, CO 12345")).toBeInTheDocument()
+    expect(screen.getByText("Drop Off Application")).toBeInTheDocument()
+    expect(screen.getByText("Drop off address street, Drop off address unit")).toBeInTheDocument()
+    expect(screen.getByText("Drop off address city, CT 45678")).toBeInTheDocument()
+    expect(screen.getByText("Drop off address office hours")).toBeInTheDocument()
+    expect(screen.getAllByText("Get Directions").length).toBe(2)
 
-    expect(queryByText("Apply Online")).toBeNull()
+    expect(screen.queryByText("Apply Online")).not.toBeInTheDocument()
   })
 
   it("shows mailing address with postmark", () => {
     const dueDate = dayjs(new Date()).add(5, "days").toDate()
     const postmarkDate = dayjs(new Date()).add(10, "days").toDate()
-    const { getByText, queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -565,20 +639,20 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
     const postmarkString = getDateString(postmarkDate, `MMM DD, YYYY [${t("t.at")}] hh:mm A`)
     expect(
-      getByText(
+      screen.getByText(
         `Applications must be received by the deadline. If sending by U.S. Mail, the application must be postmarked by ${postmarkString}. ${listing.developer} is not responsible for lost or delayed mail.`
       )
     )
 
-    expect(queryByText("Apply Online")).toBeNull()
+    expect(screen.queryByText("Apply Online")).not.toBeInTheDocument()
   })
 
   it("shows mailing address with no postmark", () => {
     const dueDate = dayjs(new Date()).add(5, "days").toDate()
-    const { getByText, queryByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -627,16 +701,16 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
     const dueDateString = getDateString(dueDate, `MMM DD, YYYY [${t("t.at")}] hh:mm A`)
 
     expect(
-      getByText(
+      screen.getByText(
         `Applications must be received by the deadline. If sending by U.S. Mail, the application must be received by ${dueDateString}. ${listing.developer} is not responsible for lost or delayed mail.`
       )
     )
 
-    expect(queryByText("Apply Online")).toBeNull()
+    expect(screen.queryByText("Apply Online")).not.toBeInTheDocument()
   })
 
   it("shows mailing address with no online or paper app", () => {
@@ -644,7 +718,7 @@ describe("<Apply>", () => {
     const addressState = "Ohio"
     const addressStreet = "1598 Peaceful Lane"
     const addressZipCode = "44128"
-    const { getByText } = render(
+    render(
       <Apply
         listing={{
           ...listing,
@@ -674,11 +748,11 @@ describe("<Apply>", () => {
         setShowDownloadModal={() => null}
       />
     )
-    expect(getByText("How to Apply")).toBeDefined()
-    expect(getByText("Send Application by US Mail")).toBeDefined()
-    expect(getByText(addressCity, { exact: false })).toBeDefined()
-    expect(getByText(addressState, { exact: false })).toBeDefined()
-    expect(getByText(addressStreet, { exact: false })).toBeDefined()
-    expect(getByText(addressZipCode, { exact: false })).toBeDefined()
+    expect(screen.getByRole("heading", { level: 2, name: "How to Apply" })).toBeInTheDocument()
+    expect(screen.getByText("Send Application by US Mail")).toBeInTheDocument()
+    expect(screen.getByText(addressCity, { exact: false })).toBeInTheDocument()
+    expect(screen.getByText(addressState, { exact: false })).toBeInTheDocument()
+    expect(screen.getByText(addressStreet, { exact: false })).toBeInTheDocument()
+    expect(screen.getByText(addressZipCode, { exact: false })).toBeInTheDocument()
   })
 })

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -373,7 +373,7 @@ export const ListingView = (props: ListingProps) => {
 
   const getOnlineApplicationURL = () => {
     let onlineApplicationURL
-    let isCommonApp
+    let isCommonApp = false
     if (hasMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.Internal)) {
       onlineApplicationURL = `/applications/start/choose-language?listingId=${listing.id}`
       onlineApplicationURL += `${props.preview ? "&preview=true" : ""}`
@@ -382,7 +382,6 @@ export const ListingView = (props: ListingProps) => {
       onlineApplicationURL =
         getMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)
           ?.externalReference || ""
-      isCommonApp = false
     }
     return { url: onlineApplicationURL, isCommonApp }
   }

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -373,15 +373,18 @@ export const ListingView = (props: ListingProps) => {
 
   const getOnlineApplicationURL = () => {
     let onlineApplicationURL
+    let isCommonApp
     if (hasMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.Internal)) {
       onlineApplicationURL = `/applications/start/choose-language?listingId=${listing.id}`
       onlineApplicationURL += `${props.preview ? "&preview=true" : ""}`
+      isCommonApp = true
     } else if (hasMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)) {
       onlineApplicationURL =
         getMethod(listing.applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)
           ?.externalReference || ""
+      isCommonApp = false
     }
-    return onlineApplicationURL
+    return { url: onlineApplicationURL, isCommonApp }
   }
 
   const getPaperApplications = () => {
@@ -419,22 +422,29 @@ export const ListingView = (props: ListingProps) => {
     return date ? dayjs(date).format(format) : null
   }
 
-  const redirectIfSignedOut = () =>
-    process.env.showMandatedAccounts && initialStateLoaded && !profile
-
   const submissionAddressExists =
     listing.listingsApplicationMailingAddress ||
     listing.applicationMailingAddressType === ApplicationAddressTypeEnum.leasingAgent ||
     listing.listingsApplicationDropOffAddress ||
     listing.applicationDropOffAddressType === ApplicationAddressTypeEnum.leasingAgent
 
+  const onlineApplicationURLInfo = getOnlineApplicationURL()
+
+  const redirectIfLogInRequired = () =>
+    process.env.showMandatedAccounts &&
+    initialStateLoaded &&
+    !profile &&
+    onlineApplicationURLInfo.isCommonApp &&
+    //previewing applications should not require admin to login
+    !props.preview
+
   const applySidebar = () => (
     <>
       <GetApplication
         onlineApplicationURL={
-          redirectIfSignedOut()
+          redirectIfLogInRequired()
             ? `/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listing.id}`
-            : getOnlineApplicationURL()
+            : onlineApplicationURLInfo.url
         }
         applicationsOpen={!appOpenInFuture}
         applicationsOpenDate={getDateString(listing.applicationOpenDate, "MMMM D, YYYY")}

--- a/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
+++ b/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
@@ -99,15 +99,18 @@ export const getOnlineApplicationURL = (
   preview: boolean
 ) => {
   let onlineApplicationURL
+  let isCommonApp
   if (hasMethod(applicationMethods, ApplicationMethodsTypeEnum.Internal)) {
     onlineApplicationURL = `/applications/start/choose-language?listingId=${listingId}`
     onlineApplicationURL += `${preview ? "&preview=true" : ""}`
+    isCommonApp = true
   } else if (hasMethod(applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)) {
     onlineApplicationURL =
       getMethod(applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)?.externalReference ||
       ""
+    isCommonApp = false
   }
-  return onlineApplicationURL
+  return { url: onlineApplicationURL, isCommonApp }
 }
 
 export const getHasNonReferralMethods = (listing: Listing) => {

--- a/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
+++ b/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
@@ -99,7 +99,7 @@ export const getOnlineApplicationURL = (
   preview: boolean
 ) => {
   let onlineApplicationURL
-  let isCommonApp
+  let isCommonApp = false
   if (hasMethod(applicationMethods, ApplicationMethodsTypeEnum.Internal)) {
     onlineApplicationURL = `/applications/start/choose-language?listingId=${listingId}`
     onlineApplicationURL += `${preview ? "&preview=true" : ""}`
@@ -108,7 +108,6 @@ export const getOnlineApplicationURL = (
     onlineApplicationURL =
       getMethod(applicationMethods, ApplicationMethodsTypeEnum.ExternalLink)?.externalReference ||
       ""
-    isCommonApp = false
   }
   return { url: onlineApplicationURL, isCommonApp }
 }

--- a/sites/public/src/components/listing/listing_sections/Apply.tsx
+++ b/sites/public/src/components/listing/listing_sections/Apply.tsx
@@ -48,7 +48,7 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
 
   const onlineApplicationUrl = redirectIfLogInRequired()
     ? `/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listing.id}`
-    : getOnlineApplicationURL(listing.applicationMethods, listing.id, preview)?.url
+    : onlineApplicationURLInfo.url
   const disableApplyButton = !preview && listing.status !== ListingsStatusEnum.active
 
   const paperApplications = getPaperApplications(listing.applicationMethods)

--- a/sites/public/src/components/listing/listing_sections/Apply.tsx
+++ b/sites/public/src/components/listing/listing_sections/Apply.tsx
@@ -32,12 +32,23 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
 
   const applicationsClosed = dayjs() > dayjs(listing.applicationDueDate)
 
-  const redirectIfSignedOut = () =>
-    process.env.showMandatedAccounts && initialStateLoaded && !profile
+  const onlineApplicationURLInfo = getOnlineApplicationURL(
+    listing.applicationMethods,
+    listing.id,
+    preview
+  )
 
-  const onlineApplicationUrl = redirectIfSignedOut()
+  const redirectIfLogInRequired = () =>
+    process.env.showMandatedAccounts &&
+    initialStateLoaded &&
+    !profile &&
+    onlineApplicationURLInfo.isCommonApp &&
+    //previewing applications should not require admin to login
+    !preview
+
+  const onlineApplicationUrl = redirectIfLogInRequired()
     ? `/sign-in?redirectUrl=/applications/start/choose-language&listingId=${listing.id}`
-    : getOnlineApplicationURL(listing.applicationMethods, listing.id, preview)
+    : getOnlineApplicationURL(listing.applicationMethods, listing.id, preview)?.url
   const disableApplyButton = !preview && listing.status !== ListingsStatusEnum.active
 
   const paperApplications = getPaperApplications(listing.applicationMethods)

--- a/sites/public/src/components/shared/FormSummaryDetails.tsx
+++ b/sites/public/src/components/shared/FormSummaryDetails.tsx
@@ -145,7 +145,7 @@ const FormSummaryDetails = ({
     return (
       <>
         <Card.Header className={styles["summary-header"]}>
-          <Heading priority={3} size="xl" className="font-serif font-normal">
+          <Heading priority={3} size="xl">
             {header}
           </Heading>
           {editMode && !validationError && <Link href={appLink}>{t("t.edit")}</Link>}
@@ -198,7 +198,7 @@ const FormSummaryDetails = ({
   return (
     <>
       <Card.Header className={styles["summary-header"]}>
-        <Heading priority={3} size="xl" className="font-serif font-normal">
+        <Heading priority={3} size="xl">
           {t("t.you")}
         </Heading>
         {editMode && <Link href="/applications/contact/name">{t("t.edit")}</Link>}
@@ -317,7 +317,7 @@ const FormSummaryDetails = ({
       {application.alternateContact.type && application.alternateContact.type !== "noContact" && (
         <>
           <Card.Header className={styles["summary-header"]}>
-            <Heading priority={3} size="xl" className="font-serif font-normal">
+            <Heading priority={3} size="xl">
               {t("application.alternateContact.type.label")}
             </Heading>
             {editMode && !validationError && (
@@ -378,7 +378,7 @@ const FormSummaryDetails = ({
       {application.householdSize > 1 && (
         <>
           <Card.Header className={styles["summary-header"]}>
-            <Heading priority={3} size="xl" className="font-serif font-normal">
+            <Heading priority={3} size="xl">
               {t("application.household.householdMembers")}
             </Heading>
             {editMode && !validationError && (
@@ -441,7 +441,7 @@ const FormSummaryDetails = ({
 
       <>
         <Card.Header className={styles["summary-header"]}>
-          <Heading priority={3} size="xl" className="font-serif font-normal">
+          <Heading priority={3} size="xl">
             {t("application.review.householdDetails")}
           </Heading>
           {editMode && !validationError && (
@@ -510,7 +510,7 @@ const FormSummaryDetails = ({
           )}
 
         <Card.Header className={styles["summary-header"]}>
-          <Heading priority={3} size="xl" className="font-serif font-normal">
+          <Heading priority={3} size="xl">
             {t("t.income")}
           </Heading>
           {editMode && !validationError && (


### PR DESCRIPTION
This PR addresses #5080 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

This PR addresses the following points in the issue:

1. The fallback image is now utilized. There was a typo creating this bug.
3. The styling is fixed by removing the unnecessary tailwind which allows the overrides to apply correctly. NOTE that this slightly changes the visuals of the core experience but since anything seeds related should be using sans serif and I assume we'd want the h3 headers to align in styling rather than create a custom one off styling for the application, I made the update
You is a example of old styling, Household Details is an example of new styling
<img width="369" height="522" alt="Screenshot 2025-07-21 at 8 21 34 AM" src="https://github.com/user-attachments/assets/aa22eea6-df02-45ca-ae1d-3fae7fb1dfe4" />

4. Mandated accounts should not force a user to sign in if the application is not a common app. This is achieved by pulling a doorway PR back to core (with slight tweaks) https://github.com/metrotranscom/doorway/pull/593

## How Can This Be Tested/Reviewed?

In Lakeview

Point 1. Create a listing with no listing image and ensure the fallback image shows on the listing browse page
Point 3. See that the h3 styling in the application summary view matches that of the other h3 headers across the site. (Personally tested in detroit and it worked as desired with the overrides)

Point 4. (with mandated accounts enabled) Try to apply to a listing with the common app (while signed out) and it should redirect, a listing with the common app (while signed in) and it should not redirect, and an external online application and it should not redirect

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
