### PR TITLE
fix: oom builds

### DIFF
--- a/sites/partners/next.config.js
+++ b/sites/partners/next.config.js
@@ -73,6 +73,9 @@ module.exports = withBundleAnalyzer(
       })
       return config
     },
+    eslint: {
+      ignoreDuringBuilds: true,
+    },
     // Uncomment line below before building when using symlink for UI-C
     // experimental: { esmExternals: "loose" },
   })

--- a/sites/public/next.config.js
+++ b/sites/public/next.config.js
@@ -70,6 +70,9 @@ module.exports = withBundleAnalyzer({
 
     return config
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   // Uncomment line below before building when using symlink for UI-C
   // experimental: { esmExternals: "loose" },
 })


### PR DESCRIPTION
## Description

This attempts to resolve our intermittent failing Netlify builds due to out of memory issues.

## How Can This Be Tested/Reviewed?

[Documentation
](https://nextjs.org/docs/app/guides/memory-usage#disable-static-analysis)

Because we already run linting in CI and locally pre-commit, which is where we are getting OOM, we don't need to also run it during a build.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
