### PR TITLE
fix: display vacant units for available units in partners

### DIFF
--- a/sites/partners/src/pages/index.tsx
+++ b/sites/partners/src/pages/index.tsx
@@ -10,6 +10,7 @@ import Layout from "../layouts"
 import { MetaTags } from "../components/shared/MetaTags"
 import { NavigationHeader } from "../components/shared/NavigationHeader"
 import DocumentArrowDownIcon from "@heroicons/react/24/solid/DocumentArrowDownIcon"
+import { FeatureFlagEnum, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 class formatLinkCell {
   link: HTMLAnchorElement
@@ -59,7 +60,7 @@ class ListingsLink extends formatLinkCell {
 
 export default function ListingsList() {
   const metaDescription = t("pageDescription.welcome", { regionName: t("region.name") })
-  const { profile } = useContext(AuthContext)
+  const { profile, doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
   const isAdmin = profile?.userRoles?.isAdmin || profile?.userRoles?.isJurisdictionalAdmin || false
   const { onExport, csvExportLoading } = useListingExport()
 
@@ -133,6 +134,19 @@ export default function ListingsList() {
         filter: false,
         resizable: true,
         minWidth: 110,
+        valueFormatter: ({ value, data }: { value: string; data: Listing }) => {
+          if (
+            doJurisdictionsHaveFeatureFlagOn(
+              FeatureFlagEnum.enableUnitGroups,
+              data.jurisdictions.id
+            )
+          ) {
+            return data.unitGroups
+              .reduce((acc, curr) => acc + (curr.totalAvailable ?? 0), 0)
+              .toString()
+          }
+          return value
+        },
       },
       {
         headerName: t("listings.waitlist.open"),


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

It will display sum of vacant units for `available units` table for `unit groups` listings.
It does not exist for current detroit, so it seem like best value to display

## How Can This Be Tested/Reviewed?

log in to partners. For `unit group` listings it will show now `available units` based on unit groups.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
