### PR TITLE
fix: fixes package.json for windows setups

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -19,7 +19,7 @@
     "test:cov": "yarn db:resetup && yarn db:migration:run && jest --config ./test/jest-with-coverage.config.js --logHeapUsage",
     "test:cov-ci": "yarn db:migration:run && jest --config ./test/jest-with-coverage.config.js --runInBand --logHeapUsage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "db:resetup": "psql -c 'DROP DATABASE IF EXISTS bloom_prisma WITH (FORCE);' && psql -c 'CREATE DATABASE bloom_prisma;' && psql -d bloom_prisma -c 'CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";'",
+    "db:resetup": "psql -c \"DROP DATABASE IF EXISTS bloom_prisma WITH (FORCE);\" && psql -c \"CREATE DATABASE bloom_prisma;\" && psql -d bloom_prisma -c \"CREATE EXTENSION IF NOT EXISTS \\\"uuid-ossp\\\";\"",
     "db:migration:run": "yarn prisma migrate deploy",
     "db:seed:production": "npx prisma db seed -- --environment production",
     "db:seed:staging": "npx prisma db seed -- --environment staging",

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -11,7 +11,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "dev": "NODE_OPTIONS='--inspect=9231' next -p ${NEXTJS_PORT:-3001}",
+    "dev": "NODE_OPTIONS=\"--inspect=9231\" next -p ${NEXTJS_PORT:-3001}",
     "build": "next build",
     "test": "concurrently \"yarn dev\" \"cypress open\"",
     "test:unit": "jest -w 1",

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -11,7 +11,7 @@
     "registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "dev": "NODE_OPTIONS='--inspect=9230' next -p ${NEXTJS_PORT:-3000}",
+    "dev": "NODE_OPTIONS=\"--inspect=9230\" next -p ${NEXTJS_PORT:-3000}",
     "build": "next build",
     "test": "concurrently \"yarn dev\" \"cypress open\"",
     "test:headless": "concurrently \"yarn dev\" \"cypress run\"",


### PR DESCRIPTION
- [x] Addresses the issue in full

## Description
This cleans up the package.jsons so they will work on windows

## How Can This Be Tested/Reviewed?
using `'` inside of `"` is actually disallowed on windows or just causes weird errors. This change will escape nested `"` instead of using the `'` method

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
