### PR TITLE
fix: filter non existent unit types on autofill

### DIFF
--- a/shared-helpers/src/utilities/unitTypes.ts
+++ b/shared-helpers/src/utilities/unitTypes.ts
@@ -1,4 +1,4 @@
-import { Unit, UnitGroup, UnitType } from "../types/backend-swagger"
+import { Application, Listing, Unit, UnitGroup, UnitType } from "../types/backend-swagger"
 
 type GetUnitTypeNamesReturn = {
   id: string
@@ -46,7 +46,7 @@ export const getUniqueUnitTypes = (units: Unit[]): GetUnitTypeNamesReturn[] => {
   return sorted
 }
 
-export const getUniqueUnitGroupUnitTypes = (unitGroups: UnitGroup[]): GetUnitTypeNamesReturn[] => {
+export const getUniqueUnitGroupUnitTypes = (unitGroups?: UnitGroup[]): GetUnitTypeNamesReturn[] => {
   if (!unitGroups) return []
 
   const unitTypes = unitGroups.reduce((acc, group) => {
@@ -78,3 +78,27 @@ export const getUniqueUnitGroupUnitTypes = (unitGroups: UnitGroup[]): GetUnitTyp
 
 // It creates array of objects with the id property
 export const createUnitTypeId = (unitIds: string[]) => unitIds?.map((id) => ({ id })) || []
+
+export const getPreferredUnitTypes = (
+  application: Application,
+  listing: Listing,
+  enableUnitGroups: boolean,
+  returnName?: boolean
+) => {
+  const allListingUnitTypes = enableUnitGroups
+    ? getUniqueUnitGroupUnitTypes(listing?.unitGroups || [])
+    : getUniqueUnitTypes(listing?.units)
+
+  const preferredUnits = application.preferredUnitTypes
+    ?.filter((unitType) =>
+      allListingUnitTypes.some((unit) => unitType.name === unit.name || unitType.id === unit.id)
+    )
+    .map((unit) => {
+      const unitDetails = allListingUnitTypes?.find(
+        (unitType) => unitType.name === unit.name || unit.id === unitType.id
+      )
+      return returnName ? unitDetails?.name || unit.name : unitDetails || unit
+    })
+
+  return returnName ? (preferredUnits as string[]) : (preferredUnits as UnitType[])
+}

--- a/sites/public/src/components/shared/FormSummaryDetails.tsx
+++ b/sites/public/src/components/shared/FormSummaryDetails.tsx
@@ -2,10 +2,9 @@ import React, { Fragment, useEffect, useState } from "react"
 import { MultiLineAddress, t } from "@bloom-housing/ui-components"
 import { Card, FieldValue, Heading, Link } from "@bloom-housing/ui-seeds"
 import {
-  getUniqueUnitTypes,
-  getUniqueUnitGroupUnitTypes,
   AddressHolder,
   cleanMultiselectString,
+  getPreferredUnitTypes,
 } from "@bloom-housing/shared-helpers"
 import {
   Address,
@@ -13,8 +12,6 @@ import {
   Application,
   ApplicationMultiselectQuestion,
   ApplicationMultiselectQuestionOption,
-  FeatureFlag,
-  FeatureFlagEnum,
   InputType,
   Listing,
   MultiselectQuestionsApplicationSectionEnum,
@@ -184,16 +181,7 @@ const FormSummaryDetails = ({
     )
   }
 
-  const allListingUnitTypes = enableUnitGroups
-    ? getUniqueUnitGroupUnitTypes(listing?.unitGroups)
-    : getUniqueUnitTypes(listing?.units)
-
-  const preferredUnits = application.preferredUnitTypes?.map((unit) => {
-    const unitDetails = allListingUnitTypes?.find(
-      (unitType) => unitType.name === unit.name || unit.id === unitType.id
-    )
-    return unitDetails?.name || unit.name
-  })
+  const preferredUnits = getPreferredUnitTypes(application, listing, enableUnitGroups, true)
 
   return (
     <>

--- a/sites/public/src/pages/applications/start/autofill.tsx
+++ b/sites/public/src/pages/applications/start/autofill.tsx
@@ -8,6 +8,7 @@ import {
   PageView,
   pushGtmEvent,
   AuthContext,
+  getPreferredUnitTypes,
 } from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { useFormConductor } from "../../../lib/hooks"
@@ -37,6 +38,9 @@ export default () => {
 
   const mounted = OnClientSide()
 
+  const enableUnitGroups = isFeatureFlagOn(conductor.config, FeatureFlagEnum.enableUnitGroups)
+  const preferredUnits = getPreferredUnitTypes(application, listing, enableUnitGroups)
+
   const { handleSubmit } = useForm()
   const onSubmit = useCallback(() => {
     if (!submitted) {
@@ -46,6 +50,7 @@ export default () => {
         const withUpdatedLang = {
           ...JSON.parse(JSON.stringify(previousApplication)),
           language: router.locale,
+          preferredUnitTypes: preferredUnits,
         }
 
         conductor.application = withUpdatedLang
@@ -60,7 +65,15 @@ export default () => {
       conductor.sync()
       conductor.routeToNextOrReturnUrl()
     }
-  }, [submitted, previousApplication, useDetails, context, conductor, router])
+  }, [
+    submitted,
+    previousApplication,
+    useDetails,
+    context,
+    conductor,
+    router.locale,
+    preferredUnits,
+  ])
 
   useEffect(() => {
     pushGtmEvent<PageView>({


### PR DESCRIPTION
This PR addresses #5081

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

It will clear unitTypes from autofill that either don't exist in listing anymore, or are closed.

## How Can This Be Tested/Reviewed?

Should work for `enableUnitGroups` flag both `true` and `false`.
being logged in submit app with unitgroups (with open waitlist). Then remove unit groups or close waitlist.
Now unit types from that unit group should not appear in autofill, and should not be submitted.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
