### PR TITLE
chore: adjust padding of Seeds tag for multi-line text

### DIFF
--- a/sites/public/styles/overrides.scss
+++ b/sites/public/styles/overrides.scss
@@ -3,6 +3,12 @@
     -webkit-font-smoothing: antialiased; // restore macOS styling that had been unset
   }
 
+  .seeds-tag {
+    --tag-padding-inline: var(--seeds-s3);
+    --tag-padding-block: var(--seeds-s1_5);
+    line-height: var(--seeds-line-height-4);
+  }
+
   .main-container {
     display: flex;
     flex: 1;


### PR DESCRIPTION
This PR addresses #5310

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

> [!WARNING]
> This is an adjustment to the metrics of the Seeds tag. We may want to make this adjustment in Seeds directly, or come up with a different approach with guidance from design.

With that caveat, this PR might be helpful at least to kick off discussion. I adjusted the padding slightly as well as tightened the line height for when the text wraps (which I don't think we ever accounted for previously). I think that looks better, but YMMV.

Before/after:

<img width="237" height="187" alt="image" src="https://github.com/user-attachments/assets/1529243d-eb02-4262-8673-54fdb9fa6fde" />

<img width="237" height="187" alt="image" src="https://github.com/user-attachments/assets/3b6aa912-2641-4dd5-b54a-ff75412db156" />

## How Can This Be Tested/Reviewed?

review app: https://deploy-preview-5341--bloom-lakeview.netlify.app

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
