### PR TITLE
fix: use the right backend availability key

### DIFF
--- a/sites/public/src/components/browse/FilterDrawer.tsx
+++ b/sites/public/src/components/browse/FilterDrawer.tsx
@@ -47,6 +47,10 @@ const FilterDrawer = (props: FilterDrawerProps) => {
     (entry) => entry === FeatureFlagEnum.enableUnitGroups
   )
 
+  const availabilityLabels = getAvailabilityValues(enableUnitGroups).map((key) =>
+    t(`listings.availability.${key}`)
+  )
+
   return (
     <Drawer
       isOpen={props.isOpen}
@@ -74,8 +78,8 @@ const FilterDrawer = (props: FilterDrawerProps) => {
             groupLabel={t("t.availability")}
             fields={buildDefaultFilterFields(
               ListingFilterKeys.availabilities,
-              "listings.availability",
-              getAvailabilityValues(enableUnitGroups),
+              availabilityLabels,
+              getAvailabilityValues(false),
               props.filterState
             )}
             register={register}


### PR DESCRIPTION
This PR addresses a logic bug from PRs #5102 & #5107

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The Units Available filter was updated to Vacant Units when unit groups feature flag is enabled, but the way the label was updated caused a backend error, which is now apparent in testing the backend updates.

## How Can This Be Tested/Reviewed?

Once this is merged into Detroit, we can do a final QA pass.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
