### PR TITLE
fix: Resurface review order status for unit groups

### DIFF
--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -668,6 +668,7 @@
   "listings.availability.openWaitlist": "Open waitlist",
   "listings.availability.unitsAvailable": "Units available",
   "listings.availability.vacantUnits": "Vacant units",
+  "listings.availabilityUnknown": "Availability unknown",
   "listings.availableAndWaitlist": "Available units & open waitlist",
   "listings.availableUnit": "Available unit",
   "listings.availableUnits": "Available units",

--- a/sites/public/__tests__/lib/helpers.test.tsx
+++ b/sites/public/__tests__/lib/helpers.test.tsx
@@ -129,6 +129,23 @@ describe("helpers", () => {
         variant: "primary",
       })
     })
+    it("should return correctly for FCFS and no unit groups with unit groups on", () => {
+      expect(
+        getStatusPrefix(
+          {
+            ...listing,
+            reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+            status: ListingsStatusEnum.active,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+          },
+          false,
+          true
+        )
+      ).toEqual({
+        label: "Availability unknown",
+        variant: "warn",
+      })
+    })
     it("should return correctly for waitlist listings with unit groups on", () => {
       expect(
         getStatusPrefix(
@@ -275,6 +292,96 @@ describe("helpers", () => {
       ).toEqual({
         label: "First come first serve",
         variant: "primary",
+      })
+    })
+    it("should return correctly for fcfs listings with unit groups waitlist closed and no available units", () => {
+      expect(
+        getStatusPrefix(
+          {
+            ...listing,
+            unitGroups: [
+              {
+                id: "1d4971f5-b651-430c-9a2f-4655534f1bda",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                maxOccupancy: 4,
+                minOccupancy: 1,
+                floorMin: 1,
+                floorMax: 4,
+                totalCount: 2,
+                totalAvailable: 10,
+                bathroomMin: 1,
+                bathroomMax: 3,
+                openWaitlist: false,
+                sqFeetMin: 340,
+                sqFeetMax: 725,
+                unitGroupAmiLevels: [
+                  {
+                    id: "8025f0c3-4103-4321-8261-da536e489572",
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    amiPercentage: 20,
+                    monthlyRentDeterminationType:
+                      EnumUnitGroupAmiLevelMonthlyRentDeterminationType.flatRent,
+                    percentageOfIncomeValue: null,
+                    flatRentValue: 1500,
+                    amiChart: {
+                      id: "cf8574bb-599f-40fa-9468-87c1e16be898",
+                      createdAt: new Date(),
+                      updatedAt: new Date(),
+                      items: [],
+                      name: "Divine Orchard",
+                      jurisdictions: {
+                        id: "e674b260-d26f-462a-9090-abaabe939cae",
+                        name: "Bloomington",
+                      },
+                    },
+                  },
+                ],
+                unitTypes: [
+                  {
+                    id: "d20ada5f-3b33-4ec6-86b8-ce9412bb8844",
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    name: UnitTypeEnum.studio,
+                    numBedrooms: 0,
+                  },
+                  {
+                    id: "a7195b0a-2311-494c-9765-7304a3637312",
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    name: UnitTypeEnum.oneBdrm,
+                    numBedrooms: 1,
+                  },
+                ],
+              },
+              {
+                id: "2d4971f5-b651-430c-9a2f-4655534f1bda",
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                openWaitlist: false,
+                unitGroupAmiLevels: [],
+                unitTypes: [
+                  {
+                    id: "a7195b0a-2311-494c-9765-7304a3637312",
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    name: UnitTypeEnum.oneBdrm,
+                    numBedrooms: 1,
+                  },
+                ],
+              },
+            ],
+            reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
+            status: ListingsStatusEnum.active,
+            applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+          },
+          false,
+          true
+        )
+      ).toEqual({
+        label: "Closed waitlist",
+        variant: "secondary-inverse",
       })
     })
   })

--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -37,7 +37,6 @@ export const ListingCard = ({
   showHomeType,
 }: ListingCardProps) => {
   const enableUnitGroups = isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableUnitGroups)
-  const enableMarketingStatus = isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableMarketingStatus)
 
   const imageUrl = imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))[0]
   const listingTags = getListingTags(
@@ -105,13 +104,6 @@ export const ListingCard = ({
     enableUnitGroups,
   ])
 
-  // Only show the status when unit groups is on if the listing is under construction
-  const showStatusMessage =
-    (!!status?.content && !enableUnitGroups) ||
-    (enableUnitGroups &&
-      enableMarketingStatus &&
-      listing.marketingType === MarketingTypeEnum.comingSoon)
-
   return (
     <li className={styles["list-item"]}>
       <ClickableCard className={styles["listing-card-container"]}>
@@ -145,7 +137,7 @@ export const ListingCard = ({
                   })}
                 </div>
               )}
-              {showStatusMessage && (
+              {!!status?.content && (
                 <div className={"seeds-m-bs-3"}>
                   {getListingStatusMessage(listing, jurisdiction, null, true)}
                 </div>

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import dayjs from "dayjs"
 import InfoIcon from "@heroicons/react/20/solid/InformationCircleIcon"
+import LockClosedIcon from "@heroicons/react/20/solid/LockClosedIcon"
 import {
   t,
   ListingCard,
@@ -172,8 +173,14 @@ export const getStatusPrefix = (
     if (listing.reviewOrderType === ReviewOrderTypeEnum.lottery)
       return { label: t("listings.lottery"), variant: "primary" }
     if (unitsAvailable) return { label: t("listings.applicationFCFS"), variant: "primary" }
-    if (hasUnitGroupsWaitlistOpen)
+    if (!listing.unitGroups || listing.unitGroups.length === 0) {
+      return { label: t("listings.availabilityUnknown"), variant: "warn" }
+    }
+    if (hasUnitGroupsWaitlistOpen) {
       return { label: t("listings.waitlist.open"), variant: "secondary" }
+    } else {
+      return { label: t("listings.availability.closedWaitlist"), variant: "secondary-inverse" }
+    }
   } else {
     switch (listing.reviewOrderType) {
       case ReviewOrderTypeEnum.lottery:
@@ -237,12 +244,27 @@ export const getListingStatusMessage = (
   const enableUnitGroups = isFeatureFlagOn(jurisdiction, "enableUnitGroups")
   const prefix = getStatusPrefix(listing, enableMarketingStatus, enableUnitGroups)
 
+  const hideNoUnitGroups =
+    enableUnitGroups &&
+    (!listing.unitGroups || listing.unitGroups.length === 0) &&
+    listing.reviewOrderType !== ReviewOrderTypeEnum.lottery
+  const hideWaitlistClosedNoAvailableUnits =
+    enableUnitGroups &&
+    !listing.unitGroups.some((group) => group.openWaitlist || group.totalAvailable > 0) &&
+    listing.reviewOrderType !== ReviewOrderTypeEnum.lottery
+  const hideIsClosed =
+    listing.status === ListingsStatusEnum.closed ||
+    (listing.applicationDueDate && dayjs() > dayjs(listing.applicationDueDate))
+
+  const hideStatusMessageContent =
+    hideDate || hideNoUnitGroups || hideWaitlistClosedNoAvailableUnits || hideIsClosed
+
   return (
     <Message
       className={styles["status-bar"]}
       customIcon={
         <Icon size="md" className={styles["primary-color-icon"]}>
-          <InfoIcon />
+          {prefix?.variant === "secondary-inverse" ? <LockClosedIcon /> : <InfoIcon />}
         </Icon>
       }
       variant={prefix?.variant}
@@ -252,7 +274,7 @@ export const getListingStatusMessage = (
       ) : (
         <div className={styles["due-date-content"]}>
           <div className={styles["date-review-order"]}>{prefix?.label}</div>
-          {!hideDate && (
+          {!hideStatusMessageContent && (
             <div>
               {getListingStatusMessageContent(
                 listing.status,

--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -244,14 +244,16 @@ export const getListingStatusMessage = (
   const enableUnitGroups = isFeatureFlagOn(jurisdiction, "enableUnitGroups")
   const prefix = getStatusPrefix(listing, enableMarketingStatus, enableUnitGroups)
 
+  const overwriteHide =
+    listing.reviewOrderType !== ReviewOrderTypeEnum.lottery &&
+    listing.marketingType !== MarketingTypeEnum.comingSoon
+
   const hideNoUnitGroups =
-    enableUnitGroups &&
-    (!listing.unitGroups || listing.unitGroups.length === 0) &&
-    listing.reviewOrderType !== ReviewOrderTypeEnum.lottery
+    enableUnitGroups && (!listing.unitGroups || listing.unitGroups.length === 0) && overwriteHide
   const hideWaitlistClosedNoAvailableUnits =
     enableUnitGroups &&
     !listing.unitGroups.some((group) => group.openWaitlist || group.totalAvailable > 0) &&
-    listing.reviewOrderType !== ReviewOrderTypeEnum.lottery
+    overwriteHide
   const hideIsClosed =
     listing.status === ListingsStatusEnum.closed ||
     (listing.applicationDueDate && dayjs() > dayjs(listing.applicationDueDate))


### PR DESCRIPTION
This PR addresses #5196 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Brings back status for unit groups listings.

## How Can This Be Tested/Reviewed?

Basically we need to test those AC's and check on `localhost:3000/listings` if it displays properly:

- If Under Construction, should show status as "Under Construction" + coming soon date (stay as-is)
- If Lottery - status will show "Lottery” + due date if applicable
- If FCFS (vacant units entered) and open waitlist - status will show ‘FCFS” + due date if applicable
- If FCFS (vacant units entered) and closed waitlist - status will show ‘FCFS” + due date if applicable
- If only open waitlist units (no vacant units entered) - status will show “Open waitlist” + due date if applicable
- If only closed waitlist (no vacant units entered) - status will show “Closed waitlist” (if there is a due date entered, it should be dropped)
- If there are no units entered, we should surface an "availability unknown" status

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
