### PR TITLE
fix: include `totalAvailable` from unit groups in vacancies query

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -545,9 +545,18 @@ export class ListingService implements OnModuleInit {
                   key: ListingFilterKeys.availabilities,
                   caseSensitive: true,
                 });
-                return builtFilter.map((filt) => ({
-                  unitsAvailable: filt,
-                }));
+
+                return builtFilter
+                  .map((filt) => ({
+                    unitsAvailable: filt,
+                  }))
+                  .concat({
+                    unitGroups: {
+                      some: {
+                        totalAvailable: { gte: 1 },
+                      },
+                    },
+                  });
               }
             },
           );
@@ -656,9 +665,17 @@ export class ListingService implements OnModuleInit {
             caseSensitive: true,
           });
           filters.push({
-            OR: builtFilter.map((filt) => ({
-              unitsAvailable: filt,
-            })),
+            OR: builtFilter
+              .map((filt) => ({
+                unitsAvailable: filt,
+              }))
+              .concat({
+                unitGroups: {
+                  some: {
+                    totalAvailable: { gte: 1 },
+                  },
+                },
+              }),
           });
         }
         if (filter[ListingFilterKeys.bathrooms] !== undefined) {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -1474,6 +1474,15 @@ describe('Testing listing service', () => {
                   gte: 1,
                 },
               },
+              {
+                unitGroups: {
+                  some: {
+                    totalAvailable: {
+                      gte: 1,
+                    },
+                  },
+                },
+              },
             ],
           },
         ],
@@ -1513,6 +1522,15 @@ describe('Testing listing service', () => {
               {
                 unitsAvailable: {
                   gte: 1,
+                },
+              },
+              {
+                unitGroups: {
+                  some: {
+                    totalAvailable: {
+                      gte: 1,
+                    },
+                  },
                 },
               },
             ],
@@ -1651,6 +1669,15 @@ describe('Testing listing service', () => {
               {
                 unitsAvailable: {
                   gte: 1,
+                },
+              },
+              {
+                unitGroups: {
+                  some: {
+                    totalAvailable: {
+                      gte: 1,
+                    },
+                  },
                 },
               },
             ],


### PR DESCRIPTION
This PR addresses #4919

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This adds an additional OR query to the backend whenever the `unitsAvailable` filter is enabled so that the `totalAvailable` field from units groups are accounted for.

## How Can This Be Tested/Reviewed?

Boot up the Public site in the Lakeview jurisdiction and verify that using the available units filter (to be renamed separately to Vacant Units in [this PR](https://github.com/bloom-housing/bloom/pull/5102))

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
