### PR TITLE
fix: large array params must be converted from object format

### DIFF
--- a/api/src/decorators/fix-large-object-array.ts
+++ b/api/src/decorators/fix-large-object-array.ts
@@ -1,0 +1,20 @@
+import { Transform } from 'class-transformer';
+
+// Because of low-level behavior with in the `qs` library,  array params over 21 items turns into
+// an object with key-pairs of indices and values. This can break data input at the controller level.
+// The following decorator restores that object to a standard array.
+// See: https://stackoverflow.com/a/75380449
+
+/**
+ * Because of low-level behavior within the `qs` library,  array params over 21 items turn into
+ * objects with key-pairs of indices and values. This can break data input at the controller level.
+ * The following decorator restores that object to a standard array.
+ * See: https://stackoverflow.com/a/75380449
+ * 
+ * @returns {PropertyDecorator}
+ */
+export function FixLargeObjectArray(): PropertyDecorator {
+  return Transform(({ value }) =>
+    value && typeof value === 'object' ? Object.values(value) : value,
+  );
+}

--- a/api/src/dtos/listings/listings-filter-params.dto.ts
+++ b/api/src/dtos/listings/listings-filter-params.dto.ts
@@ -14,6 +14,7 @@ import { BaseFilter } from '../shared/base-filter.dto';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
 import { FilterAvailabilityEnum } from '../../enums/listings/filter-availability-enum';
 import { ListingFilterKeys } from '../../enums/listings/filter-key-enum';
+import { FixLargeObjectArray } from '../../decorators/fix-large-object-array';
 
 export class ListingFilterParams extends BaseFilter {
   @Expose()
@@ -103,6 +104,7 @@ export class ListingFilterParams extends BaseFilter {
   })
   @IsUUID(4, { groups: [ValidationsGroupsEnum.default], each: true })
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
+  @FixLargeObjectArray()
   [ListingFilterKeys.ids]?: string[];
 
   @Expose()


### PR DESCRIPTION
This PR addresses #5266 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

I'm not 100% sold on my solution, but it's definitely a fix for the original issue (you can see an explanation in a code comment). My own preference would have been to change the behavior of the underlying `qs` library as utilized by NestJS so that it doesn't cause the original bug, but after some time researching I wasn't able to come up with a way to do so.

I also spent some time trying to figure out a way to test the fix in our E2E suite, but I wasn't able to replicate the exact behavior as a GET request with URL-based query params that worked as an E2E test.

## How Can This Be Tested/Reviewed?

As it requires favoriting more than 21 listings, it's probably easiest to try by using the Netlify preview.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
