### PR TITLE
feat: add additional neighborhood amenities

### DIFF
--- a/api/prisma/migrations/37_add_new_neighborhood_amenities/migration.sql
+++ b/api/prisma/migrations/37_add_new_neighborhood_amenities/migration.sql
@@ -1,7 +1,7 @@
 -- AlterEnum
 ALTER TYPE "neighborhood_amenities_enum" ADD VALUE 'shoppingVenues';
 ALTER TYPE "neighborhood_amenities_enum" ADD VALUE 'hospitals';
-ALTER TYPE "neighborhood_amenities_enum" ADD VALUE 'seniorCenter';
+ALTER TYPE "neighborhood_amenities_enum" ADD VALUE 'seniorCenters';
 ALTER TYPE "neighborhood_amenities_enum" ADD VALUE 'recreationalFacilities';
 ALTER TYPE "neighborhood_amenities_enum" ADD VALUE 'playgrounds';
 ALTER TYPE "neighborhood_amenities_enum" ADD VALUE 'busStops';
@@ -11,5 +11,5 @@ ALTER TABLE "listing_neighborhood_amenities" ADD COLUMN     "bus_stops" TEXT,
 ADD COLUMN     "hospitals" TEXT,
 ADD COLUMN     "playgrounds" TEXT,
 ADD COLUMN     "recreational_facilities" TEXT,
-ADD COLUMN     "senior_center" TEXT,
+ADD COLUMN     "senior_centers" TEXT,
 ADD COLUMN     "shopping_venues" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1000,7 +1000,7 @@ model ListingNeighborhoodAmenities {
   publicTransportation     String?   @map("public_transportation")
   shoppingVenues           String?   @map("shopping_venues")
   hospitals                String?
-  seniorCenter             String?   @map("senior_center")
+  seniorCenters            String?   @map("senior_centers")
   recreationalFacilities   String?   @map("recreational_facilities")
   playgrounds              String?
   busStops                 String?   @map("bus_stops")
@@ -1312,7 +1312,7 @@ enum NeighborhoodAmenitiesEnum {
   healthCareResources
   shoppingVenues
   hospitals
-  seniorCenter
+  seniorCenters
   recreationalFacilities
   playgrounds
   busStops

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -167,7 +167,7 @@ export const stagingSeed = async (
         NeighborhoodAmenitiesEnum.pharmacies,
         NeighborhoodAmenitiesEnum.shoppingVenues,
         NeighborhoodAmenitiesEnum.hospitals,
-        NeighborhoodAmenitiesEnum.seniorCenter,
+        NeighborhoodAmenitiesEnum.seniorCenters,
         NeighborhoodAmenitiesEnum.recreationalFacilities,
         NeighborhoodAmenitiesEnum.playgrounds,
         NeighborhoodAmenitiesEnum.busStops,

--- a/api/src/dtos/listings/listing-neighborhood-amenities.dto.ts
+++ b/api/src/dtos/listings/listing-neighborhood-amenities.dto.ts
@@ -56,7 +56,7 @@ export class ListingNeighborhoodAmenities {
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })
   @IsString({ groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional()
-  seniorCenter?: string | null;
+  seniorCenters?: string | null;
 
   @Expose()
   @IsOptional({ groups: [ValidationsGroupsEnum.default] })

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -851,9 +851,9 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
           path: 'listingNeighborhoodAmenities.hospitals',
           label: 'Neighborhood Amenities - Hospitals',
         },
-        [NeighborhoodAmenitiesEnum.seniorCenter]: {
-          path: 'listingNeighborhoodAmenities.seniorCenter',
-          label: 'Neighborhood Amenities - Senior Center',
+        [NeighborhoodAmenitiesEnum.seniorCenters]: {
+          path: 'listingNeighborhoodAmenities.seniorCenters',
+          label: 'Neighborhood Amenities - Senior Centers',
         },
         [NeighborhoodAmenitiesEnum.recreationalFacilities]: {
           path: 'listingNeighborhoodAmenities.recreationalFacilities',

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -577,7 +577,7 @@ describe('Testing listing service', () => {
         hospitals: 'hospitals',
         playgrounds: 'playgrounds',
         recreationalFacilities: 'recreational facilities',
-        seniorCenter: 'senior center',
+        seniorCenters: 'senior centers',
         shoppingVenues: 'shopping venues',
       },
       marketingType: undefined,
@@ -3492,7 +3492,7 @@ describe('Testing listing service', () => {
               hospitals: 'hospitals',
               playgrounds: 'playgrounds',
               recreationalFacilities: 'recreational facilities',
-              seniorCenter: 'senior center',
+              seniorCenters: 'senior centers',
               shoppingVenues: 'shopping venues',
             },
           },
@@ -4000,7 +4000,7 @@ describe('Testing listing service', () => {
               hospitals: 'hospitals',
               playgrounds: 'playgrounds',
               recreationalFacilities: 'recreational facilities',
-              seniorCenter: 'senior center',
+              seniorCenters: 'senior centers',
               shoppingVenues: 'shopping venues',
             },
           },
@@ -4485,7 +4485,7 @@ describe('Testing listing service', () => {
         hospitals: 'hospitals',
         playgrounds: 'playgrounds',
         recreationalFacilities: 'recreational facilities',
-        seniorCenter: 'senior center',
+        seniorCenters: 'senior centers',
         shoppingVenues: 'shopping venues',
       };
 
@@ -4870,7 +4870,7 @@ describe('Testing listing service', () => {
                 hospitals: null,
                 playgrounds: null,
                 recreationalFacilities: null,
-                seniorCenter: null,
+                seniorCenters: null,
                 shoppingVenues: null,
               },
               update: {
@@ -4884,7 +4884,7 @@ describe('Testing listing service', () => {
                 hospitals: null,
                 playgrounds: null,
                 recreationalFacilities: null,
-                seniorCenter: null,
+                seniorCenters: null,
                 shoppingVenues: null,
               },
               where: {
@@ -5033,7 +5033,7 @@ describe('Testing listing service', () => {
                 hospitals: null,
                 playgrounds: null,
                 recreationalFacilities: null,
-                seniorCenter: null,
+                seniorCenters: null,
                 shoppingVenues: null,
               },
               update: {
@@ -5047,7 +5047,7 @@ describe('Testing listing service', () => {
                 hospitals: null,
                 playgrounds: null,
                 recreationalFacilities: null,
-                seniorCenter: null,
+                seniorCenters: null,
                 shoppingVenues: null,
               },
               where: {

--- a/shared-helpers/src/locales/ar.json
+++ b/shared-helpers/src/locales/ar.json
@@ -646,7 +646,7 @@
   "listings.amenities.schools": "المدارس",
   "listings.amenities.shoppingVenues": "أماكن التسوق",
   "listings.amenities.hospitals": "المستشفيات",
-  "listings.amenities.seniorCenter": "مركز كبار السن",
+  "listings.amenities.seniorCenters": "مراكز كبار السن",
   "listings.amenities.recreationalFacilities": "المرافق الترفيهية",
   "listings.amenities.playgrounds": "ملاعب",
   "listings.amenities.busStops": "محطات الحافلات",

--- a/shared-helpers/src/locales/bn.json
+++ b/shared-helpers/src/locales/bn.json
@@ -646,7 +646,7 @@
   "listings.amenities.schools": "স্কুল",
   "listings.amenities.shoppingVenues": "শপিং ভেন্যু",
   "listings.amenities.hospitals": "হাসপাতাল",
-  "listings.amenities.seniorCenter": "সিনিয়র সেন্টার",
+  "listings.amenities.seniorCenters": "সিনিয়র সেন্টারসমূহ",
   "listings.amenities.recreationalFacilities": "বিনোদন সুবিধা",
   "listings.amenities.playgrounds": "খেলার মাঠ",
   "listings.amenities.busStops": "বাস স্টপ",

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -646,7 +646,7 @@
   "listings.amenities.schools": "Escuelas",
   "listings.amenities.shoppingVenues": "Lugares de compras",
   "listings.amenities.hospitals": "Hospitales",
-  "listings.amenities.seniorCenter": "Centro para personas mayores",
+  "listings.amenities.seniorCenters": "Centros para personas mayores",
   "listings.amenities.recreationalFacilities": "Instalaciones recreativas",
   "listings.amenities.playgrounds": "Parques infantiles",
   "listings.amenities.busStops": "Paradas de autobús",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -646,7 +646,7 @@
   "listings.amenities.schools": "Schools",
   "listings.amenities.shoppingVenues": "Shopping venues",
   "listings.amenities.hospitals": "Hospitals",
-  "listings.amenities.seniorCenter": "Senior center",
+  "listings.amenities.seniorCenters": "Senior centers",
   "listings.amenities.recreationalFacilities": "Recreational facilities",
   "listings.amenities.playgrounds": "Playgrounds",
   "listings.amenities.busStops": "Bus stops",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -646,7 +646,7 @@
   "listings.amenities.schools": "Mga paaralan",
   "listings.amenities.shoppingVenues": "Mga lugar ng pamimili",
   "listings.amenities.hospitals": "Mga ospital",
-  "listings.amenities.seniorCenter": "Sentro ng mga nakatatanda",
+  "listings.amenities.seniorCenters": "Sentro ng mga nakatatanda",
   "listings.amenities.recreationalFacilities": "Mga pasilidad ng libangan",
   "listings.amenities.playgrounds": "Mga palaruan",
   "listings.amenities.busStops": "Mga hintuan ng bus",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -646,7 +646,7 @@
   "listings.amenities.schools": "Trường học",
   "listings.amenities.shoppingVenues": "Địa điểm mua sắm",
   "listings.amenities.hospitals": "Bệnh viện",
-  "listings.amenities.seniorCenter": "Trung tâm người cao tuổi",
+  "listings.amenities.seniorCenters": "Các trung tâm người cao tuổi",
   "listings.amenities.recreationalFacilities": "Cơ sở giải trí",
   "listings.amenities.playgrounds": "Sân chơi",
   "listings.amenities.busStops": "Trạm xe buýt",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -646,7 +646,7 @@
   "listings.amenities.schools": "学校",
   "listings.amenities.shoppingVenues": "購物場所",
   "listings.amenities.hospitals": "醫院",
-  "listings.amenities.seniorCenter": "老年中心",
+  "listings.amenities.seniorCenters": "老年中心",
   "listings.amenities.recreationalFacilities": "休閒設施",
   "listings.amenities.playgrounds": "遊樂場",
   "listings.amenities.busStops": "公車站",

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -3931,7 +3931,7 @@ export interface ListingNeighborhoodAmenities {
   hospitals?: string
 
   /**  */
-  seniorCenter?: string
+  seniorCenters?: string
 
   /**  */
   recreationalFacilities?: string
@@ -7577,7 +7577,7 @@ export enum NeighborhoodAmenitiesEnum {
   "healthCareResources" = "healthCareResources",
   "shoppingVenues" = "shoppingVenues",
   "hospitals" = "hospitals",
-  "seniorCenter" = "seniorCenter",
+  "seniorCenters" = "seniorCenters",
   "recreationalFacilities" = "recreationalFacilities",
   "playgrounds" = "playgrounds",
   "busStops" = "busStops",

--- a/sites/partners/__tests__/components/listings/PaperListingForm/sections/NeighborhoodAmenities.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/sections/NeighborhoodAmenities.test.tsx
@@ -38,7 +38,7 @@ describe("NeighborhoodAmenities", () => {
       NeighborhoodAmenitiesEnum.healthCareResources,
       NeighborhoodAmenitiesEnum.shoppingVenues,
       NeighborhoodAmenitiesEnum.hospitals,
-      NeighborhoodAmenitiesEnum.seniorCenter,
+      NeighborhoodAmenitiesEnum.seniorCenters,
       NeighborhoodAmenitiesEnum.recreationalFacilities,
       NeighborhoodAmenitiesEnum.playgrounds,
       NeighborhoodAmenitiesEnum.busStops,


### PR DESCRIPTION
This PR addresses #5498

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds new entries to NeighborhoodAmenities enum, and new columns to NeighborhoodAmenities table. Adds them to `Angelopolis` seed to they will display on partners site, and after filling on public.
Translations are google translate fyi

## How Can This Be Tested/Reviewed?

Reseed data.
Now on partners add / edit listing. For "Angelopolis" it should have new fields. Test if they appear in details, and on public listing site (with translations). Also check csv export (if any jurisdiction has them visible, they should appear)

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
