### PR TITLE
fix: change password validity to 365

### DIFF
--- a/api/prisma/migrations/31_change_password_validity_to_365/migration.sql
+++ b/api/prisma/migrations/31_change_password_validity_to_365/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "user_accounts" ALTER COLUMN "password_valid_for_days" SET DEFAULT 365;
+-- Update existing rows
+UPDATE "user_accounts" SET "password_valid_for_days" = 365

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -842,7 +842,7 @@ model UserAccounts {
   id                       String                  @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   passwordHash             String                  @map("password_hash") @db.VarChar
   passwordUpdatedAt        DateTime                @default(now()) @map("password_updated_at") @db.Timestamp(6)
-  passwordValidForDays     Int                     @default(180) @map("password_valid_for_days")
+  passwordValidForDays     Int                     @default(365) @map("password_valid_for_days")
   resetToken               String?                 @map("reset_token") @db.VarChar
   confirmationToken        String?                 @map("confirmation_token") @db.VarChar
   confirmedAt              DateTime?               @map("confirmed_at") @db.Timestamptz(6)


### PR DESCRIPTION
This PR addresses [#1421](https://github.com/metrotranscom/doorway/issues/1421)
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description
`DO NOT MERGE TO HBA`

Changes default value for `password_valid_for_days` to 365 and updates current users to have that value.

## How Can This Be Tested/Reviewed?

Run migration  (`db:migration:run` in `api`, then `prisma generate`) -> it should update all existing users to have `365`.
Then go to partners `/users` and create user, it should be created with 365 as default value. Same should be applied for public create account.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
