### PR TITLE
feat: Remove publish lottery button on JA roles 

### DIFF
--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -744,7 +744,7 @@ describe("lottery", () => {
     expect(queryByText("Release lottery")).not.toBeInTheDocument()
   })
 
-  it("should now show publish button if in released to partners state as a parter", async () => {
+  it("should not show publish button if in released to partners state as a parter", async () => {
     mockNextRouter({ id: "Uvbk5qurpB2WI9V6WnNdH" })
     document.cookie = "access-token-available=True"
     server.use(

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -775,12 +775,12 @@ describe("lottery", () => {
       lotteryStatus: LotteryStatusEnum.releasedToPartners,
     }
 
-    const { getByText, findByText } = render(<Lottery listing={updatedListing} />)
+    const { getByText, findByText, queryByText } = render(<Lottery listing={updatedListing} />)
 
     const header = await findByText("Lottery")
     expect(header).toBeInTheDocument()
     expect(getByText("Publish lottery data")).toBeInTheDocument()
-    expect(getByText("Publish")).not.toBeInTheDocument()
+    expect(queryByText("Publish")).not.toBeInTheDocument()
   })
 
   it("should show export if in published to public state as a parter", async () => {

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -744,6 +744,45 @@ describe("lottery", () => {
     expect(queryByText("Release lottery")).not.toBeInTheDocument()
   })
 
+  it("should now show publish button if in released to partners state as a parter", async () => {
+    mockNextRouter({ id: "Uvbk5qurpB2WI9V6WnNdH" })
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            userRoles: { isParner: false, isJurisdictionalAdmin: true },
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      }),
+      rest.get("http://localhost:3100/applicationFlaggedSets/meta", (_req, res, ctx) => {
+        return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
+      }),
+      rest.get(
+        "http://localhost:3100/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
+    )
+
+    const updatedListing = {
+      ...closedListing,
+      lotteryStatus: LotteryStatusEnum.releasedToPartners,
+    }
+
+    const { getByText, findByText } = render(<Lottery listing={updatedListing} />)
+
+    const header = await findByText("Lottery")
+    expect(header).toBeInTheDocument()
+
+    expect(getByText("Publish lottery data")).toBeInTheDocument()
+  })
+
   it("should show export if in published to public state as a parter", async () => {
     mockNextRouter({ id: "Uvbk5qurpB2WI9V6WnNdH" })
     document.cookie = "access-token-available=True"

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -779,8 +779,8 @@ describe("lottery", () => {
 
     const header = await findByText("Lottery")
     expect(header).toBeInTheDocument()
-
     expect(getByText("Publish lottery data")).toBeInTheDocument()
+    expect(getByText("Publish")).toBeInTheDocument()
   })
 
   it("should show export if in published to public state as a parter", async () => {

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -779,8 +779,8 @@ describe("lottery", () => {
 
     const header = await findByText("Lottery")
     expect(header).toBeInTheDocument()
-    expect(getByText("Publish lottery data")).toBeInTheDocument()
-    expect(getByText("Publish")).toBeInTheDocument()
+    expect(getByText("Publish lottery data"))toBeInTheDocument()
+    expect(getByText("Publish")).not.toBeInTheDocument()
   })
 
   it("should show export if in published to public state as a parter", async () => {

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -752,7 +752,7 @@ describe("lottery", () => {
         return res(
           ctx.json({
             id: "user1",
-            userRoles: { isParner: false, isJurisdictionalAdmin: true },
+            userRoles: { isAdmin: false, isJurisdictionalAdmin: true },
           })
         )
       }),

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -752,7 +752,7 @@ describe("lottery", () => {
         return res(
           ctx.json({
             id: "user1",
-            userRoles: { isAdmin: false, isJurisdictionalAdmin: true },
+            userRoles: { isAdmin: true, isJurisdictionalAdmin: false },
           })
         )
       }),

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -779,7 +779,7 @@ describe("lottery", () => {
 
     const header = await findByText("Lottery")
     expect(header).toBeInTheDocument()
-    expect(getByText("Publish lottery data"))toBeInTheDocument()
+    expect(getByText("Publish lottery data")).toBeInTheDocument()
     expect(getByText("Publish")).not.toBeInTheDocument()
   })
 

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -744,7 +744,7 @@ describe("lottery", () => {
     expect(queryByText("Release lottery")).not.toBeInTheDocument()
   })
 
-  it("should not show publish button if in released to partners state as a parter", async () => {
+  it("should not show publish button if in released to partners state as a jurisdictional admin", async () => {
     mockNextRouter({ id: "Uvbk5qurpB2WI9V6WnNdH" })
     document.cookie = "access-token-available=True"
     server.use(

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -752,7 +752,7 @@ describe("lottery", () => {
         return res(
           ctx.json({
             id: "user1",
-            userRoles: { isAdmin: true, isJurisdictionalAdmin: false },
+            userRoles: { isParner: true, isJurisdictionalAdmin: false },
           })
         )
       }),

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -744,53 +744,6 @@ describe("lottery", () => {
     expect(queryByText("Release lottery")).not.toBeInTheDocument()
   })
 
-  it("should show publish modal if in released to partners state as a parter", async () => {
-    mockNextRouter({ id: "Uvbk5qurpB2WI9V6WnNdH" })
-    document.cookie = "access-token-available=True"
-    server.use(
-      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
-        return res(
-          ctx.json({
-            id: "user1",
-            userRoles: { isParner: true, isJurisdictionalAdmin: false },
-          })
-        )
-      }),
-      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
-        return res(ctx.json(""))
-      }),
-      rest.get("http://localhost:3100/applicationFlaggedSets/meta", (_req, res, ctx) => {
-        return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
-      }),
-      rest.get(
-        "http://localhost:3100/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
-        (_req, res, ctx) => {
-          return res(ctx.json([]))
-        }
-      )
-    )
-
-    const updatedListing = {
-      ...closedListing,
-      lotteryStatus: LotteryStatusEnum.releasedToPartners,
-    }
-
-    const { getByText, findByText } = render(<Lottery listing={updatedListing} />)
-
-    const header = await findByText("Lottery")
-    expect(header).toBeInTheDocument()
-
-    expect(getByText("Publish lottery data")).toBeInTheDocument()
-    fireEvent.click(getByText("Publish"))
-    expect(await findByText("Confirmation needed")).toBeInTheDocument()
-    expect(
-      getByText(
-        "Publishing the lottery for this listing will email a notification to applicants that results are available in their account."
-      )
-    ).toBeInTheDocument()
-    expect(getByText("Publish lottery")).toBeInTheDocument()
-  })
-
   it("should show export if in published to public state as a parter", async () => {
     mockNextRouter({ id: "Uvbk5qurpB2WI9V6WnNdH" })
     document.cookie = "access-token-available=True"

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -220,7 +220,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
               </p>
             </div>
 
-            {(profile?.userRoles?.isPartner || profile?.userRoles?.isAdmin) && (
+            {profile?.userRoles?.isPartner && (
               <div>
                 <Button
                   onClick={() => {

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -219,16 +219,20 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 })}
               </p>
             </div>
-            <div>
-              <Button
-                onClick={() => {
-                  setPublishModal(true)
-                }}
-                id={"lottery-publish-button"}
-              >
-                {t("listings.actions.publish")}
-              </Button>
-            </div>
+
+            {profile?.userRoles?.isPartner ||
+              (profile?.userRoles?.isAdmin && (
+                <div>
+                  <Button
+                    onClick={() => {
+                      setPublishModal(true)
+                    }}
+                    id={"lottery-publish-button"}
+                  >
+                    {t("listings.actions.publish")}
+                  </Button>
+                </div>
+              ))}
           </CardSection>
         )
       } else if (listing.lotteryStatus === LotteryStatusEnum.publishedToPublic) {

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -220,19 +220,18 @@ const Lottery = (props: { listing: Listing | undefined }) => {
               </p>
             </div>
 
-            {profile?.userRoles?.isPartner ||
-              (profile?.userRoles?.isAdmin && (
-                <div>
-                  <Button
-                    onClick={() => {
-                      setPublishModal(true)
-                    }}
-                    id={"lottery-publish-button"}
-                  >
-                    {t("listings.actions.publish")}
-                  </Button>
-                </div>
-              ))}
+            {(profile?.userRoles?.isPartner || profile?.userRoles?.isAdmin) && (
+              <div>
+                <Button
+                  onClick={() => {
+                    setPublishModal(true)
+                  }}
+                  id={"lottery-publish-button"}
+                >
+                  {t("listings.actions.publish")}
+                </Button>
+              </div>
+            )}
           </CardSection>
         )
       } else if (listing.lotteryStatus === LotteryStatusEnum.publishedToPublic) {


### PR DESCRIPTION
This PR addresses #5422

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Please include a summary of the change and which issue(s) is addressed.

## How Can This Be Tested/Reviewed?

1. Sign in as an admin
2. Creat a listing enabling lottery.
How is the application review order determined?

  - Lottery

  - Will the lottery be run in the partner portal?

  - Select time

3. Close the listing
4. Lottery tab will then appear
5. On the lottery tab, click Run lottery
6. Click on release lottery to partners
7. Log in as a JA or JA (NO PII) 
8. Look for the closed listing 
9.  Click on the Lottery tab
10.  Should NO see the publish button

Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
