### PR TITLE
fix: allow empty address

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -140,6 +140,7 @@ export const stagingSeed = async (
   const nadaHill = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Nada Hill', {
       featureFlags: [],
+      requiredListingFields: ['name'],
     }),
   });
   // create super admin user

--- a/shared-helpers/src/utilities/Address.tsx
+++ b/shared-helpers/src/utilities/Address.tsx
@@ -9,12 +9,14 @@ interface AddressProps {
 }
 
 export const oneLineAddress = (address: AddressType) => {
+  if (!address) return ""
   return `${address.street}${address.street2 ? `, ${address.street2}` : ""}, ${address.city}, ${
     address.state
   } ${address.zipCode}`
 }
 
 export const multiLineAddress = (address: AddressType) => {
+  if (!address) return <></>
   return (
     <>
       {address.placeName && <span>{address.placeName}</span>}
@@ -25,6 +27,7 @@ export const multiLineAddress = (address: AddressType) => {
 }
 
 export const Address = ({ address, getDirections }: AddressProps) => {
+  if (!address) return <></>
   const googleMapsHref = "https://www.google.com/maps/place/" + oneLineAddress(address)
 
   return (

--- a/sites/public/__tests__/components/browse/ListingCard.test.tsx
+++ b/sites/public/__tests__/components/browse/ListingCard.test.tsx
@@ -128,4 +128,18 @@ describe("<ListingCard>", () => {
     expect(view.getByText("Seniors 62+")).toBeDefined()
     expect(view.getByText("Supportive housing for the homeless")).toBeDefined()
   })
+  it("renders with no address", () => {
+    const view = render(
+      <ListingCard
+        listing={{
+          ...listing,
+          status: ListingsStatusEnum.active,
+          applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+          listingsBuildingAddress: null,
+        }}
+        jurisdiction={jurisdiction}
+      />
+    )
+    expect(view.getByText(listing.name)).toBeDefined()
+  })
 })

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -165,18 +165,20 @@ export const MainDetails = ({
         >
           {listing.name}
         </Heading>
-        <div className={styles["listing-address-container"]}>
-          <div className={styles["listing-address"]}>
-            <div className={`seeds-m-ie-4 ${styles["flex-margin"]}`}>
-              {oneLineAddress(listing.listingsBuildingAddress)}
-            </div>
-            <div className={styles["flex-margin"]}>
-              <Link href={googleMapsHref} newWindowTarget={true}>
-                {t("t.viewOnMap")}
-              </Link>
+        {listing.listingsBuildingAddress && (
+          <div className={styles["listing-address-container"]}>
+            <div className={styles["listing-address"]}>
+              <div className={`seeds-m-ie-4 ${styles["flex-margin"]}`}>
+                {oneLineAddress(listing.listingsBuildingAddress)}
+              </div>
+              <div className={styles["flex-margin"]}>
+                <Link href={googleMapsHref} newWindowTarget={true}>
+                  {t("t.viewOnMap")}
+                </Link>
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
         {listingTags.length > 0 && (
           <div className={`${styles["listing-tags"]} seeds-m-bs-3`} data-testid={"listing-tags"}>

--- a/sites/public/src/components/listing/listing_sections/Neighborhood.tsx
+++ b/sites/public/src/components/listing/listing_sections/Neighborhood.tsx
@@ -30,6 +30,9 @@ export const Neighborhood = ({
     ? Object.values(neighborhoodAmenities).some((value) => value !== null && value !== undefined)
     : null
 
+  const showSection = address || neighborhood || region || hasNeighborhoodAmenities
+  if (!showSection) return null
+
   return (
     <CollapsibleSection
       title={t("t.neighborhood")}
@@ -37,10 +40,14 @@ export const Neighborhood = ({
       priority={2}
     >
       <div className={`${styles["mobile-inline-collapse-padding"]} seeds-m-bs-section`}>
-        <ListingMap address={getGenericAddress(address)} listingName={name} />
-        <Link href={googleMapsHref} newWindowTarget={true} className={"seeds-m-bs-4"}>
-          {t("t.getDirections")}
-        </Link>
+        {address && (
+          <>
+            <ListingMap address={getGenericAddress(address)} listingName={name} />
+            <Link href={googleMapsHref} newWindowTarget={true} className={"seeds-m-bs-4"}>
+              {t("t.getDirections")}
+            </Link>
+          </>
+        )}
         {neighborhood && (
           <HeadingGroup
             heading={t("t.neighborhood")}


### PR DESCRIPTION
## Description

Allows for a listing to not have the address filled out and still render. Currently the browse and detail pages in Detroit dev when we bring over the replatforming breaks without an address ([deploy preview](https://deploy-preview-1685--detroit-public-dev.netlify.app/listings)). Some of the test data in old Detroit dev does not have an address.

## How Can This Be Tested/Reviewed?

Detail page: Check out a preview of this Nada Hill listing with no address: https://deploy-preview-5307--bloom-public-seeds.netlify.app/preview/listings/5d6629cf-a37d-4cfb-8600-3ca4c2b64500

Browse page: The browse page needs to be tested locally - set the public env jurisdiction variable to Nada Hill and create a listing with no address.

<img width="1056" height="498" alt="Screenshot 2025-08-26 at 10 20 42 AM" src="https://github.com/user-attachments/assets/3481f678-90e7-44c7-9890-7f24b52e2396" />


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
