### PR TITLE
feat: add feature flag for housing developer owner

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -155,7 +155,7 @@ export const stagingSeed = async (
   });
   const angelopolisJurisdiction = await prismaClient.jurisdictions.create({
     data: jurisdictionFactory('Angelopolis', {
-      featureFlags: [],
+      featureFlags: [FeatureFlagEnum.enableHousingDeveloperOwner],
       requiredListingFields: [
         'listingsBuildingAddress',
         'name',

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -14,6 +14,7 @@ export enum FeatureFlagEnum {
   enableGeocodingPreferences = 'enableGeocodingPreferences',
   enableGeocodingRadiusMethod = 'enableGeocodingRadiusMethod',
   enableHomeType = 'enableHomeType',
+  enableHousingDeveloperOwner = 'enableHousingDeveloperOwner',
   enableIsVerified = 'enableIsVerified',
   enableLimitedHowDidYouHear = 'enableLimitedHowDidYouHear',
   enableListingFavoriting = 'enableListingFavoriting',
@@ -103,6 +104,11 @@ export const featureFlagMap: { name: string; description: string }[] = [
   {
     name: FeatureFlagEnum.enableHomeType,
     description: 'When true, home type feature is turned on',
+  },
+  {
+    name: FeatureFlagEnum.enableHousingDeveloperOwner,
+    description:
+      "When true, the 'Housing developer' field label becomes 'Housing developer / owner'",
   },
   {
     name: FeatureFlagEnum.enableIsVerified,

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -451,7 +451,12 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
       },
       {
         path: 'developer',
-        label: 'Developer',
+        label: doAnyJurisdictionHaveFeatureFlagSet(
+          user.jurisdictions,
+          FeatureFlagEnum.enableHousingDeveloperOwner,
+        )
+          ? 'Housing developer / owner'
+          : 'Developer',
       },
       {
         path: 'listingsBuildingAddress.street',

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -7554,6 +7554,7 @@ export enum FeatureFlagEnum {
   "enableGeocodingPreferences" = "enableGeocodingPreferences",
   "enableGeocodingRadiusMethod" = "enableGeocodingRadiusMethod",
   "enableHomeType" = "enableHomeType",
+  "enableHousingDeveloperOwner" = "enableHousingDeveloperOwner",
   "enableIsVerified" = "enableIsVerified",
   "enableLimitedHowDidYouHear" = "enableLimitedHowDidYouHear",
   "enableListingFavoriting" = "enableListingFavoriting",

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -250,6 +250,7 @@
   "listings.events.openHouseNotes": "Open house notes",
   "listings.fieldError": "Please resolve any errors before saving or publishing your listing.",
   "listings.firstComeFirstServe": "First come first serve",
+  "listings.housingDeveloperOwner": "Housing developer / owner",
   "listings.isDigitalApplication": "Is there a digital application?",
   "listings.isPaperApplication": "Is there a paper application?",
   "listings.isReferralOpportunity": "Is there a referral opportunity?",

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailListingIntro.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailListingIntro.tsx
@@ -4,9 +4,17 @@ import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { ListingContext } from "../../ListingContext"
 import { getDetailFieldString } from "./helpers"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
+import { AuthContext } from "@bloom-housing/shared-helpers"
+import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 const DetailListingIntro = () => {
   const listing = useContext(ListingContext)
+  const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
+
+  const enableHousingDeveloperOwner = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableHousingDeveloperOwner,
+    listing.jurisdictions.id
+  )
 
   return (
     <SectionWithGrid heading={t("listings.sections.introTitle")} inset>
@@ -24,7 +32,14 @@ const DetailListingIntro = () => {
           </FieldValue>
         </Grid.Cell>
         <Grid.Cell>
-          <FieldValue id="developer" label={t("listings.developer")}>
+          <FieldValue
+            id="developer"
+            label={
+              enableHousingDeveloperOwner
+                ? t("listings.housingDeveloperOwner")
+                : t("listings.developer")
+            }
+          >
             {getDetailFieldString(listing.developer)}
           </FieldValue>
         </Grid.Cell>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/ListingIntro.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/ListingIntro.tsx
@@ -1,6 +1,9 @@
-import React from "react"
+import React, { useContext } from "react"
 import { useFormContext } from "react-hook-form"
-import { Jurisdiction } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  FeatureFlagEnum,
+  Jurisdiction,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { t, Field, SelectOption, Select } from "@bloom-housing/ui-components"
 import { Grid } from "@bloom-housing/ui-seeds"
 import {
@@ -11,6 +14,7 @@ import {
 } from "../../../../lib/helpers"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 import styles from "../ListingForm.module.scss"
+import { AuthContext } from "@bloom-housing/shared-helpers"
 
 interface ListingIntroProps {
   jurisdictions: Jurisdiction[]
@@ -19,9 +23,16 @@ interface ListingIntroProps {
 
 const ListingIntro = (props: ListingIntroProps) => {
   const formMethods = useFormContext()
+  const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, clearErrors, errors } = formMethods
+  const { register, clearErrors, errors, watch } = formMethods
+  const jurisdiction = watch("jurisdictions.id")
+
+  const enableHousingDeveloperOwner = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableHousingDeveloperOwner,
+    jurisdiction
+  )
 
   const jurisdictionOptions: SelectOption[] = [
     { label: "", value: "" },
@@ -101,7 +112,9 @@ const ListingIntro = (props: ListingIntroProps) => {
               register={register}
               {...defaultFieldProps(
                 "developer",
-                t("listings.developer"),
+                enableHousingDeveloperOwner
+                  ? t("listings.housingDeveloperOwner")
+                  : t("listings.developer"),
                 props.requiredFields,
                 errors,
                 clearErrors


### PR DESCRIPTION
This PR addresses #5468

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Changes label from `Housing developer` to `Housing developer / owner` (behind feature flag `enableHousingDeveloperOwner`)

## How Can This Be Tested/Reviewed?

Seed or add new feature flag. Now on `Angelopolis` listings it should show `Housing developer / owner` on partners edit / add listing form.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
