### PR TITLE
docs: Add note about api unit tests needing TIME_ZONE env var

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -183,6 +183,12 @@ These tests will mock Prisma and therefore will not interface directly with the 
 
 #### How to run unit tests
 
+The tests require the TIME_ZONE environment variable to be set. Create a `.env` file:
+
+```bash
+echo 'TIME_ZONE=America/Los_Angeles' > .env
+```
+
 Running the following will run all unit tests: `yarn test`
 
 ### Testing with code coverage


### PR DESCRIPTION
## Description

Updates the api docs to note the dependency on TIME_ZONE env var for unit tests to pass.

## How Can This Be Tested/Reviewed?

Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
