### PR TITLE
fix: improve rich text a11y pt 2

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -364,6 +364,7 @@ const RankingsAndResults = ({
             <TextEditor
               editor={whatToExpectEditor}
               editorId={"whatToExpect"}
+              labelId={"whatToExpectLabel"}
               error={fieldHasError(errors?.whatToExpect)}
               label={getLabel("whatToExpect", requiredFields, t("listings.whatToExpectLabel"))}
               errorMessage={fieldMessage(errors.whatToExpect)}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/RankingsAndResults.tsx
@@ -364,7 +364,6 @@ const RankingsAndResults = ({
             <TextEditor
               editor={whatToExpectEditor}
               editorId={"whatToExpect"}
-              labelId={"whatToExpectLabel"}
               error={fieldHasError(errors?.whatToExpect)}
               label={getLabel("whatToExpect", requiredFields, t("listings.whatToExpectLabel"))}
               errorMessage={fieldMessage(errors.whatToExpect)}

--- a/sites/partners/src/components/shared/TextEditor.tsx
+++ b/sites/partners/src/components/shared/TextEditor.tsx
@@ -236,7 +236,6 @@ type TextEditorProps = {
   error?: boolean
   errorMessage?: string
   label: string | React.ReactNode
-  labelId: string
 }
 
 export const TextEditor = ({
@@ -246,9 +245,10 @@ export const TextEditor = ({
   error,
   errorMessage,
   label,
-  labelId,
 }: TextEditorProps) => {
   const [errorState, setErrorState] = useState(error)
+
+  const labelId = `${editorId}Label`
 
   if (!editor) {
     return null

--- a/sites/partners/src/components/shared/TextEditor.tsx
+++ b/sites/partners/src/components/shared/TextEditor.tsx
@@ -236,6 +236,7 @@ type TextEditorProps = {
   error?: boolean
   errorMessage?: string
   label: string | React.ReactNode
+  labelId: string
 }
 
 export const TextEditor = ({
@@ -245,6 +246,7 @@ export const TextEditor = ({
   error,
   errorMessage,
   label,
+  labelId,
 }: TextEditorProps) => {
   const [errorState, setErrorState] = useState(error)
 
@@ -256,20 +258,26 @@ export const TextEditor = ({
     if (errorState) setErrorState(false)
   })
 
+  editor.on("create", () => {
+    editor?.view.setProps({
+      attributes: { "aria-labelledby": labelId, role: "textbox" },
+    })
+  })
+
   const characterCount = editor?.storage?.characterCount?.characters()
   const overLimit = characterCount > characterLimit
 
   return (
     <>
-      <label>
+      <label id={labelId}>
         <span className={`${styles["label"]} ${errorState ? styles["error-text"] : null}`}>
           {label}
         </span>
-        <div className={`${styles["editor"]} ${overLimit || errorState ? styles["error"] : ""}`}>
-          <MenuBar editor={editor} />
-          <EditorContent editor={editor} id={editorId} data-testid={editorId} />
-        </div>
       </label>
+      <div className={`${styles["editor"]} ${overLimit || errorState ? styles["error"] : ""}`}>
+        <MenuBar editor={editor} />
+        <EditorContent editor={editor} id={editorId} data-testid={editorId} />
+      </div>
       <div
         className={`${styles["character-count"]} ${
           overLimit ? styles["character-count-warning"] : ""


### PR DESCRIPTION
Issue #5174 

## Description

[This PR](https://github.com/bloom-housing/bloom/pull/5175) introduced a regression, where now when you hover over the label for the rich text editor, the first item in the menu bar also gets the visual hover state.


https://github.com/user-attachments/assets/7bb8eb1f-903f-49a4-a12f-035d862202c5


## How Can This Be Tested/Reviewed?

Resolves the hover issue, while still maintaining the initial goal of having a label associated with the editor. If you use a screen reader, you can see the textbox still announces the label name.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs <-- will add to the parent ticket #5174
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
