### PR TITLE
feat: waitlist lottery - update get started screen states

### DIFF
--- a/sites/public/src/components/listing/listing_sections/Availability.tsx
+++ b/sites/public/src/components/listing/listing_sections/Availability.tsx
@@ -246,7 +246,6 @@ export const Availability = ({ listing, jurisdiction }: AvailabilityProps) => {
         case ReviewOrderTypeEnum.lottery:
           return [lotteryContent]
         case ReviewOrderTypeEnum.waitlist:
-        case ReviewOrderTypeEnum.waitlistLottery:
           return [waitlistContent]
         default:
           return [fcfsContent]


### PR DESCRIPTION
This PR addresses #5508

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The purpose of this change was that the user could see the "Open Waitlist" opportunity type label for also for Waitlist Lottery type when is on the "Let's get started on your application" screen after I've clicked apply online and signed in.

This change applies for both SHOW_NEW_SEEDS_DESIGNS=TRUE/FALSE

Please include a summary of the change and which issue(s) is addressed.

## How Can This Be Tested/Reviewed?

1. Create a waitlistLottery listing in the partners site
2. Navigate to the public site (Core) and find that listing
3. Open the listing
4. In the listing detail page click on Apply online
5. Below the image you should see the Open waitlist status

1-core

<img width="813" height="426" alt="image" src="https://github.com/user-attachments/assets/b765c80d-5543-47e2-a847-5544cf82d69f" />



Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
