### PR TITLE
feat: add github workflow for building docker images from main branch

### DIFF
--- a/.github/workflows/docker_image_build.yml
+++ b/.github/workflows/docker_image_build.yml
@@ -11,16 +11,29 @@ permissions:
   packages: write
 
 env:
-  # Connects the image to the repository: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package.
-  label: org.opencontainers.image.source=https://github.com/${{ github.repository }}
   image_base: ghcr.io/${{ github.repository }}
-  gitsha_tag: gitsha-${{ github.sha }}
 
 jobs:
-  build-images:
+  build-image:
+    # Builds each image in a separate job in parallel.
+    strategy:
+      matrix:
+        # The docker/build-push-action uses the git repo as the docker build context instead of
+        # cloning the repo to the action runner disk and using the disk context. For the API image
+        # we need to set the context to just the api/ directory which the '{{defaultContext}}:api'
+        # syntax does: https://github.com/docker/build-push-action?tab=readme-ov-file#git-context.
+        include:
+          - container: api
+            docker_context: "{{defaultContext}}:api"
+            dockerfile: Dockerfile
+          - container: partners
+            docker_context: "{{defaultContext}}"
+            dockerfile: Dockerfile.sites.partners
+          - container: public
+            docker_context: "{{defaultContext}}"
+            dockerfile: Dockerfile.sites.public
     runs-on: ubuntu-latest
     steps:
-      # Required to push to ghcr.io.
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3.6.0
         with:
@@ -32,39 +45,16 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3.11.1
 
-      - name: "API: Build and push image"
+      - name: "Build and push image"
         uses: docker/build-push-action@v6.18.0
         with:
           push: true
-          cache-to: type=registry,mode=max,ref=${{ env.image_base }}/api/container-layer-cache:latest
-          cache-from: type=registry,ref=${{ env.image_base }}/api/container-layer-cache:latest
-          context: "{{defaultContext}}:api"
-          file: Dockerfile
+          cache-to: type=registry,mode=max,ref=${{ env.image_base }}/${{ matrix.container }}/container-layer-cache:latest
+          cache-from: type=registry,ref=${{ env.image_base }}/${{ matrix.container }}/container-layer-cache:latest
+          context: ${{ matrix.docker_context }}
+          file: ${{ matrix.dockerfile }}
           tags: |
-            ${{ env.image_base }}/api:latest
-            ${{ env.image_base }}/api:${{ env.gitsha_tag }}
-          labels: ${{ env.label }}
-
-      - name: "Partners: Build and push image"
-        uses: docker/build-push-action@v6.18.0
-        with:
-          push: true
-          cache-to: type=registry,mode=max,ref=${{ env.image_base }}/partners/container-layer-cache:latest
-          cache-from: type=registry,ref=${{ env.image_base }}/partners/container-layer-cache:latest
-          file: Dockerfile.sites.partners
-          tags: |
-            ${{ env.image_base }}/partners:latest
-            ${{ env.image_base }}/partners:${{ env.gitsha_tag }}
-          labels: ${{ env.label }}
-
-      - name: "Public: Build and push image"
-        uses: docker/build-push-action@v6.18.0
-        with:
-          push: true
-          cache-to: type=registry,mode=max,ref=${{ env.image_base }}/public/container-layer-cache:latest
-          cache-from: type=registry,ref=${{ env.image_base }}/public/container-layer-cache:latest
-          file: Dockerfile.sites.public
-          tags: |
-            ${{ env.image_base }}/public:latest
-            ${{ env.image_base }}/public:${{ env.gitsha_tag }}
-          labels: ${{ env.label }}
+            ${{ env.image_base }}/${{ matrix.container }}:latest
+            ${{ env.image_base }}/${{ matrix.container }}:gitsha-${{ github.sha }}
+          # Connects the image to the repository: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package.
+          labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}


### PR DESCRIPTION
This PR addresses #5437

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds a github workflow that builds the bloom docker images and pushes them to the GitHub Container Registry. The workflow runs on every push to main branch. The following images will be built and pushed with the 'latest' and 'gitsha-<COMMIT_SHA>' labels:

- ghcr.io/bloom-housing/bloom/api
- ghcr.io/bloom-housing/bloom/partners
- ghcr.io/bloom-housing/bloom/public

Additionally, the workflow will push the following cache images that contain all the layers produced from the build:

- ghcr.io/bloom-housing/bloom/api/container-layer-cache:latest
- ghcr.io/bloom-housing/bloom/partners/container-layer-cache:latest
- ghcr.io/bloom-housing/bloom/public/container-layer-cache:latest

These images will be read by the subsequent build which significantly speeds it up if the node dependencies do not change.  I started by using the GitHub actions cache but there was no speed-up because the cache size is limited to 10GB which was not enough to store the cached layers from all 3 containers.

## How Can This Be Tested/Reviewed?

I tested in my fork: https://github.com/avrittrohwer/bloom.  This PR adds the 'Packages' section to the right sidebar on the repo overview.  Packages were published to my github user (they will be published to the bloom-housing organization): https://github.com/avrittrohwer?tab=packages.

- Run with no image cache images, took 4m 16s: https://github.com/avrittrohwer/bloom/actions/runs/18928670916
- Ran again with no code changes (so everything cached), took 37s: https://github.com/avrittrohwer/bloom/actions/runs/18928746548
- Run where each container has a code change, but no node dependency changes, took 2m 5s: https://github.com/avrittrohwer/bloom/actions/runs/18928786103

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
