### PR TITLE
fix: hide closed and draft listings from crawlers

### DIFF
--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -202,6 +202,7 @@ interface LayoutProps {
   children: React.ReactNode
   metaDescription?: string
   metaImage?: string
+  noIndex?: boolean
   pageTitle?: string
 }
 
@@ -231,6 +232,7 @@ const Layout = (props: LayoutProps) => {
           <title>
             {props.pageTitle ? `${props.pageTitle} - ${t("nav.siteTitle")}` : t("nav.siteTitle")}
           </title>
+          {props.noIndex && <meta name="robots" content="noindex, follow" />}
           {props.pageTitle && (
             <MetaTags
               title={props.pageTitle}

--- a/sites/public/src/pages/listing/[id]/[slug].tsx
+++ b/sites/public/src/pages/listing/[id]/[slug].tsx
@@ -14,7 +14,11 @@ import { ListingView } from "../../../components/listing/ListingView"
 import { ErrorPage } from "../../_error"
 import dayjs from "dayjs"
 import { fetchJurisdictionByName } from "../../../lib/hooks"
-import { Jurisdiction, Listing } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  Jurisdiction,
+  Listing,
+  ListingsStatusEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { ListingViewSeeds } from "../../../components/listing/ListingViewSeeds"
 
 interface ListingProps {
@@ -64,7 +68,13 @@ export default function ListingPage(props: ListingProps) {
   const metaImage = imageUrlFromListing(listing, parseInt(process.env.listingPhotoSize))[0]
 
   return (
-    <Layout pageTitle={listing.name} metaImage={metaImage} metaDescription={metaDescription}>
+    <Layout
+      pageTitle={listing.name}
+      metaImage={metaImage}
+      metaDescription={metaDescription}
+      // search engines should not crawl for closed or draft listings
+      noIndex={listing.status !== ListingsStatusEnum.active}
+    >
       {process.env.showNewSeedsDesigns ? (
         <ListingViewSeeds listing={listing} profile={profile} jurisdiction={props.jurisdiction} />
       ) : (


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When searching for a listing on google non-open listings can be shown. This is not ideal if a listing is still in draft or a listing has been duplicated and the older posting is showing higher in the search results 

## How Can This Be Tested/Reviewed?

You can't test if this will prevent search crawlers from finding the page, but you can verify that the listing details page is adding the "meta" tag on non-open listings.

1. Go to the /listings/[id] page of an open listing. You should not see the new meta tag in the <head>
2. Go to the /listings/[id] page of a closed listing. You should see the new meta tag in the <head>
3. Go to the /listings/[id] page of a draft listing. You should see the new meta tag in the <head>

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
