### PR TITLE
fix: clear filters

### DIFF
--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -629,6 +629,7 @@
   "leasingAgent.contact": "Comuníquese con el agente de alquiler",
   "leasingAgent.dueToHighCallVolume": "Debido al alto volumen de llamadas, usted podría escuchar un mensaje.",
   "leasingAgent.officeHours": "Horario de oficina",
+  "listingFilters.clear": "Borrar",
   "listingFilters.program.Families": "Familias",
   "listingFilters.program.Residents with Disabilities": "Residentes con discapacidades",
   "listingFilters.program.Seniors 55+": "Adultos mayores de 55 años",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -620,6 +620,7 @@
   "leasingAgent.contact": "Contact leasing agent",
   "leasingAgent.dueToHighCallVolume": "Due to high call volume you may hear a message.",
   "leasingAgent.officeHours": "Office hours",
+  "listingFilters.clear": "Clear",
   "listingFilters.program.Families": "Families",
   "listingFilters.program.Residents with Disabilities": "Residents with disabilities",
   "listingFilters.program.Seniors 55+": "Seniors 55+",

--- a/sites/public/src/components/browse/FilterDrawer.tsx
+++ b/sites/public/src/components/browse/FilterDrawer.tsx
@@ -127,7 +127,7 @@ const FilterDrawer = (props: FilterDrawerProps) => {
               return {
                 key: `${ListingFilterKeys.regions}.${region}`,
                 label: region.replace("_", " "),
-                defaultChecked: props.filterState?.[ListingFilterKeys.regions]?.[region],
+                defaultChecked: isTrue(props.filterState?.[ListingFilterKeys.regions]?.[region]),
               }
             })}
             register={register}
@@ -165,8 +165,8 @@ const FilterDrawer = (props: FilterDrawerProps) => {
           variant="primary-outlined"
           size="sm"
           onClick={() => {
-            reset({})
             props.onClear()
+            reset({})
           }}
         >
           {t("listingFilters.clear")}

--- a/sites/public/src/components/browse/FilterDrawer.tsx
+++ b/sites/public/src/components/browse/FilterDrawer.tsx
@@ -29,6 +29,7 @@ export interface FilterDrawerProps {
   isOpen: boolean
   onClose: () => void
   onSubmit: (data: FilterData) => void
+  onClear: () => void
   multiselectData: MultiselectQuestion[]
   activeFeatureFlags?: FeatureFlagEnum[]
 }
@@ -42,6 +43,7 @@ const FilterDrawer = (props: FilterDrawerProps) => {
     setValue,
     setError,
     clearErrors,
+    reset,
     formState: { errors },
   } = useForm({ mode: "onBlur" })
 
@@ -159,8 +161,15 @@ const FilterDrawer = (props: FilterDrawerProps) => {
         <Button type="submit" variant="primary" size="sm" nativeButtonProps={{ form: "filter" }}>
           {t("listings.showMatchingListings")}
         </Button>
-        <Button variant="primary-outlined" size="sm" onClick={props.onClose}>
-          {t("t.cancel")}
+        <Button
+          variant="primary-outlined"
+          size="sm"
+          onClick={() => {
+            reset({})
+            props.onClear()
+          }}
+        >
+          {t("listingFilters.clear")}
         </Button>
       </Drawer.Footer>
     </Drawer>

--- a/sites/public/src/components/browse/ListingBrowse.tsx
+++ b/sites/public/src/components/browse/ListingBrowse.tsx
@@ -141,6 +141,10 @@ export const ListingBrowse = (props: ListingBrowseProps) => {
     }
   }
 
+  const onFilterClear = () => {
+    setFilterState({})
+  }
+
   const onShowAll = useCallback(async () => {
     await router.replace(router.pathname)
   }, [router])
@@ -168,6 +172,7 @@ export const ListingBrowse = (props: ListingBrowseProps) => {
         filterState={filterState}
         multiselectData={props.multiselectData}
         activeFeatureFlags={jurisdictionActiveFeatureFlags}
+        onClear={onFilterClear}
       />
       <LoadingState loading={isLoading}>
         <div className={styles["listing-directory"]}>


### PR DESCRIPTION
This PR addresses #5247

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds clear filters button

## How Can This Be Tested/Reviewed?

Go to `/listings` open filter drawer, it should have now `clear` button instead of close.
male sure it clears filters:
- when no filters applied
- when filters applied

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
