### PR TITLE
fix: gitleaks only run on push

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,8 +1,6 @@
 name: gitleaks
 on:
   push:
-  issues:
-  issue_comment:
 
 jobs:
   scan:


### PR DESCRIPTION
This PR addresses #5358 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

This PR removes the trigger of running on issues because it is not yet supported. See https://github.com/bloom-housing/bloom/actions/runs/17736286648/job/50398846672

This only failed after a merge to main. It is possible the issues trigger only takes affect on the main branch and that is why it did not fail on the PR branch.

## How Can This Be Tested/Reviewed?

gitleaks action should continue to run on push

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
