### PR TITLE
fix: partners color contrast

### DIFF
--- a/sites/partners/src/components/applications/Aside.tsx
+++ b/sites/partners/src/components/applications/Aside.tsx
@@ -57,7 +57,7 @@ const Aside = ({ listingId, type, onDelete, triggerSubmitAndRedirect }: AsidePro
         <Grid.Cell key="btn-cancel">
           <Button
             variant="text"
-            className={"w-full darker-delete"}
+            className={"w-full darker-alert"}
             onClick={() => setDeleteModal(true)}
           >
             {t("t.delete")}
@@ -104,7 +104,7 @@ const Aside = ({ listingId, type, onDelete, triggerSubmitAndRedirect }: AsidePro
             <Button
               type="button"
               variant="text"
-              className={"w-full darker-delete"}
+              className={"w-full darker-alert"}
               onClick={() => setDeleteModal(true)}
             >
               {t("t.delete")}

--- a/sites/partners/src/components/applications/Aside.tsx
+++ b/sites/partners/src/components/applications/Aside.tsx
@@ -4,7 +4,6 @@ import { t, StatusMessages } from "@bloom-housing/ui-components"
 import { Button, Dialog, Grid, Link } from "@bloom-housing/ui-seeds"
 import { ApplicationContext } from "./ApplicationContext"
 import { StatusAside } from "../shared/StatusAside"
-import styles from "../listings/PaperListingForm/ListingForm.module.scss"
 
 type AsideProps = {
   type: AsideType

--- a/sites/partners/src/components/applications/Aside.tsx
+++ b/sites/partners/src/components/applications/Aside.tsx
@@ -4,6 +4,7 @@ import { t, StatusMessages } from "@bloom-housing/ui-components"
 import { Button, Dialog, Grid, Link } from "@bloom-housing/ui-seeds"
 import { ApplicationContext } from "./ApplicationContext"
 import { StatusAside } from "../shared/StatusAside"
+import styles from "../listings/PaperListingForm/ListingForm.module.scss"
 
 type AsideProps = {
   type: AsideType
@@ -33,7 +34,10 @@ const Aside = ({ listingId, type, onDelete, triggerSubmitAndRedirect }: AsidePro
 
     const cancel = (
       <Grid.Cell key="btn-cancel">
-        <Link className="w-full justify-center" href={`/listings/${listingId}/applications`}>
+        <Link
+          className={"w-full justify-center darker-link"}
+          href={`/listings/${listingId}/applications`}
+        >
           {t("t.cancel")}
         </Link>
       </Grid.Cell>
@@ -51,7 +55,11 @@ const Aside = ({ listingId, type, onDelete, triggerSubmitAndRedirect }: AsidePro
           </Button>
         </Grid.Cell>,
         <Grid.Cell key="btn-cancel">
-          <Button variant="text" className="text-alert w-full" onClick={() => setDeleteModal(true)}>
+          <Button
+            variant="text"
+            className={"w-full darker-delete"}
+            onClick={() => setDeleteModal(true)}
+          >
             {t("t.delete")}
           </Button>
         </Grid.Cell>
@@ -96,7 +104,7 @@ const Aside = ({ listingId, type, onDelete, triggerSubmitAndRedirect }: AsidePro
             <Button
               type="button"
               variant="text"
-              className="text-alert w-full"
+              className={"w-full darker-delete"}
               onClick={() => setDeleteModal(true)}
             >
               {t("t.delete")}

--- a/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsHouseholdMembers.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsHouseholdMembers.tsx
@@ -5,6 +5,7 @@ import { YesNoEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagg
 import { ApplicationContext } from "../../ApplicationContext"
 import { MembersDrawer } from "../DetailsMemberDrawer"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
+import styles from "../../../listings/PaperListingForm/ListingForm.module.scss"
 
 type DetailsHouseholdMembersProps = {
   setMembersDrawer: (member: MembersDrawer) => void
@@ -64,7 +65,7 @@ const DetailsHouseholdMembers = ({
         content: (
           <Button
             type="button"
-            className="font-semibold"
+            className={"font-semibold darker-link"}
             onClick={() => setMembersDrawer(item)}
             variant="text"
           >

--- a/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsHouseholdMembers.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsHouseholdMembers.tsx
@@ -5,7 +5,6 @@ import { YesNoEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagg
 import { ApplicationContext } from "../../ApplicationContext"
 import { MembersDrawer } from "../DetailsMemberDrawer"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
-import styles from "../../../listings/PaperListingForm/ListingForm.module.scss"
 
 type DetailsHouseholdMembersProps = {
   setMembersDrawer: (member: MembersDrawer) => void

--- a/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsPrimaryApplicant.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsPrimaryApplicant.tsx
@@ -1,10 +1,11 @@
 import React, { useContext } from "react"
 import { t } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
+import { YesNoEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import SectionWithGrid from "../../../shared/SectionWithGrid"
+import styles from "../../../listings/PaperListingForm/ListingForm.module.scss"
 import { ApplicationContext } from "../../ApplicationContext"
 import { DetailsAddressColumns, AddressColsType } from "../DetailsAddressColumns"
-import SectionWithGrid from "../../../shared/SectionWithGrid"
-import { YesNoEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 type DetailsPrimaryApplicantProps = {
   enableFullTimeStudentQuestion?: boolean
@@ -56,6 +57,7 @@ const DetailsPrimaryApplicant = ({
             t(`application.contact.phoneNumberTypes.${application.applicant.phoneNumberType}`)
           }
           testId="phoneNumber"
+          className={"darker-help-text"}
         >
           {application.applicant.phoneNumber || t("t.n/a")}
         </FieldValue>
@@ -69,6 +71,7 @@ const DetailsPrimaryApplicant = ({
             t(`application.contact.phoneNumberTypes.${application.additionalPhoneNumberType}`)
           }
           testId="additionalPhoneNumber"
+          className={"darker-help-text"}
         >
           {application.additionalPhoneNumber || t("t.n/a")}
         </FieldValue>

--- a/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsPrimaryApplicant.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsPrimaryApplicant.tsx
@@ -3,7 +3,6 @@ import { t } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { YesNoEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
-import styles from "../../../listings/PaperListingForm/ListingForm.module.scss"
 import { ApplicationContext } from "../../ApplicationContext"
 import { DetailsAddressColumns, AddressColsType } from "../DetailsAddressColumns"
 

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
@@ -127,7 +127,7 @@ const FormHouseholdMembers = ({
               </Button>
               <Button
                 type="button"
-                className={"font-semibold darker-delete"}
+                className={"font-semibold darker-alert"}
                 onClick={() => setMembersDeleteModal(member.orderId)}
                 variant="text"
               >

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
@@ -8,6 +8,7 @@ import { t, MinimalTable } from "@bloom-housing/ui-components"
 import { Button, Dialog, Drawer } from "@bloom-housing/ui-seeds"
 import { FormMember } from "../FormMember"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
+import styles from "../../../listings/PaperListingForm/ListingForm.module.scss"
 
 type FormHouseholdMembersProps = {
   householdMembers: HouseholdMember[]
@@ -118,7 +119,7 @@ const FormHouseholdMembers = ({
             <div className="flex gap-3">
               <Button
                 type="button"
-                className="font-semibold"
+                className={"font-semibold darker-link"}
                 onClick={() => editMember(member)}
                 variant="text"
               >
@@ -126,7 +127,7 @@ const FormHouseholdMembers = ({
               </Button>
               <Button
                 type="button"
-                className="font-semibold text-alert"
+                className={"font-semibold darker-delete"}
                 onClick={() => setMembersDeleteModal(member.orderId)}
                 variant="text"
               >

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormHouseholdMembers.tsx
@@ -6,9 +6,8 @@ import {
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { t, MinimalTable } from "@bloom-housing/ui-components"
 import { Button, Dialog, Drawer } from "@bloom-housing/ui-seeds"
-import { FormMember } from "../FormMember"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
-import styles from "../../../listings/PaperListingForm/ListingForm.module.scss"
+import { FormMember } from "../FormMember"
 
 type FormHouseholdMembersProps = {
   householdMembers: HouseholdMember[]

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -1,21 +1,21 @@
 import React, { useContext, useMemo } from "react"
 import { useRouter } from "next/router"
 import dayjs from "dayjs"
+import LinkIcon from "@heroicons/react/20/solid/LinkIcon"
+import PencilSquareIcon from "@heroicons/react/24/solid/PencilSquareIcon"
 import { t, StatusMessages } from "@bloom-housing/ui-components"
 import { Button, Link, Grid, Icon } from "@bloom-housing/ui-seeds"
 import { pdfUrlFromListingEvents, AuthContext, MessageContext } from "@bloom-housing/shared-helpers"
-import PencilSquareIcon from "@heroicons/react/24/solid/PencilSquareIcon"
-import LinkIcon from "@heroicons/react/20/solid/LinkIcon"
-import { ListingContext } from "./ListingContext"
-import { StatusAside } from "../shared/StatusAside"
 import {
   ListingEventsTypeEnum,
   ListingUpdate,
   ListingsStatusEnum,
   UserRoleEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-
+import { StatusAside } from "../shared/StatusAside"
 import { SubmitFunction } from "./PaperListingForm"
+import { ListingContext } from "./ListingContext"
+import styles from "./PaperListingForm/ListingForm.module.scss"
 
 export enum ListingFormActionsType {
   add = "add",
@@ -97,7 +97,7 @@ const ListingFormActions = ({
         <Button
           id="listingsExitButton"
           variant="text"
-          className="w-full justify-center p-3"
+          className={"w-full justify-center p-3 darker-link"}
           onClick={() => {
             showSaveBeforeExitDialog()
           }}

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -15,7 +15,6 @@ import {
 import { StatusAside } from "../shared/StatusAside"
 import { SubmitFunction } from "./PaperListingForm"
 import { ListingContext } from "./ListingContext"
-import styles from "./PaperListingForm/ListingForm.module.scss"
 
 export enum ListingFormActionsType {
   add = "add",

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailApplicationDates.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailApplicationDates.tsx
@@ -49,7 +49,13 @@ const DetailApplicationDates = () => {
             startTime: { content: startTime && getDetailFieldTime(startTime) },
             endTime: { content: endTime && getDetailFieldTime(endTime) },
             url: {
-              content: url ? <Link href={url}>{t("t.url")}</Link> : t("t.n/a"),
+              content: url ? (
+                <Link href={url} className={"darker-link"}>
+                  {t("t.url")}
+                </Link>
+              ) : (
+                t("t.n/a")
+              ),
             },
             view: {
               content: (
@@ -124,7 +130,7 @@ const DetailApplicationDates = () => {
                     </FieldValue>
                     <FieldValue id="drawer.url" label={t("t.url")}>
                       {drawer?.url ? (
-                        <Link className="mx-0 my-0" href={drawer.url}>
+                        <Link className={`mx-0 my-0 darker-link`} href={drawer.url}>
                           {drawer?.label ?? t("t.url")}
                         </Link>
                       ) : (

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailApplicationDates.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailApplicationDates.tsx
@@ -12,6 +12,8 @@ import { ListingContext } from "../../ListingContext"
 import { getDetailFieldDate, getDetailFieldString, getDetailFieldTime } from "./helpers"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 import { AuthContext } from "@bloom-housing/shared-helpers/src/auth/AuthContext"
+import styles from "../../PaperListingForm/ListingForm.module.scss"
+
 const DetailApplicationDates = () => {
   const listing = useContext(ListingContext)
   const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
@@ -57,7 +59,7 @@ const DetailApplicationDates = () => {
                     type="button"
                     variant="text"
                     size="sm"
-                    className="font-semibold"
+                    className={"font-semibold darker-link"}
                     onClick={() => setDrawer(event)}
                   >
                     {t("t.view")}

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailApplicationDates.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailApplicationDates.tsx
@@ -2,17 +2,16 @@ import React, { useContext, useMemo, useState } from "react"
 import dayjs from "dayjs"
 import { t, MinimalTable } from "@bloom-housing/ui-components"
 import { Button, Card, Drawer, FieldValue, Grid, Link } from "@bloom-housing/ui-seeds"
+import { AuthContext } from "@bloom-housing/shared-helpers/src/auth/AuthContext"
 import {
   ListingEvent,
   ListingEventsTypeEnum,
   MarketingTypeEnum,
   FeatureFlagEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import SectionWithGrid from "../../../shared/SectionWithGrid"
 import { ListingContext } from "../../ListingContext"
 import { getDetailFieldDate, getDetailFieldString, getDetailFieldTime } from "./helpers"
-import SectionWithGrid from "../../../shared/SectionWithGrid"
-import { AuthContext } from "@bloom-housing/shared-helpers/src/auth/AuthContext"
-import styles from "../../PaperListingForm/ListingForm.module.scss"
 
 const DetailApplicationDates = () => {
   const listing = useContext(ListingContext)

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailUnits.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailUnits.tsx
@@ -12,6 +12,7 @@ import {
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 import { formatRange, formatRentRange, minMaxFinder } from "../../helpers"
+import styles from "../../PaperListingForm/ListingForm.module.scss"
 
 type DetailUnitsProps = {
   setUnitDrawer: (unit: UnitDrawer) => void
@@ -112,7 +113,7 @@ const DetailUnits = ({ setUnitDrawer }: DetailUnitsProps) => {
                   type="button"
                   variant="text"
                   size="sm"
-                  className="font-semibold"
+                  className={"font-semibold darker-link"}
                   onClick={() => setUnitDrawer(unit)}
                 >
                   {t("t.view")}

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailUnits.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailUnits.tsx
@@ -2,8 +2,6 @@ import React, { useContext, useMemo } from "react"
 import { t, MinimalTable } from "@bloom-housing/ui-components"
 import { Button, FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { AuthContext } from "@bloom-housing/shared-helpers"
-import { ListingContext } from "../../ListingContext"
-import { UnitDrawer } from "../DetailsUnitDrawer"
 import {
   EnumUnitGroupAmiLevelMonthlyRentDeterminationType,
   FeatureFlagEnum,
@@ -11,8 +9,9 @@ import {
   ReviewOrderTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
+import { ListingContext } from "../../ListingContext"
 import { formatRange, formatRentRange, minMaxFinder } from "../../helpers"
-import styles from "../../PaperListingForm/ListingForm.module.scss"
+import { UnitDrawer } from "../DetailsUnitDrawer"
 
 type DetailUnitsProps = {
   setUnitDrawer: (unit: UnitDrawer) => void

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -648,7 +648,7 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
           onClick={() => onClose(false, false, null)}
           variant="text"
           size="sm"
-          className={"font-semibold darker-delete"}
+          className={"font-semibold darker-alert"}
         >
           {t("t.cancel")}
         </Button>

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -643,7 +643,13 @@ const UnitForm = ({ onSubmit, onClose, defaultUnit, nextId, draft }: UnitFormPro
           {t("t.saveExit")}
         </Button>
 
-        <Button type="button" onClick={() => onClose(false, false, null)} variant="text" size="sm">
+        <Button
+          type="button"
+          onClick={() => onClose(false, false, null)}
+          variant="text"
+          size="sm"
+          className={"font-semibold darker-delete"}
+        >
           {t("t.cancel")}
         </Button>
       </Drawer.Footer>

--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
@@ -232,7 +232,13 @@ const UnitGroupAmiForm = ({
           {t("t.save")}
         </Button>
 
-        <Button type="button" onClick={onClose} variant="text" size="sm">
+        <Button
+          type="button"
+          onClick={onClose}
+          variant="text"
+          size="sm"
+          className={"font-semibold darker-delete"}
+        >
           {t("t.cancel")}
         </Button>
       </Drawer.Footer>

--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
@@ -237,7 +237,7 @@ const UnitGroupAmiForm = ({
           onClick={onClose}
           variant="text"
           size="sm"
-          className={"font-semibold darker-delete"}
+          className={"font-semibold darker-alert"}
         >
           {t("t.cancel")}
         </Button>

--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
@@ -218,7 +218,7 @@ const UnitGroupForm = ({
                 </Button>
                 <Button
                   type="button"
-                  className={"font-semibold darker-delete"}
+                  className={"font-semibold darker-alert"}
                   variant="text"
                   size="sm"
                   onClick={() => setAmiDeleteModal(ami.tempId)}
@@ -553,7 +553,7 @@ const UnitGroupForm = ({
           onClick={() => onClose()}
           variant="text"
           size="sm"
-          className={"font-semibold darker-delete"}
+          className={"font-semibold darker-alert"}
         >
           {t("t.cancel")}
         </Button>

--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupForm.tsx
@@ -207,7 +207,7 @@ const UnitGroupForm = ({
               <div className="flex gap-3">
                 <Button
                   type="button"
-                  className="front-semibold"
+                  className={"font-semibold darker-link"}
                   variant="text"
                   size="sm"
                   onClick={() => {
@@ -218,7 +218,7 @@ const UnitGroupForm = ({
                 </Button>
                 <Button
                   type="button"
-                  className="front-semibold text-alert"
+                  className={"font-semibold darker-delete"}
                   variant="text"
                   size="sm"
                   onClick={() => setAmiDeleteModal(ami.tempId)}
@@ -548,7 +548,13 @@ const UnitGroupForm = ({
           {t("t.saveExit")}
         </Button>
 
-        <Button type="button" onClick={() => onClose()} variant="text" size="sm">
+        <Button
+          type="button"
+          onClick={() => onClose()}
+          variant="text"
+          size="sm"
+          className={"font-semibold darker-delete"}
+        >
           {t("t.cancel")}
         </Button>
       </Drawer.Footer>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationDates.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationDates.tsx
@@ -70,7 +70,7 @@ const ApplicationDates = ({
               <Button
                 type="button"
                 size="sm"
-                className="font-semibold"
+                className={"font-semibold darker-link"}
                 onClick={() => setDrawerOpenHouse(event)}
                 variant="text"
               >
@@ -79,7 +79,7 @@ const ApplicationDates = ({
               <Button
                 type="button"
                 size="sm"
-                className="font-semibold text-alert"
+                className={"font-semibold darker-delete"}
                 onClick={() => setModalDeleteOpenHouse(event)}
                 variant="text"
               >

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationDates.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ApplicationDates.tsx
@@ -79,7 +79,7 @@ const ApplicationDates = ({
               <Button
                 type="button"
                 size="sm"
-                className={"font-semibold darker-delete"}
+                className={"font-semibold darker-alert"}
                 onClick={() => setModalDeleteOpenHouse(event)}
                 variant="text"
               >

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -136,7 +136,7 @@ const BuildingSelectionCriteria = () => {
             </Button>
             <Button
               type="button"
-              className={"font-semibold darker-delete"}
+              className={"font-semibold darker-alert"}
               onClick={() => {
                 setCloudinaryData({ ...cloudinaryData, id: "" })
                 deletePDF()
@@ -173,7 +173,7 @@ const BuildingSelectionCriteria = () => {
             </Button>
             <Button
               type="button"
-              className={"font-semibold darker-delete"}
+              className={"font-semibold darker-alert"}
               onClick={() => {
                 setValue("buildingSelectionCriteria", "")
               }}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/BuildingSelectionCriteria.tsx
@@ -125,7 +125,7 @@ const BuildingSelectionCriteria = () => {
           <div className="flex gap-3">
             <Button
               type="button"
-              className="font-semibold uppercase my-0"
+              className={"font-semibold darker-link"}
               onClick={() => {
                 setDrawerState(true)
               }}
@@ -136,7 +136,7 @@ const BuildingSelectionCriteria = () => {
             </Button>
             <Button
               type="button"
-              className="font-semibold text-alert"
+              className={"font-semibold darker-delete"}
               onClick={() => {
                 setCloudinaryData({ ...cloudinaryData, id: "" })
                 deletePDF()
@@ -162,7 +162,7 @@ const BuildingSelectionCriteria = () => {
           <div className="flex gap-3">
             <Button
               type="button"
-              className="font-semibold"
+              className={"font-semibold darker-link"}
               onClick={() => {
                 setDrawerState(true)
               }}
@@ -173,7 +173,7 @@ const BuildingSelectionCriteria = () => {
             </Button>
             <Button
               type="button"
-              className="font-semibold text-alert"
+              className={"font-semibold darker-delete"}
               onClick={() => {
                 setValue("buildingSelectionCriteria", "")
               }}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhotos.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhotos.tsx
@@ -103,7 +103,7 @@ const ListingPhotos = (props: ListingPhotosProps) => {
         content: (
           <Button
             type="button"
-            className={"darker-delete"}
+            className={"darker-alert"}
             onClick={() => {
               saveImageFields(fields.filter((item, i2) => i2 != index) as ListingImage[])
             }}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhotos.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ListingPhotos.tsx
@@ -103,7 +103,7 @@ const ListingPhotos = (props: ListingPhotosProps) => {
         content: (
           <Button
             type="button"
-            className="text-alert"
+            className={"darker-delete"}
             onClick={() => {
               saveImageFields(fields.filter((item, i2) => i2 != index) as ListingImage[])
             }}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -136,7 +136,7 @@ const SelectAndOrder = ({
             <div className="flex">
               <Button
                 type="button"
-                className="font-semibold text-alert"
+                className={"font-semibold darker-delete"}
                 onClick={() => {
                   deleteItem(item, true)
                 }}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/SelectAndOrder.tsx
@@ -136,7 +136,7 @@ const SelectAndOrder = ({
             <div className="flex">
               <Button
                 type="button"
-                className={"font-semibold darker-delete"}
+                className={"font-semibold darker-alert"}
                 onClick={() => {
                   deleteItem(item, true)
                 }}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -249,7 +249,7 @@ const FormUnits = ({
                   <div className="flex gap-3">
                     <Button
                       type="button"
-                      className="font-semibold"
+                      className={"font-semibold darker-link"}
                       onClick={() => editUnitGroup(unitGroup.tempId)}
                       variant="text"
                       size="sm"
@@ -258,7 +258,7 @@ const FormUnits = ({
                     </Button>
                     <Button
                       type="button"
-                      className="font-semibold text-alert"
+                      className={"font-semibold darker-delete"}
                       onClick={() => setUnitDeleteModal(unitGroup.tempId)}
                       variant="text"
                       size="sm"
@@ -282,7 +282,7 @@ const FormUnits = ({
                 <div className="flex gap-3">
                   <Button
                     type="button"
-                    className="font-semibold"
+                    className={"font-semibold darker-link"}
                     onClick={() => editUnit(unit.tempId)}
                     variant="text"
                     size="sm"
@@ -291,7 +291,7 @@ const FormUnits = ({
                   </Button>
                   <Button
                     type="button"
-                    className="font-semibold text-alert"
+                    className={"font-semibold darker-delete"}
                     onClick={() => setUnitDeleteModal(unit.tempId)}
                     variant="text"
                     size="sm"

--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -258,7 +258,7 @@ const FormUnits = ({
                     </Button>
                     <Button
                       type="button"
-                      className={"font-semibold darker-delete"}
+                      className={"font-semibold darker-alert"}
                       onClick={() => setUnitDeleteModal(unitGroup.tempId)}
                       variant="text"
                       size="sm"
@@ -291,7 +291,7 @@ const FormUnits = ({
                   </Button>
                   <Button
                     type="button"
-                    className={"font-semibold darker-delete"}
+                    className={"font-semibold darker-alert"}
                     onClick={() => setUnitDeleteModal(unit.tempId)}
                     variant="text"
                     size="sm"

--- a/sites/partners/src/components/shared/TextEditor.tsx
+++ b/sites/partners/src/components/shared/TextEditor.tsx
@@ -92,7 +92,7 @@ const MenuBar = ({ editor }) => {
   }
 
   return (
-    <div className={styles["editor-menu"]} role={"menu"}>
+    <div className={styles["editor-menu"]}>
       <button
         onClick={() => editor?.chain().focus().toggleBold().run()}
         disabled={!editor?.can().chain().focus().toggleBold().run()}
@@ -100,7 +100,6 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Bold"}
         id={"editor-bold"}
-        role={"menuitem"}
       >
         <Icon>
           <BoldIcon />
@@ -112,7 +111,6 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Bullet list"}
         id={"editor-bullet-list"}
-        role={"menuitem"}
       >
         <Icon>
           <BulletListIcon />
@@ -124,7 +122,6 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Numbered list"}
         id={"editor-numbered-list"}
-        role={"menuitem"}
       >
         <Icon>
           <OrderedListIcon />
@@ -135,7 +132,6 @@ const MenuBar = ({ editor }) => {
         className={editor?.isActive("link") ? styles["is-active"] : ""}
         type="button"
         aria-label={"Set link"}
-        role={"menuitem"}
       >
         <Icon>
           <LinkIcon />
@@ -146,7 +142,6 @@ const MenuBar = ({ editor }) => {
         disabled={!editor?.isActive("link")}
         type="button"
         aria-label={"Unlink"}
-        role={"menuitem"}
       >
         <Icon>
           <UnlinkIcon />
@@ -157,7 +152,6 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Line break"}
         id={"editor-line-break"}
-        role={"menuitem"}
       >
         <Icon>
           <DividerIcon />
@@ -220,10 +214,7 @@ export const TextEditor = ({
 
   return (
     <>
-      <label
-        className={`${styles["label"]} ${errorState ? styles["error-text"] : null}`}
-        htmlFor={"editorId"}
-      >
+      <label className={`${styles["label"]} ${errorState ? styles["error-text"] : null}`}>
         {label}
       </label>
       <div className={`${styles["editor"]} ${overLimit || errorState ? styles["error"] : ""}`}>

--- a/sites/partners/src/components/shared/TextEditor.tsx
+++ b/sites/partners/src/components/shared/TextEditor.tsx
@@ -92,7 +92,7 @@ const MenuBar = ({ editor }) => {
   }
 
   return (
-    <div className={styles["editor-menu"]}>
+    <div className={styles["editor-menu"]} role={"menu"}>
       <button
         onClick={() => editor?.chain().focus().toggleBold().run()}
         disabled={!editor?.can().chain().focus().toggleBold().run()}
@@ -100,6 +100,7 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Bold"}
         id={"editor-bold"}
+        role={"menuitem"}
       >
         <Icon>
           <BoldIcon />
@@ -111,6 +112,7 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Bullet list"}
         id={"editor-bullet-list"}
+        role={"menuitem"}
       >
         <Icon>
           <BulletListIcon />
@@ -122,6 +124,7 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Numbered list"}
         id={"editor-numbered-list"}
+        role={"menuitem"}
       >
         <Icon>
           <OrderedListIcon />
@@ -132,6 +135,7 @@ const MenuBar = ({ editor }) => {
         className={editor?.isActive("link") ? styles["is-active"] : ""}
         type="button"
         aria-label={"Set link"}
+        role={"menuitem"}
       >
         <Icon>
           <LinkIcon />
@@ -142,6 +146,7 @@ const MenuBar = ({ editor }) => {
         disabled={!editor?.isActive("link")}
         type="button"
         aria-label={"Unlink"}
+        role={"menuitem"}
       >
         <Icon>
           <UnlinkIcon />
@@ -152,6 +157,7 @@ const MenuBar = ({ editor }) => {
         type="button"
         aria-label={"Line break"}
         id={"editor-line-break"}
+        role={"menuitem"}
       >
         <Icon>
           <DividerIcon />
@@ -222,7 +228,7 @@ export const TextEditor = ({
       </label>
       <div className={`${styles["editor"]} ${overLimit || errorState ? styles["error"] : ""}`}>
         <MenuBar editor={editor} />
-        <EditorContent editor={editor} id={editorId} data-testid={editorId} role={"textbox"} />
+        <EditorContent editor={editor} id={editorId} data-testid={editorId} />
       </div>
       <div
         className={`${styles["character-count"]} ${

--- a/sites/partners/src/components/shared/TextEditor.tsx
+++ b/sites/partners/src/components/shared/TextEditor.tsx
@@ -214,12 +214,15 @@ export const TextEditor = ({
 
   return (
     <>
-      <label className={`${styles["label"]} ${errorState ? styles["error-text"] : null}`}>
+      <label
+        className={`${styles["label"]} ${errorState ? styles["error-text"] : null}`}
+        htmlFor={"editorId"}
+      >
         {label}
       </label>
       <div className={`${styles["editor"]} ${overLimit || errorState ? styles["error"] : ""}`}>
         <MenuBar editor={editor} />
-        <EditorContent editor={editor} id={editorId} data-testid={editorId} />
+        <EditorContent editor={editor} id={editorId} data-testid={editorId} role={"textbox"} />
       </div>
       <div
         className={`${styles["character-count"]} ${

--- a/sites/partners/src/components/users/FormUserManage.tsx
+++ b/sites/partners/src/components/users/FormUserManage.tsx
@@ -11,6 +11,7 @@ import {
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { JurisdictionAndListingSelection } from "./JurisdictionAndListingSelection"
 import SectionWithGrid from "../shared/SectionWithGrid"
+import styles from "../listings/PaperListingForm/ListingForm.module.scss"
 
 type FormUserManageProps = {
   isOpen: boolean
@@ -449,7 +450,7 @@ const FormUserManage = ({
           {mode === "edit" && (
             <Button
               type="button"
-              className="bg-opacity-0 text-alert"
+              className={"bg-opacity-0 darker-delete"}
               onClick={() => setDeleteModalActive(true)}
               variant="text"
             >

--- a/sites/partners/src/components/users/FormUserManage.tsx
+++ b/sites/partners/src/components/users/FormUserManage.tsx
@@ -9,9 +9,8 @@ import {
   User,
   UserRole,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { JurisdictionAndListingSelection } from "./JurisdictionAndListingSelection"
 import SectionWithGrid from "../shared/SectionWithGrid"
-import styles from "../listings/PaperListingForm/ListingForm.module.scss"
+import { JurisdictionAndListingSelection } from "./JurisdictionAndListingSelection"
 
 type FormUserManageProps = {
   isOpen: boolean

--- a/sites/partners/src/components/users/FormUserManage.tsx
+++ b/sites/partners/src/components/users/FormUserManage.tsx
@@ -450,7 +450,7 @@ const FormUserManage = ({
           {mode === "edit" && (
             <Button
               type="button"
-              className={"bg-opacity-0 darker-delete"}
+              className={"bg-opacity-0 darker-alert"}
               onClick={() => setDeleteModalActive(true)}
               variant="text"
             >

--- a/sites/partners/src/layouts/index.tsx
+++ b/sites/partners/src/layouts/index.tsx
@@ -74,9 +74,6 @@ const Layout = (props) => {
         </main>
         <SiteFooter>
           <FooterNav copyright={`© ${currentYear} • All Rights Reserved`} />
-          <FooterSection className="bg-black" small>
-            <ExygyFooter />
-          </FooterSection>
         </SiteFooter>
       </div>
     </div>

--- a/sites/partners/styles/overrides.scss
+++ b/sites/partners/styles/overrides.scss
@@ -197,3 +197,17 @@
   vertical-align: 15%;
   margin-inline-start: var(--seeds-s3);
 }
+
+// Temporary short-term overrides for contrast compliance
+.darker-link {
+  --seeds-color-primary: var(--seeds-color-blue-700);
+  --bloom-color-primary: var(--seeds-color-blue-700);
+}
+
+.darker-delete {
+  --seeds-color-primary: var(--seeds-color-red-700);
+}
+
+.darker-help-text {
+  --field-value-help-text-color: var(--seeds-input-text-label-color);
+}

--- a/sites/partners/styles/overrides.scss
+++ b/sites/partners/styles/overrides.scss
@@ -204,7 +204,7 @@
   --bloom-color-primary: var(--seeds-color-blue-700);
 }
 
-.darker-delete {
+.darker-alert {
   --seeds-color-primary: var(--seeds-color-red-700);
 }
 


### PR DESCRIPTION
This PR addresses #5173

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

We have some color contrast violations in partners flagged by the [Axe Developer Hub](https://github.com/bloom-housing/bloom/issues/5139) suite when run locally. The three issues are when our current link color, alert color, or help text color are used on our light gray background colors. This shows up for various `View` `Edit` `Delete` and `Cancel` text-styled buttons and links.

This PR, as a temporary measure recommended by design until we change these token colors in Seeds and uptake them in partners, is to change these button colors only if they appear on a non-white background to just be one shade darker.

## How Can This Be Tested/Reviewed?

This is tedious to test comprehensively manually (but would be extremely easy in the future with the test suite set up in CI!) - but, you can see examples of the new colors in the unit drawer and unit details section on the listing edit and view states, and in the cell phone helper text on the detail view of an application below. We shouldn't have any more links or delete buttons or helper text on non-white background colors with the current tokens in partners. There are no other changes here other than adding the new class names, so I would recommend a lighter QA, and after the concurrent PR to set up the test suite goes up, we can re-run it there and the fixes will be more easily identifiable, but open to feedback about how we should QA this ticket.

Before:
<img width="347" height="195" alt="Screenshot 2025-07-29 at 8 31 22 AM" src="https://github.com/user-attachments/assets/b9035093-a32a-4992-a992-f07d511cc1f0" />
After:
<img width="343" height="184" alt="Screenshot 2025-07-29 at 8 31 30 AM" src="https://github.com/user-attachments/assets/95edcfcf-e581-4a82-8ae0-a45219f49461" />

Before:
<img width="380" height="195" alt="Screenshot 2025-07-29 at 8 32 12 AM" src="https://github.com/user-attachments/assets/2b588bd6-1811-450f-837a-ccf7d0268d62" />
After:
<img width="372" height="198" alt="Screenshot 2025-07-29 at 8 31 57 AM" src="https://github.com/user-attachments/assets/d52e615c-fad5-4fa2-8cb3-f2fe53cb7ff5" />

Before:
<img width="170" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeTdnQ2c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--3430ee1b7bfb75dd2a16e4fbe91d5fd5f7941b51/Screenshot%202025-07-29%20at%208.38.46%E2%80%AFAM.png" alt="Screenshot 2025-07-29 at 8.38.46 AM.png" />
After:
<img width="174" src="https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBeS9nQ2c9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--d631c25049e6470f2d1c0013a1b101032b9d0431/Screenshot%202025-07-29%20at%208.38.25%E2%80%AFAM.png" alt="Screenshot 2025-07-29 at 8.38.25 AM.png" />

Places in partners this change was introduced:
* Applications right action bar
* Application view-only household members
* Application view-only primary applicant details for cell phone type helper text
* Application edit household members
* Listing right action bar
* Listing view-only open houses
* Listing view-only units
* Listing edit units and unit groups
* Listing edit open houses
* Listing edit building selection criteria
* Listing edit preferences / programs
* Users edit user

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
