### PR TITLE
fix: add what to expect additional for non-seeds page

### DIFF
--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -7437,7 +7437,6 @@ export enum UserRoleEnum {
 export enum FeatureFlagEnum {
   "disableCommonApplication" = "disableCommonApplication",
   "disableJurisdictionalAdmin" = "disableJurisdictionalAdmin",
-  "enableSupportAdmin" = "enableSupportAdmin",
   "disableListingPreferences" = "disableListingPreferences",
   "disableWorkInRegion" = "disableWorkInRegion",
   "enableAccessibilityFeatures" = "enableAccessibilityFeatures",
@@ -7463,6 +7462,7 @@ export enum FeatureFlagEnum {
   "enableRegions" = "enableRegions",
   "enableSection8Question" = "enableSection8Question",
   "enableSingleUseCode" = "enableSingleUseCode",
+  "enableSupportAdmin" = "enableSupportAdmin",
   "enableUnderConstructionHome" = "enableUnderConstructionHome",
   "enableUnitGroups" = "enableUnitGroups",
   "enableUtilitiesIncluded" = "enableUtilitiesIncluded",

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -928,6 +928,13 @@ export const ListingView = (props: ListingProps) => {
             {listing.whatToExpect && (
               <ExpandableSection
                 content={<Markdown className={"bloom-markdown"}>{listing.whatToExpect}</Markdown>}
+                expandableContent={
+                  listing.whatToExpectAdditionalText ? (
+                    <Markdown className={"bloom-markdown"}>
+                      {listing.whatToExpectAdditionalText}
+                    </Markdown>
+                  ) : undefined
+                }
                 strings={{
                   title: t("whatToExpect.label"),
                   readMore: t("t.readMore"),


### PR DESCRIPTION
This PR addresses bug found during Doorway bash, but related to #5117 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When testing this change in Doorway it was noticed that the new "what to expect additional" field was added to the partners site but because it does not use the new seeds public changes the additional text is not shown anywhere.

This change adds it to the older listing details page.

## How Can This Be Tested/Reviewed?

Prerequisite for both scenarios is the `SHOW_NEW_SEEDS_DESIGNS` flag for the public site must be turned to `FALSE`

### with the new data
1. create or edit a listing in partners. Fill out the "Tell the applicant any additional information" field with data and publish the listing
2. Go to the public site and you should see the "read more" button within the "What to Expect" section for that listing.
3. On clicking the "read more" you should see the data filled out.

### without the new data
1. create or edit a listing in partners. Do not fill out "Tell the applicant any additional information" field with data and publish the listing
2. Go to the public site and you should *NOT* see the "read more" button within the "What to Expect" section for that listing.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
