### PR TITLE
fix: upgrade ui-seeds for drawer scroll

### DIFF
--- a/shared-helpers/package.json
+++ b/shared-helpers/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@bloom-housing/ui-components": "12.7.7",
-    "@bloom-housing/ui-seeds": "2.0.2",
+    "@bloom-housing/ui-seeds": "2.0.3",
     "@heroicons/react": "^2.1.1",
     "axios-cookiejar-support": "^5.0.5"
   },

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bloom-housing/shared-helpers": "^7.7.1",
     "@bloom-housing/ui-components": "12.7.7",
-    "@bloom-housing/ui-seeds": "2.0.2",
+    "@bloom-housing/ui-seeds": "2.0.3",
     "@heroicons/react": "^2.2.0",
     "@mapbox/mapbox-sdk": "^0.13.0",
     "@tiptap/core": "^2.24.0",

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@bloom-housing/shared-helpers": "^7.7.1",
     "@bloom-housing/ui-components": "12.7.7",
-    "@bloom-housing/ui-seeds": "2.0.2",
+    "@bloom-housing/ui-seeds": "2.0.3",
     "@heroicons/react": "^2.1.1",
     "@mapbox/mapbox-sdk": "^0.13.0",
     "@sentry/nextjs": "^7.61.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,10 +1041,10 @@
     tailwindcss-rtl "^0.9.0"
     typesafe-actions "^5.1.0"
 
-"@bloom-housing/ui-seeds@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-seeds/-/ui-seeds-2.0.2.tgz#5a7348efc347160e5aad9c5f2279d332dd59458b"
-  integrity sha512-ezcvsS3RZFnbydRFNg8qDB1bDWtu0TCaKxdYmEixcS/TrK3niUnLTf3c2mSK5HuCiN92X3ajL+tp5bG/I3GESw==
+"@bloom-housing/ui-seeds@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-seeds/-/ui-seeds-2.0.3.tgz#bf49806647418a6f44648c39cbed0e17a75329de"
+  integrity sha512-a8bXSBOBCXwFg2PrkRC6BxFWwpRvnkZPQGqnGwUeznMBiuwcKkbhOwEwb1uY0xIlLhh7JZqQ0rl/u1V4yTmt4Q==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.3.0"
     "@fortawesome/react-fontawesome" "^0.2.0"


### PR DESCRIPTION
This PR addresses [This slack message](https://exygy.slack.com/archives/C02G1S19QA2/p1761931174412729)

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Users in Detroit have reported an inability to scroll within the user creation drawer in partners. We have been unable to reproduce it, but this fix adds the ability to scroll with the arrow keys when you click within the drawer.

The ui-seeds update should also be preventing the scrolling of the main page when the drawer is open however that functionality doesn't appear to be working

## How Can This Be Tested/Reviewed?

1. In the partner site go to "add user". 
2. Select the role of "partner" for this new user
3. select at least one jurisdiction so that the number of listings go beyond the page size
4. Click within the drawer and use the arrow keys to scroll.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
