### PR TITLE
fix: listing export fixes

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -16,6 +16,7 @@ yarn-error.log*
 # Tests
 /coverage
 /.nyc_output
+sampleFile.csv
 
 # IDEs and editors
 /.idea

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -223,7 +223,7 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
   /**
    *
    * @param filename
-   * @param queryParams
+   * @param optionParams
    * @returns a promise with SuccessDTO
    */
   async createCsv<QueryParams extends ListingCsvQueryParams>(
@@ -434,7 +434,7 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
           formatLocalDate(val, this.dateFormat, this.timeZone),
       },
       {
-        path: 'updatedAt',
+        path: 'contentUpdatedAt',
         label: 'Last Updated',
         format: (val: string): string =>
           formatLocalDate(val, this.dateFormat, this.timeZone),
@@ -955,23 +955,23 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
           label: 'Leasing Agent Zip',
         },
         {
-          path: 'listingsLeasingAgentAddress.street',
+          path: 'listingsApplicationMailingAddress.street',
           label: 'Leasing Agency Mailing Address',
         },
         {
-          path: 'listingsLeasingAgentAddress.street2',
+          path: 'listingsApplicationMailingAddress.street2',
           label: 'Leasing Agency Mailing Address Street 2',
         },
         {
-          path: 'listingsLeasingAgentAddress.city',
+          path: 'listingsApplicationMailingAddress.city',
           label: 'Leasing Agency Mailing Address City',
         },
         {
-          path: 'listingsLeasingAgentAddress.state',
+          path: 'listingsApplicationMailingAddress.state',
           label: 'Leasing Agency Mailing Address State',
         },
         {
-          path: 'listingsLeasingAgentAddress.zipCode',
+          path: 'listingsApplicationMailingAddress.zipCode',
           label: 'Leasing Agency Mailing Address Zip',
         },
         {
@@ -1117,7 +1117,9 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
           path: 'userAccounts',
           label: 'Partners Who Have Access',
           format: (val: User[]): string =>
-            val.map((user) => `${user.firstName} ${user.lastName}`).join(', '),
+            val
+              ?.map((user) => `${user.firstName} ${user.lastName}`)
+              .join(', ') || '',
         },
       ],
     );

--- a/api/test/unit/services/listing-csv-export.service.spec.ts
+++ b/api/test/unit/services/listing-csv-export.service.spec.ts
@@ -1,10 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Logger } from '@nestjs/common';
+import { ListingEventsTypeEnum, ListingsStatusEnum } from '@prisma/client';
+import dayjs from 'dayjs';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
 import { ListingCsvExporterService } from '../../../src/services/listing-csv-export.service';
 import { PrismaService } from '../../../src/services/prisma.service';
 import Listing from '../../../src/dtos/listings/listing.dto';
+import { User } from '../../../src/dtos/users/user.dto';
 
 describe('Testing listing csv export service', () => {
   let service: ListingCsvExporterService;
@@ -29,6 +32,113 @@ describe('Testing listing csv export service', () => {
       // do nothing
     });
     jest.restoreAllMocks();
+  });
+
+  describe('crateCsv', () => {
+    it('should create the listing csv', async () => {
+      const timestamp = new Date(1759430299657);
+      const unit = {
+        number: 1,
+        numBathrooms: 2,
+        floor: 3,
+        sqFeet: 1200,
+        minOccupancy: 1,
+        maxOccupancy: 8,
+        amiPercentage: 80,
+        monthlyRentAsPercentOfIncome: null,
+        monthlyRent: 4000,
+        unitTypes: { id: randomUUID(), name: 'studio' },
+        amiChart: { id: randomUUID(), name: 'Ami Chart Name' },
+      };
+      const mockListing = {
+        id: 'listing1-ID',
+        name: `listing1-Name`,
+        createdAt: timestamp,
+        jurisdictions: { id: 'jurisdiction-ID', name: 'jurisdiction-Name' },
+        status: ListingsStatusEnum.active,
+        publishedAt: timestamp,
+        contentUpdatedAt: timestamp,
+        developer: 'developer',
+        listingsBuildingAddress: {
+          street: '123 main st',
+          city: 'Bloomington',
+          state: 'BL',
+          zipCode: '01234',
+          latitude: 'latitude',
+          longitude: 'longitude',
+        },
+        neighborhood: 'neighborhood',
+        yearBuilt: '2025',
+        listingEvents: [
+          {
+            type: ListingEventsTypeEnum.publicLottery,
+            startTime: timestamp,
+            endTime: dayjs(timestamp).add(2, 'hours').toDate(),
+            note: 'lottery note',
+          },
+        ],
+        applicationFee: 45,
+        depositHelperText: 'sample deposit helper text',
+        depositMin: 12,
+        depositMax: 120,
+        costsNotIncluded: 'sample costs not included',
+        amenities: 'sample amenities',
+        accessibility: 'sample accessibility',
+        unitAmenities: 'sample unit amenities',
+        smokingPolicy: 'sample smoking policy',
+        petPolicy: 'sample pet policy',
+        servicesOffered: 'sample services offered',
+        leasingAgentName: 'Name of leasing agent',
+        leasingAgentEmail: 'Email of leasing agent',
+        leasingAgentTitle: 'Title of leasing agent',
+        leasingAgentOfficeHours: 'office hours',
+        listingsLeasingAgentAddress: {
+          street: '321 main st',
+          city: 'Bloomington',
+          state: 'BL',
+          zipCode: '01234',
+          latitude: 'latitude',
+          longitude: 'longitude',
+        },
+        listingsApplicationMailingAddress: {
+          street: '456 main st',
+          city: 'Bloomington',
+          state: 'BL',
+          zipCode: '01234',
+          latitude: 'latitude',
+          longitude: 'longitude',
+        },
+        listingsApplicationPickUpAddress: {
+          street: '789 main st',
+          city: 'Bloomington',
+          state: 'BL',
+          zipCode: '01234',
+          latitude: 'latitude',
+          longitude: 'longitude',
+        },
+        applicationDueDate: timestamp,
+        listingMultiselectQuestions: [],
+        applicationMethods: [],
+        userAccounts: [{ firstName: 'userFirst', lastName: 'userLast' }],
+        units: [unit],
+      };
+      await service.createCsv('sampleFile.csv', undefined, {
+        listings: [mockListing as unknown as Listing],
+        user: { jurisdictions: [] } as unknown as User,
+      });
+
+      expect(writeStream.bytesWritten).toBeGreaterThan(0);
+      const content = fs.readFileSync('sampleFile.csv', 'utf8');
+      // Validate headers
+      expect(content).toContain(
+        'Listing Id,Created At Date,Jurisdiction,Listing Name,Listing Status,Publish Date,Last Updated,Copy or Original,Copied From,Developer,Building Street Address,Building City,Building State,Building Zip,Building Neighborhood,Building Year Built,Community Types,Latitude,Longitude,Listing Availability,Review Order,Lottery Date,Lottery Start,Lottery End,Lottery Notes,Housing Preferences,Application Fee,Deposit Helper Text,Deposit Min,Deposit Max,Costs Not Included,Property Amenities,Additional Accessibility,Unit Amenities,Smoking Policy,Pets Policy,Services Offered,Eligibility Rules - Credit History,Eligibility Rules - Rental History,Eligibility Rules - Criminal Background,Eligibility Rules - Rental Assistance,Building Selection Criteria,Important Program Rules,Required Documents,Special Notes,Waitlist,Leasing Agent Name,Leasing Agent Email,Leasing Agent Phone,Leasing Agent Title,Leasing Agent Office Hours,Leasing Agent Street Address,Leasing Agent Apt/Unit #,Leasing Agent City,Leasing Agent State,Leasing Agent Zip,Leasing Agency Mailing Address,Leasing Agency Mailing Address Street 2,Leasing Agency Mailing Address City,Leasing Agency Mailing Address State,Leasing Agency Mailing Address Zip,Leasing Agency Pickup Address,Leasing Agency Pickup Address Street 2,Leasing Agency Pickup Address City,Leasing Agency Pickup Address State,Leasing Agency Pickup Address Zip,Leasing Pick Up Office Hours,Digital Application,Digital Application URL,Paper Application,Paper Application URL,Referral Opportunity,Can applications be mailed in?,Can applications be picked up?,Can applications be dropped off?,Postmark,Additional Application Submission Notes,Application Due Date,Application Due Time,Open House,Partners Who Have Access',
+      );
+      // Validate first row
+      expect(content).toContain(
+        '"listing1-ID","10-02-2025 11:38:19AM PDT","jurisdiction-Name","listing1-Name","Public","10-02-2025 11:38:19AM PDT","10-02-2025 11:38:19AM PDT","Original",,"developer","123 main st","Bloomington","BL","01234","neighborhood","2025",,"latitude","longitude","Available Units",,"10-02-2025","11:38AM PDT","01:38PM PDT","lottery note",,"$45","sample deposit helper text","$12","$120","sample costs not included","sample amenities","sample accessibility","sample unit amenities","sample smoking policy","sample pet policy","sample services offered",,,,,,,,,"No","Name of leasing agent","Email of leasing agent",,"Title of leasing agent","office hours","321 main st",,"Bloomington","BL","01234","456 main st",,"Bloomington","BL","01234","789 main st",,"Bloomington","BL","01234",,"No",,"No",,"No","No","No","No",,,"10-02-2025","11:38AM PDT",,"userFirst userLast"',
+      );
+    });
+    it.todo('should create the listing csv with feature flagged columns');
   });
 
   describe('createUnitCsv', () => {
@@ -158,7 +268,9 @@ describe('Testing listing csv export service', () => {
         },
       };
 
-      await expect(service.authorizeCSVExport(user as any)).resolves.toBeUndefined();
+      await expect(
+        service.authorizeCSVExport(user as any),
+      ).resolves.toBeUndefined();
     });
 
     it('should allow support admin users to export', async () => {
@@ -178,7 +290,9 @@ describe('Testing listing csv export service', () => {
         },
       };
 
-      await expect(service.authorizeCSVExport(user as any)).resolves.toBeUndefined();
+      await expect(
+        service.authorizeCSVExport(user as any),
+      ).resolves.toBeUndefined();
     });
 
     it('should throw ForbiddenException for unauthorized users', async () => {


### PR DESCRIPTION
This PR addresses #5407 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The listing export CSV is incorrectly using the updatedAt field instead of the contentUpdatedAt. This is causing issues because the updatedAt field gets updated in scenarios that doesn't involve an actual change to the listing.

While writing a new test I also found an issue with the "mailing address" as well

## How Can This Be Tested/Reviewed?

This can be tested by downloading a listing csv export in the partner site.

1. Reseed the database
2. Login to the partner site as an admin
3. Go to the /listings page and click "export"
4. validate that the update fields are accurate ("Last Updated" and "Leasing Agency Mailing Address" fields)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
