### PR TITLE
fix: use listing assets only when array, refactor of photo helper

### DIFF
--- a/shared-helpers/src/utilities/photos.ts
+++ b/shared-helpers/src/utilities/photos.ts
@@ -19,22 +19,21 @@ export const getUrlForListingImage = (image: Asset, size = 400) => {
 }
 
 export const imageUrlFromListing = (listing: Listing, size = 400): string[] => {
-  const imageAssets =
-    listing?.listingImages?.length && listing.listingImages[0].assets
-      ? listing.listingImages
-          .sort((imageA, imageB) => (imageA.ordinal ?? 10) - (imageB?.ordinal ?? 10))
-          .map((imageObj) => imageObj.assets)
-      : listing?.assets
+  let imageAssets: Asset[] = []
+
+  if (listing?.listingImages?.length && listing.listingImages[0].assets) {
+    imageAssets = listing.listingImages
+      .sort((imageA, imageB) => (imageA.ordinal ?? 10) - (imageB?.ordinal ?? 10))
+      .map((imageObj) => imageObj.assets)
+  } else if (Array.isArray(listing?.assets)) {
+    imageAssets = listing.assets
+  }
 
   const imageUrls = imageAssets
     ?.filter(
       (asset: Asset) => asset.label === CLOUDINARY_BUILDING_LABEL || asset.label === "building"
     )
-    ?.map((asset: Asset) => {
-      return asset.label === CLOUDINARY_BUILDING_LABEL
-        ? cloudinaryUrlFromId(asset.fileId, size)
-        : asset.fileId
-    })
+    ?.map((asset: Asset) => getUrlForListingImage(asset, size) as string)
 
   return imageUrls?.length > 0 ? imageUrls : ["/images/listing-fallback.png"]
 }

--- a/shared-helpers/src/utilities/photos.ts
+++ b/shared-helpers/src/utilities/photos.ts
@@ -33,7 +33,7 @@ export const imageUrlFromListing = (listing: Listing, size = 400): string[] => {
     ?.filter(
       (asset: Asset) => asset.label === CLOUDINARY_BUILDING_LABEL || asset.label === "building"
     )
-    ?.map((asset: Asset) => getUrlForListingImage(asset, size) as string)
+    ?.map((asset: Asset) => getUrlForListingImage(asset, size) || "")
 
-  return imageUrls?.length > 0 ? imageUrls : ["/images/listing-fallback.png"]
+  return imageUrls?.length > 0 ? imageUrls : [IMAGE_FALLBACK_URL]
 }


### PR DESCRIPTION
This PR addresses #5075

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

If a listing gets published with no image, there was old fallback code to look at assets directly attached to a listing. The problem was that JSON value could be `{}` instead of `[]`. I'm not sure why even after spending some time poking around, so I simply add this Array type check. If we don't like that approach, an alternative might be to stop look at listings assets (is that even still a requirement?).

## How Can This Be Tested/Reviewed?

Save a new published listing with no image, then verify you can view it on public and see a fallback image placeholder.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
