### PR TITLE
5117/what to expect additional text field

### DIFF
--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -517,6 +517,14 @@ class Listing extends AbstractDTO {
   whatToExpect?: string;
 
   @Expose()
+  @ValidateListingPublish('whatToExpectAdditionalText', {
+    groups: [ValidationsGroupsEnum.default],
+  })
+  @ApiPropertyOptional()
+  @SanitizeHtml()
+  whatToExpectAdditionalText?: string;
+
+  @Expose()
   @ValidateListingPublish('status', {
     groups: [ValidationsGroupsEnum.default],
   })

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -1123,5 +1123,6 @@
   "welcome.viewAdditionalHousingTruncated": "View resources",
   "whatToExpect.default": "Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents.",
   "whatToExpectAdditionalText.default": "",
-  "whatToExpect.label": "What to Expect"
+  "whatToExpect.label": "What to Expect",
+  "whatToExpectAdditionalText.label": "Additional Info"
 }

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -1122,5 +1122,6 @@
   "welcome.viewAdditionalHousing": "View additional housing opportunities and resources",
   "welcome.viewAdditionalHousingTruncated": "View resources",
   "whatToExpect.default": "Applicants will be contacted by the property agent in rank order until vacancies are filled. All of the information that you have provided will be verified and your eligibility confirmed. Your application will be removed from the waitlist if you have made any fraudulent statements. If we cannot verify a housing preference that you have claimed, you will not receive the preference but will not be otherwise penalized. Should your application be chosen, be prepared to fill out a more detailed application and provide required supporting documents.",
+  "whatToExpectAdditionalText.default": "",
   "whatToExpect.label": "What to Expect"
 }

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -3971,6 +3971,9 @@ export interface Listing {
   whatToExpect?: string
 
   /**  */
+  whatToExpectAdditionalText?: string
+
+  /**  */
   status: ListingsStatusEnum
 
   /**  */
@@ -4610,6 +4613,12 @@ export interface ListingCreate {
   waitlistMaxSize?: number
 
   /**  */
+  whatToExpect?: string
+
+  /**  */
+  whatToExpectAdditionalText?: string
+
+  /**  */
   status: ListingsStatusEnum
 
   /**  */
@@ -4749,9 +4758,6 @@ export interface ListingCreate {
 
   /**  */
   requestedChangesUser?: IdDTO
-
-  /**  */
-  whatToExpect?: string
 }
 
 export interface ListingDuplicate {
@@ -4923,6 +4929,12 @@ export interface ListingUpdate {
   waitlistMaxSize?: number
 
   /**  */
+  whatToExpect?: string
+
+  /**  */
+  whatToExpectAdditionalText?: string
+
+  /**  */
   status: ListingsStatusEnum
 
   /**  */
@@ -5062,9 +5074,6 @@ export interface ListingUpdate {
 
   /**  */
   requestedChangesUser?: IdDTO
-
-  /**  */
-  whatToExpect?: string
 }
 
 export interface Accessibility {

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -481,6 +481,7 @@
   "listings.waitlist.openSize": "Number of Openings",
   "listings.waitlist.openSizeQuestion": "How many spots are open on the list?",
   "listings.whatToExpectLabel": "Tell the applicant what to expect from the process",
+  "listings.whatToExpectAdditionalTextLabel": "Tell the applicant any additional information",
   "listings.whenApplicationsClose": "When applications close to the public",
   "listings.whereDropOffQuestion": "Where are applications dropped off?",
   "listings.wherePickupQuestion": "Where are applications picked up?",

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -481,6 +481,7 @@
   "listings.waitlist.openSize": "Number of Openings",
   "listings.waitlist.openSizeQuestion": "How many spots are open on the list?",
   "listings.whatToExpectLabel": "Tell the applicant what to expect from the process",
+  "listings.whatToExpectAdditionalText": "Tell the applicant any additional process information",
   "listings.whatToExpectAdditionalTextLabel": "Tell the applicant any additional information",
   "listings.whenApplicationsClose": "When applications close to the public",
   "listings.whereDropOffQuestion": "Where are applications dropped off?",

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailRankingsAndResults.tsx
@@ -106,6 +106,14 @@ const DetailRankingsAndResults = () => {
           {getDetailFieldRichText(listing.whatToExpect, "whatToExpect")}
         </FieldValue>
       </Grid.Row>
+      <Grid.Row>
+        <FieldValue
+          id="whatToExpectAdditionalText"
+          label={t("listings.whatToExpectAdditionalText")}
+        >
+          {getDetailFieldRichText(listing.whatToExpectAdditionalText, "whatToExpectAdditionalText")}
+        </FieldValue>
+      </Grid.Row>
     </SectionWithGrid>
   )
 }

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -159,6 +159,14 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
     immediatelyRender: false,
   })
 
+  const whatToExpectAdditionalDetailsEditor = useEditor({
+    extensions,
+    content: !listing
+      ? t("whatToExpectAdditionalText.default")
+      : listing?.whatToExpectAdditionalText,
+    immediatelyRender: false,
+  })
+
   const enableUnitGroups =
     activeFeatureFlags?.find((flag) => flag.name === FeatureFlagEnum.enableUnitGroups)?.active ||
     false
@@ -265,6 +273,19 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
           }
 
           formData.whatToExpect = cleanRichText(whatToExpectEditor.getHTML())
+
+          if (
+            whatToExpectAdditionalDetailsEditor?.storage.characterCount.characters() >
+            CHARACTER_LIMIT
+          ) {
+            setLoading(false)
+            setAlert("form")
+            return
+          }
+
+          formData.whatToExpectAdditionalText = cleanRichText(
+            whatToExpectAdditionalDetailsEditor.getHTML()
+          )
 
           if (!enableSection8) {
             formData.listingSection8Acceptance = YesNoEnum.no
@@ -458,6 +479,7 @@ const ListingForm = ({ listing, editMode, setListingName }: ListingFormProps) =>
                             listing={listing}
                             isAdmin={profile?.userRoles.isAdmin}
                             whatToExpectEditor={whatToExpectEditor}
+                            whatToExpectAdditionalTextEditor={whatToExpectAdditionalDetailsEditor}
                           />
                           <LeasingAgent />
                           <ApplicationTypes listing={listing} />

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -21,9 +21,15 @@ type RankingsAndResultsProps = {
   listing?: FormListing
   isAdmin?: boolean
   whatToExpectEditor: Editor
+  whatToExpectAdditionalTextEditor: Editor
 }
 
-const RankingsAndResults = ({ listing, isAdmin, whatToExpectEditor }: RankingsAndResultsProps) => {
+const RankingsAndResults = ({
+  listing,
+  isAdmin,
+  whatToExpectEditor,
+  whatToExpectAdditionalTextEditor,
+}: RankingsAndResultsProps) => {
   const formMethods = useFormContext()
   const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
 
@@ -346,6 +352,15 @@ const RankingsAndResults = ({ listing, isAdmin, whatToExpectEditor }: RankingsAn
           <Grid.Cell className="seeds-grid-span-2">
             <label className={"textarea-label"}>{t("listings.whatToExpectLabel")}</label>
             <TextEditor editor={whatToExpectEditor} editorId={"whatToExpect"} />
+          </Grid.Cell>
+          <Grid.Cell className="seeds-grid-span-2">
+            <label className={"textarea-label"}>
+              {t("listings.whatToExpectAdditionalTextLabel")}
+            </label>
+            <TextEditor
+              editor={whatToExpectAdditionalTextEditor}
+              editorId={"whatToExpectAdditionalText"}
+            />
           </Grid.Cell>
         </Grid.Row>
       </SectionWithGrid>

--- a/sites/public/src/components/browse/ListingBrowse.tsx
+++ b/sites/public/src/components/browse/ListingBrowse.tsx
@@ -72,7 +72,7 @@ export const ListingBrowse = (props: ListingBrowseProps) => {
     FeatureFlagEnum.enableListingFiltering
   )
 
-  const jurisdictionActiveFeatureFlags = props.jurisdiction.featureFlags
+  const jurisdictionActiveFeatureFlags = props.jurisdiction?.featureFlags
     .filter((featureFlag) => featureFlag.active)
     .map((entry) => entry.name)
 

--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -45,6 +45,7 @@ import { Neighborhood } from "./listing_sections/Neighborhood"
 import { RentSummary } from "./listing_sections/RentSummary"
 import { UnitSummaries } from "./listing_sections/UnitSummaries"
 import styles from "./ListingViewSeeds.module.scss"
+import { ReadMore } from "../../patterns/ReadMore"
 
 interface ListingProps {
   listing: Listing
@@ -142,6 +143,16 @@ export const ListingViewSeeds = ({ listing, jurisdiction, profile, preview }: Li
     </>
   )
 
+  const WhatToExpectAdditionalText = (
+    <>
+      {listing.whatToExpectAdditionalText && (
+        <InfoCard heading={t("whatToExpectAdditionalText.label")}>
+          <ReadMore maxLength={140} content={listing.whatToExpectAdditionalText} />
+        </InfoCard>
+      )}
+    </>
+  )
+
   const UnitFeatures = (
     <>
       <Heading size={"lg"} className={"seeds-m-be-header"} priority={3}>
@@ -201,6 +212,7 @@ export const ListingViewSeeds = ({ listing, jurisdiction, profile, preview }: Li
       {LotteryEvent}
       {ReferralApplication}
       {WhatToExpect}
+      {WhatToExpectAdditionalText}
       <LeasingAgent
         address={listing.listingsLeasingAgentAddress}
         email={listing.leasingAgentEmail}


### PR DESCRIPTION
This PR addresses #5117 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Add the new optional `whatToExpectAdditionalText` listing DTO field
* Generate a new backend-swagger file with the new schema 
* Add a new Rich Text Editor for the `What To Expect Additional Text` section on the partner's site
* Add the `What To Expect Additional Text` content preview on the partner's site
* Add the  'Additional Info' card section to the listing page on the public site
* Add a new temporary translation strings for the new components 

## How Can This Be Tested/Reviewed?

* Go to the partner's site dashboard and select any listing for the jurisdiction currently configured for the public site
* Click on the `Edit` button
* Switch to the `Application Process` tab
* Scroll down to the "Tell the applicant any additional information" rich text editor and input some mock-up text (make sure the text is at least 140 characters long to test the read more functionality)
* Click the `Save` button and wait for the update confirmation
* Go to the public site `/listings` page and select the preciously edited listing
* The Listings' page sidebar should now contain the new `Additional Info` section with the mock text

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
