### PR TITLE
feat: always show deposit helper text if present

### DIFF
--- a/sites/public/src/components/listing/listing_sections/AdditionalFees.tsx
+++ b/sites/public/src/components/listing/listing_sections/AdditionalFees.tsx
@@ -45,14 +45,16 @@ export const AdditionalFees = ({
                   <div>{t("listings.applicationFeeDueAt")}</div>
                 </div>
               )}
-              {(depositMin || depositMax) && (
+              {(depositMin || depositMax || depositHelperText) && (
                 <div className={styles["split-card-cell"]}>
                   <Heading size={"md"} className={listingStyles["thin-heading"]} priority={4}>
                     {t("t.deposit")}
                   </Heading>
-                  <div className={styles.emphasized}>
-                    {getCurrencyRange(parseInt(depositMin), parseInt(depositMax))}
-                  </div>
+                  {(depositMin || depositMax) && (
+                    <div className={styles.emphasized}>
+                      {getCurrencyRange(parseInt(depositMin), parseInt(depositMax))}
+                    </div>
+                  )}
                   <div>{depositHelperText}</div>
                 </div>
               )}


### PR DESCRIPTION
This PR addresses #5047

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Previously, if deposit min and/or max wasn't present, the entire Deposit section under Additional Fees wasn't shown. Now, it will be shown even if deposit helper text alone is available.

## How Can This Be Tested/Reviewed?

Save a listing with deposit helper text but no deposit min/max, verify the Deposit section is still shown. Then remove the helper text and verify the section is hidden.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
