### PR TITLE
chore(deps): bump dotenv to 17.2.3

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -66,7 +66,7 @@
     "cookie-parser": "~1.4.6",
     "cron": "^3.1.7",
     "dayjs": "~1.11.9",
-    "dotenv": "^16.4.5",
+    "dotenv": "^17.2.3",
     "exceljs": "^4.4.0",
     "express": "^4.21.1",
     "handlebars": "~4.7.8",

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -4647,10 +4647,15 @@ dotenv-expand@10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
 
-dotenv@16.4.5, dotenv@^16.4.5:
+dotenv@16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
+dotenv@^17.2.3:
+  version "17.2.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.3.tgz#ad995d6997f639b11065f419a22fabf567cdb9a2"
+  integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
 
 dunder-proto@^1.0.1:
   version "1.0.1"

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -46,7 +46,7 @@
     "axios-cookiejar-support": "^5.0.5",
     "clone-deep": "^4.0.1",
     "dayjs": "^1.10.7",
-    "dotenv": "^8.2.0",
+    "dotenv": "^17.2.3",
     "markdown-to-jsx": "^7.7.12",
     "nanoid": "^3.1.12",
     "next": "^14.2.28",

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -40,7 +40,7 @@
     "axios-cookiejar-support": "^5.0.5",
     "clone-deep": "^4.0.1",
     "dayjs": "^1.10.7",
-    "dotenv": "^8.2.0",
+    "dotenv": "^17.2.3",
     "markdown-to-jsx": "^7.7.12",
     "next": "^14.2.28",
     "qs": "^6.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5015,10 +5015,10 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+dotenv@^17.2.3:
+  version "17.2.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.3.tgz#ad995d6997f639b11065f419a22fabf567cdb9a2"
+  integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [ ] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

There were several dependency PRs open for dotenv upgrades across our directories. This combines them all into one PR

## How Can This Be Tested/Reviewed?

dotenv is currently used in the following places:
* Cypress test configuration
* Jest test configuration
* Non-production builds of nextjs
* client generation file from the backend 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
