### PR TITLE
feat: bloom-dev AWS deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,10 +107,10 @@ services:
       DATABASE_URL: "postgres://postgres:example@db:5432/bloom_prisma"
     healthcheck:
       test: ["CMD", "curl", "--fail", "http://127.0.0.1:3100/"]
-      interval: "2s"
-      timeout: "1s"
-      retries: 20
-      start_period: "1s"
+      interval: "5s"
+      timeout: "2s"
+      retries: 10
+      start_period: "5s"
     depends_on:
       db:
         condition: service_healthy

--- a/infra/tofu_importable_modules/bloom_deployment/db.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/db.tf
@@ -1,0 +1,42 @@
+# Create a database.
+resource "aws_db_subnet_group" "bloom" {
+  region     = var.aws_region
+  name       = "bloom"
+  subnet_ids = [for s in aws_subnet.private : s.id]
+}
+resource "aws_db_instance" "bloom" {
+  identifier                      = "bloom"
+  deletion_protection             = local.is_prod
+  engine                          = "postgres"
+  engine_version                  = "17"
+  instance_class                  = local.database_config.instance_class
+  multi_az                        = var.high_availability
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade", "iam-db-auth-error"]
+  username                        = "master"
+  manage_master_user_password     = true
+
+  # Monitoring
+  performance_insights_enabled          = "true"
+  performance_insights_retention_period = 7 # minimum
+  database_insights_mode                = "standard"
+
+  # Networking
+  vpc_security_group_ids              = [aws_security_group.db.id]
+  iam_database_authentication_enabled = true
+  db_subnet_group_name                = aws_db_subnet_group.bloom.id
+
+  # Updates
+  apply_immediately           = true # If false, any changes are applied in the next maintenance window instead of when tofu apply runs.
+  engine_lifecycle_support    = "open-source-rds-extended-support"
+  allow_major_version_upgrade = false
+  auto_minor_version_upgrade  = true
+
+  # Storage
+  storage_encrypted         = true
+  storage_type              = "gp2"
+  allocated_storage         = local.database_config.starting_storage_gb
+  max_allocated_storage     = local.database_config.max_storage_gb
+  backup_retention_period   = local.database_config.backup_retention_days
+  final_snapshot_identifier = "bloom-db-finalsnapshot"
+  skip_final_snapshot       = !local.is_prod
+}

--- a/infra/tofu_importable_modules/bloom_deployment/ecs.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs.tf
@@ -1,0 +1,189 @@
+# Create an ECS cluster and services for each Bloom binary.
+resource "aws_iam_service_linked_role" "ecs" {
+  aws_service_name = "ecs.amazonaws.com"
+}
+resource "aws_ecs_cluster" "bloom" {
+  region     = var.aws_region
+  name       = "bloom"
+  depends_on = [aws_iam_service_linked_role.ecs]
+  setting {
+    name  = "containerInsights"
+    value = "enhanced"
+  }
+}
+
+# Set up service discovery for the sites to talk to the api.
+resource "aws_service_discovery_http_namespace" "bloom" {
+  region      = var.aws_region
+  name        = "bloom"
+  description = "Service namespace the bloom services use."
+}
+
+# Create logs groups.
+resource "aws_cloudwatch_log_group" "task_logs" {
+  for_each = toset([
+    "bloom-api",
+    "bloom-site-partners",
+    "bloom-site-public"
+  ])
+  region            = var.aws_region
+  name              = each.value
+  log_group_class   = "STANDARD"
+  retention_in_days = local.ecs_logs_retention_days
+}
+
+# Create a secret key used by the API to sign JWTs.
+resource "aws_secretsmanager_secret" "api_jwt_signing_key" {
+  region                  = var.aws_region
+  description             = "Key used by the Bloom API to sign JWTs"
+  name_prefix             = "bloom-api-jwt-signing-key" # avoids 'you can't create this secret because a secret with this name is already scheduled for deletion' issue when re-deploying an account.
+  recovery_window_in_days = 7                           # minimum
+
+  # TODO: use an ephemeral resource instead of local-exec:
+  # https://github.com/bloom-housing/bloom/issues/5637.
+  #
+  # The provisioner block runs after the resource has been created, and never again.
+  provisioner "local-exec" {
+    interpreter = ["/usr/bin/env", "bash", "-c"]
+    # We need to be very careful that any errors result in a non-zero exit code. Otherwise tofu will
+    # think this block succeeded and not error.
+    command = <<-EOT
+    if ! type -P aws &>/dev/null; then
+      echo 'ERROR: aws required'
+      exit 1
+    fi
+    if ! type -P openssl &>/dev/null; then
+      echo 'ERROR: openssl required'
+      exit 1
+    fi
+    if ! type -P tr &>/dev/null; then
+      echo 'ERROR: tr required'
+      exit 1
+    fi
+
+    if ! s=$(openssl rand -base64 256 | tr -d '\n'); then
+        echo 'ERROR: failed to generate random value'
+        exit 1
+    fi
+
+    if ! aws secretsmanager put-secret-value \
+         --profile ${var.aws_profile} \
+         --region ${var.aws_region} \
+         --secret-id ${self.id} \
+         --secret-string "$s"
+    then
+        echo 'ERROR: failed to put secret value'
+        exit 1
+    fi
+    EOT
+  }
+}
+
+locals {
+  roles = {
+    "api" = {
+      task_execution_policy_extra_statements = [
+        {
+          Action   = "secretsmanager:GetSecretValue"
+          Effect   = "Allow"
+          Resource = aws_db_instance.bloom.master_user_secret[0].secret_arn
+        },
+        {
+          Action   = "secretsmanager:GetSecretValue"
+          Effect   = "Allow"
+          Resource = aws_secretsmanager_secret.api_jwt_signing_key.arn
+        }
+      ]
+    }
+    "site-partners" = {
+      task_execution_policy_extra_statements = []
+    }
+    "site-public" = {
+      task_execution_policy_extra_statements = []
+    }
+  }
+}
+
+# Create roles for the ECS task executor and the tasks.
+resource "aws_iam_role" "bloom_ecs" {
+  for_each    = local.roles
+  name        = "bloom-${each.key}-ecs"
+  description = "Role the ECS service uses when launching Bloom ${each.key} tasks."
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html#create_task_iam_policy_and_role
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Condition = {
+        ArnLike = {
+          "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_number}:*"
+        }
+        StringEquals = {
+          "aws:SourceAccount" = var.aws_account_number
+        }
+      }
+    }]
+  })
+}
+resource "aws_iam_role_policy" "bloom_ecs" {
+  for_each = local.roles
+  name     = "bloom-${each.key}-ecs"
+  role     = aws_iam_role.bloom_ecs[each.key].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Action = [
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+          ]
+          Effect   = "Allow"
+          Resource = "${aws_cloudwatch_log_group.task_logs["bloom-${each.key}"].arn}:log-stream:*"
+        },
+      ],
+      each.value.task_execution_policy_extra_statements
+    )
+  })
+}
+resource "aws_iam_role" "bloom_container" {
+  for_each    = local.roles
+  name        = "bloom-${each.key}-container"
+  description = "Role the Bloom ${each.key} container runs as."
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html#create_task_iam_policy_and_role
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "ecs-tasks.amazonaws.com"
+      }
+      Condition = {
+        ArnLike = {
+          "aws:SourceArn" = "arn:aws:ecs:${var.aws_region}:${var.aws_account_number}:*"
+        }
+        StringEquals = {
+          "aws:SourceAccount" = var.aws_account_number
+        }
+      }
+    }]
+  })
+}
+resource "aws_iam_role_policy" "bloom_container" {
+  for_each = local.roles
+  name     = "bloom-${each.key}-container"
+  role     = aws_iam_role.bloom_container[each.key].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action   = "*"
+      Effect   = "Deny"
+      Resource = "*"
+    }]
+  })
+}

--- a/infra/tofu_importable_modules/bloom_deployment/ecs_api_task.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_api_task.tf
@@ -1,0 +1,143 @@
+locals {
+  api_default_env_vars = {
+    PORT     = "3100"
+    NODE_ENV = "production"
+    DB_USER  = aws_db_instance.bloom.username
+    DB_HOST  = aws_db_instance.bloom.endpoint
+  }
+}
+resource "aws_ecs_task_definition" "bloom_api" {
+  region                   = var.aws_region
+  family                   = "bloom-api"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  execution_role_arn = aws_iam_role.bloom_ecs["api"].arn
+  task_role_arn      = aws_iam_role.bloom_container["api"].arn
+
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+  cpu    = 1024     # 1 vCPU
+  memory = 2 * 1024 # 2 GiB in MiB
+
+  container_definitions = jsonencode([
+    {
+      Name  = "bloom-api"
+      image = var.bloom_api_image
+      command = [
+        "/bin/bash",
+        "-c",
+        # TODO: https://www.prisma.io/docs/orm/more/help-and-troubleshooting/dataguide/connection-uris#percent-encoding-values
+        "export DATABASE_URL=postgres://$DB_USER:$(echo $DB_PASSWORD | sed 's| |%20|; s|%|%25|; s|&|%26|; s|/|%2F|; s|:|%3A|; s|=|%3D|; s|?|%3F|; s|@|%40|; s|\\[|%5B|; s|]|%5D|')@$DB_HOST/bloomprisma && env && yarn db:migration:run && yarn start:prod",
+      ]
+      secrets = [
+        {
+          # TODO: replace with IAM authentication https://github.com/bloom-housing/bloom/issues/5451
+          name = "DB_PASSWORD"
+          # The master_user_secret tofu attribute is a block, so it is exposed as a list even though
+          # there is only one element.
+          #
+          # The RDS managed secret has a username key and a password key. Docs for how to read
+          # a specific key out of a secret:
+          # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/secrets-envvar-secrets-manager.html#secrets-envvar-secrets-manager-update-container-definition
+          valueFrom = "${aws_db_instance.bloom.master_user_secret[0].secret_arn}:password::"
+        },
+        {
+          name      = "APP_SECRET",
+          valueFrom = aws_secretsmanager_secret.api_jwt_signing_key.arn
+        }
+      ]
+      environment = [for k, v in merge(local.api_default_env_vars, var.bloom_api_env_vars) : { name = k, value = v }]
+      portMappings = [
+        {
+          name          = "http"
+          appProtocol   = "http"
+          containerPort = 3100
+        }
+      ]
+      restartPolicy = {
+        enabled = false
+      }
+      healthCheck = {
+        command = [
+          "curl",
+          "--fail",
+          "http://127.0.0.1:3100/"
+        ]
+        interval    = 5 # seconds
+        timeout     = 2 # seconds
+        retries     = 10
+        startPeriod = 5 # seconds
+      }
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-region"        = var.aws_region
+          "awslogs-group"         = aws_cloudwatch_log_group.task_logs["bloom-api"].name
+          "awslogs-stream-prefix" = "bloom-api"
+        }
+      }
+    }
+  ])
+}
+resource "aws_ecs_service" "bloom_api" {
+  depends_on = [
+    aws_db_instance.bloom,
+    aws_vpc_endpoint.secrets_manager,
+    aws_route_table_association.private_subnet,
+  ]
+  wait_for_steady_state         = true # if tofu waits for the triggered deployment to complete.
+  region                        = var.aws_region
+  cluster                       = aws_ecs_cluster.bloom.arn
+  name                          = "bloom-api"
+  force_delete                  = true # allow deletion of the service without scaling down tasks to 0 first.
+  task_definition               = aws_ecs_task_definition.bloom_api.arn
+  launch_type                   = "FARGATE"
+  scheduling_strategy           = "REPLICA"
+  availability_zone_rebalancing = "ENABLED"
+  desired_count                 = local.bloom_api_task_count
+  deployment_configuration {
+    strategy = "ROLLING"
+  }
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+  deployment_controller {
+    type = "ECS"
+  }
+  deployment_maximum_percent = 200 # allow surge of up to twice desired task count.
+
+  network_configuration {
+    security_groups  = [aws_security_group.api.id]
+    subnets          = [for s in aws_subnet.private : s.id]
+    assign_public_ip = false
+  }
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.bloom.arn
+    service {
+      port_name = "http"
+      client_alias {
+        dns_name = "bloom-api"
+        port     = 3100
+      }
+      discovery_name = "bloom-api"
+      timeout {
+        idle_timeout_seconds        = 0 # disable idleTimeout
+        per_request_timeout_seconds = 60
+      }
+    }
+    log_configuration {
+      log_driver = "awslogs"
+      options = {
+        "awslogs-region"        = var.aws_region
+        "awslogs-group"         = aws_cloudwatch_log_group.task_logs["bloom-api"].name
+        "awslogs-stream-prefix" = "service-connect-proxy"
+      }
+    }
+  }
+}

--- a/infra/tofu_importable_modules/bloom_deployment/ecs_site_partners_task.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_site_partners_task.tf
@@ -1,0 +1,103 @@
+locals {
+  site_partners_default_env_vars = {
+    NODE_ENV         = "production"
+    NEXTJS_PORT      = "3001"
+    BACKEND_API_BASE = "http://bloom-api:3100"
+    LISTINGS_QUERY   = "/listings"
+  }
+}
+resource "aws_ecs_task_definition" "bloom_site_partners" {
+  region                   = var.aws_region
+  family                   = "bloom-site-partners"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  execution_role_arn = aws_iam_role.bloom_ecs["site-partners"].arn
+  task_role_arn      = aws_iam_role.bloom_container["site-partners"].arn
+
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+  cpu    = 2048     # 2 vCPU
+  memory = 4 * 1024 # 4 GiB in MiB
+
+  container_definitions = jsonencode([
+    {
+      Name        = "bloom-site-partners"
+      image       = var.bloom_site_partners_image
+      environment = [for k, v in merge(local.site_partners_default_env_vars, var.bloom_site_partners_env_vars) : { name = k, value = v }]
+      portMappings = [
+        {
+          containerPort = 3001
+          appProtocol   = "http"
+        }
+      ]
+      restartPolicy = {
+        enabled = false
+      }
+      # TODO healthCheck https://github.com/bloom-housing/bloom/issues/5583
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-region"        = var.aws_region
+          "awslogs-group"         = aws_cloudwatch_log_group.task_logs["bloom-site-partners"].name
+          "awslogs-stream-prefix" = "bloom-site-partners"
+        }
+      }
+    }
+  ])
+}
+resource "aws_ecs_service" "bloom_site_partners" {
+  depends_on = [
+    aws_ecs_service.bloom_api,
+    aws_route_table_association.private_subnet,
+  ]
+  region                = var.aws_region
+  cluster               = aws_ecs_cluster.bloom.arn
+  name                  = "bloom-site-partners"
+  force_delete          = true # allow deletion of the service without scaling down tasks to 0 first.
+  task_definition       = aws_ecs_task_definition.bloom_site_partners.arn
+  wait_for_steady_state = true
+
+  network_configuration {
+    security_groups  = [aws_security_group.site_partners.id]
+    subnets          = [for s in aws_subnet.private : s.id]
+    assign_public_ip = false
+  }
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.bloom.arn
+    log_configuration {
+      log_driver = "awslogs"
+      options = {
+        "awslogs-region"        = var.aws_region
+        "awslogs-group"         = aws_cloudwatch_log_group.task_logs["bloom-site-partners"].name
+        "awslogs-stream-prefix" = "service-connect-proxy"
+      }
+    }
+  }
+  load_balancer {
+    target_group_arn = aws_lb_target_group.site_partners.arn
+    container_name   = "bloom-site-partners"
+    container_port   = 3001
+  }
+  health_check_grace_period_seconds = 500 # seconds, how long the LB will wait before considering a new task unhealthy.
+
+  launch_type                   = "FARGATE"
+  scheduling_strategy           = "REPLICA"
+  availability_zone_rebalancing = "ENABLED"
+  desired_count                 = local.bloom_site_partners_task_count
+  deployment_configuration {
+    strategy = "ROLLING"
+  }
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+  deployment_controller {
+    type = "ECS"
+  }
+  deployment_maximum_percent = 200 # allow surge of up to twice desired task count.
+}

--- a/infra/tofu_importable_modules/bloom_deployment/ecs_site_public_task.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_site_public_task.tf
@@ -1,0 +1,112 @@
+locals {
+  site_public_default_env_vars = {
+    NODE_ENV                      = "production"
+    NEXTJS_PORT                   = "3000"
+    BACKEND_API_BASE              = "http://bloom-api:3100"
+    BACKEND_API_BASE_NEW          = "http://bloom-api:3100"
+    LISTINGS_QUERY                = "/listings"
+    MAX_BROWSE_LISTINGS           = "10"
+    HOUSING_COUNSELOR_SERVICE_URL = "/get-assistance"
+    IDLE_TIEMOUT                  = "5"  # seconds
+    CACHE_REVALIDATE              = "30" # seconds
+    SHOW_PUBLIC_LOTTERY           = "TRUE"
+    SHOW_MANDATED_ACCOUNTS        = "FALSE"
+    SHOW_PWDLESS                  = "FALSE"
+    SHOW_NEW_SEEDS_DESIGNS        = "FALSE"
+  }
+}
+resource "aws_ecs_task_definition" "bloom_site_public" {
+  region                   = var.aws_region
+  family                   = "bloom-site-public"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  execution_role_arn = aws_iam_role.bloom_ecs["site-public"].arn
+  task_role_arn      = aws_iam_role.bloom_container["site-public"].arn
+
+  # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
+  cpu    = 2048     # 2 vCPU
+  memory = 6 * 1024 # 4 GiB in MiB
+
+  container_definitions = jsonencode([
+    {
+      Name        = "bloom-site-public"
+      image       = var.bloom_site_public_image
+      environment = [for k, v in merge(local.site_public_default_env_vars, var.bloom_site_public_env_vars) : { name = k, value = v }]
+      portMappings = [
+        {
+          containerPort = 3000
+          appProtocol   = "http"
+        }
+      ]
+      restartPolicy = {
+        enabled = false
+      }
+      # TODO healthCheck https://github.com/bloom-housing/bloom/issues/5583
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-region"        = var.aws_region
+          "awslogs-group"         = aws_cloudwatch_log_group.task_logs["bloom-site-public"].name
+          "awslogs-stream-prefix" = "bloom-site-public"
+        }
+      }
+    }
+  ])
+}
+resource "aws_ecs_service" "bloom_site_public" {
+  depends_on = [
+    aws_ecs_service.bloom_api,
+    aws_route_table_association.private_subnet,
+  ]
+  region                = var.aws_region
+  cluster               = aws_ecs_cluster.bloom.arn
+  name                  = "bloom-site-public"
+  force_delete          = true # allow deletion of the service without scaling down tasks to 0 first.
+  task_definition       = aws_ecs_task_definition.bloom_site_public.arn
+  wait_for_steady_state = true
+
+  network_configuration {
+    security_groups  = [aws_security_group.site_public.id]
+    subnets          = [for s in aws_subnet.private : s.id]
+    assign_public_ip = false
+  }
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.bloom.arn
+    log_configuration {
+      log_driver = "awslogs"
+      options = {
+        "awslogs-region"        = var.aws_region
+        "awslogs-group"         = aws_cloudwatch_log_group.task_logs["bloom-site-public"].name
+        "awslogs-stream-prefix" = "service-connect-proxy"
+      }
+    }
+  }
+  load_balancer {
+    target_group_arn = aws_lb_target_group.site_public.arn
+    container_name   = "bloom-site-public"
+    container_port   = 3000
+  }
+  health_check_grace_period_seconds = 500 # seconds, how long the LB will wait before considering a new task unhealthy.
+
+  launch_type                   = "FARGATE"
+  scheduling_strategy           = "REPLICA"
+  availability_zone_rebalancing = "ENABLED"
+  desired_count                 = local.bloom_site_public_task_count
+  deployment_configuration {
+    strategy = "ROLLING"
+  }
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+  deployment_controller {
+    type = "ECS"
+  }
+  deployment_maximum_percent = 200 # allow surge of up to twice desired task count.
+}

--- a/infra/tofu_importable_modules/bloom_deployment/lb.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/lb.tf
@@ -1,0 +1,172 @@
+# Create an application load balancer that the partners and public sites can be accessed through.
+resource "aws_lb" "bloom" {
+  region                     = var.aws_region
+  name                       = "bloom"
+  enable_deletion_protection = local.is_prod
+
+  load_balancer_type = "application"
+  internal           = false
+  subnets            = [for s in aws_subnet.public : s.id]
+
+  idle_timeout               = 60 # seconds
+  security_groups            = [aws_security_group.lb.id]
+  enable_zonal_shift         = true
+  desync_mitigation_mode     = "strictest"
+  drop_invalid_header_fields = true
+}
+output "lb_dns_name" {
+  value       = aws_lb.bloom.dns_name
+  description = "DNS name of the load balancer."
+}
+data "aws_acm_certificate" "bloom" {
+  domain      = var.domain_name
+  most_recent = true
+
+  lifecycle {
+    postcondition {
+      condition     = self.status == "ISSUED"
+      error_message = "The certificate must be ISSUED before bloom can deploy its load balancer."
+    }
+  }
+}
+resource "aws_lb_listener" "bloom" {
+  region            = var.aws_region
+  load_balancer_arn = aws_lb.bloom.arn
+  certificate_arn   = var.aws_certificate_arn
+
+  port     = 443
+  protocol = "HTTPS"
+
+  default_action {
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Error: routing misconfiguration"
+      status_code  = 501
+    }
+  }
+}
+
+# Routing for partners site
+resource "aws_lb_listener_rule" "site_partners" {
+  region       = var.aws_region
+  listener_arn = aws_lb_listener.bloom.arn
+  condition {
+    host_header {
+      values = ["partners.${var.domain_name}"]
+    }
+  }
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.site_partners.arn
+  }
+  tags = {
+    Name = "bloom-site-partners"
+  }
+
+  lifecycle {
+    replace_triggered_by = [aws_lb_target_group.site_partners]
+  }
+}
+resource "aws_lb_target_group" "site_partners" {
+  region = var.aws_region
+  vpc_id = aws_vpc.bloom.id
+  name   = "bloom-site-partners"
+
+  target_type      = "ip"
+  ip_address_type  = "ipv4"
+  port             = 3001
+  protocol         = "HTTP"
+  protocol_version = "HTTP1"
+
+  load_balancing_algorithm_type = "round_robin"
+  stickiness {
+    enabled = true
+    type    = "app_cookie"
+    # https://github.com/bloom-housing/bloom/blob/main/docs/Authentication.md
+    cookie_name = "access-token"
+  }
+
+  deregistration_delay = 5 # seconds
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2  # this is the minimum
+    unhealthy_threshold = 2  # this is the minimum
+    interval            = 10 # seconds, this is the minimum
+    timeout             = 5  # seconds
+    protocol            = "HTTP"
+    # TODO: use healthcheck endpoint https://github.com/bloom-housing/bloom/issues/5583
+    path    = "/"
+    matcher = "200"
+  }
+  target_group_health {
+    dns_failover {
+      minimum_healthy_targets_count = 1
+    }
+    unhealthy_state_routing {
+      minimum_healthy_targets_count = 1
+    }
+  }
+}
+
+# Routing for public site
+resource "aws_lb_listener_rule" "site_public" {
+  region       = var.aws_region
+  listener_arn = aws_lb_listener.bloom.arn
+  condition {
+    host_header {
+      values = [var.domain_name]
+    }
+  }
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.site_public.arn
+  }
+  tags = {
+    Name = "bloom-site-public"
+  }
+
+  lifecycle {
+    replace_triggered_by = [aws_lb_target_group.site_public]
+  }
+}
+resource "aws_lb_target_group" "site_public" {
+  region = var.aws_region
+  vpc_id = aws_vpc.bloom.id
+  name   = "bloom-site-public"
+
+  target_type      = "ip"
+  ip_address_type  = "ipv4"
+  port             = 3000
+  protocol         = "HTTP"
+  protocol_version = "HTTP1"
+
+  load_balancing_algorithm_type = "round_robin"
+  stickiness {
+    enabled = true
+    type    = "app_cookie"
+    # https://github.com/bloom-housing/bloom/blob/main/docs/Authentication.md
+    cookie_name = "access-token"
+  }
+
+  deregistration_delay = 5 # seconds
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2  # this is the minimum
+    unhealthy_threshold = 2  # this is the minimum
+    interval            = 10 # seconds, this is the minimum
+    timeout             = 5  # seconds
+    protocol            = "HTTP"
+    # TODO: use healthcheck endpoint https://github.com/bloom-housing/bloom/issues/5583
+    path    = "/"
+    matcher = "200"
+  }
+  target_group_health {
+    dns_failover {
+      minimum_healthy_targets_count = 1
+    }
+    unhealthy_state_routing {
+      minimum_healthy_targets_count = 1
+    }
+  }
+}

--- a/infra/tofu_importable_modules/bloom_deployment/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/main.tf
@@ -1,0 +1,158 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "6.21.0"
+      source  = "hashicorp/aws"
+    }
+  }
+}
+
+variable "aws_profile" {
+  type        = string
+  description = "AWS CLI profile to use when running aws commands in local-exec provisioners."
+}
+variable "aws_account_number" {
+  type        = number
+  description = "AWS account number that is being configured."
+}
+variable "aws_region" {
+  type        = string
+  description = "Region to deploy AWS resources to"
+  validation {
+    condition = (
+      var.aws_region == "us-east-1" ||
+      var.aws_region == "us-east-2" ||
+      var.aws_region == "us-west-1" ||
+      var.aws_region == "us-west-2"
+    )
+    error_message = "Must be 'us-east-1', 'us-east-2', 'us-west-1', or 'us-west-2'."
+  }
+}
+variable "high_availability" {
+  type        = bool
+  description = "Deploy the Bloom services in a highly-available manner. If true, a minimum of 2 instances will be running for each Bloom service."
+  default     = true
+}
+variable "env_type" {
+  type        = string
+  description = "Type of environment this deployment is going in."
+  validation {
+    condition = (
+      var.env_type == "dev" ||
+      var.env_type == "production"
+    )
+    error_message = "Must be 'dev' or 'production'."
+  }
+}
+locals {
+  is_prod = var.env_type == "production"
+}
+variable "database_config" {
+  description = "Settings for the Bloom database. Defaults are provided based on the env_type setting."
+  type = object({
+    # Pricing: https://aws.amazon.com/rds/postgresql/pricing/?pg=pr&loc=3
+    # Machine specs: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Summary.html#hardware-specifications.burstable-inst-classes
+    instance_class        = string
+    starting_storage_gb   = number
+    max_storage_gb        = number
+    backup_retention_days = number
+  })
+  default = null
+}
+locals {
+  database_config = var.database_config != null ? var.database_config : (local.is_prod ? {
+    # Prod defaults
+    instance_class        = "db.t4g.medium"
+    starting_storage_gb   = 10
+    max_storage_gb        = 100
+    backup_retention_days = 30
+    } : {
+    # Non-prod defaults
+    instance_class        = "db.t4g.micro"
+    starting_storage_gb   = 5 # minimum
+    max_storage_gb        = 10
+    backup_retention_days = 7
+  })
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Domain name the bloom deployment will be served on"
+}
+variable "aws_certificate_arn" {
+  type        = string
+  description = "ARN of the validated certificate for the domain_name"
+}
+
+variable "ecs_logs_retention_days" {
+  description = "How long ECS task logs are retained. Default is provided based on the env_type setting."
+  type        = number
+  default     = null
+}
+locals {
+  ecs_logs_retention_days = var.ecs_logs_retention_days != null ? var.ecs_logs_retention_days : (local.is_prod ? 30 : 3)
+}
+
+variable "bloom_api_image" {
+  type        = string
+  description = "Container image for the Bloom API."
+}
+variable "bloom_api_env_vars" {
+  type        = map(any)
+  description = "Environment variables for the Bloom API tasks. This is merged with the default env vars set in the ecs_api_task.tf file, with these variables taking precedence."
+  default     = {}
+}
+variable "bloom_api_task_count" {
+  description = "How many API tasks that should be running. Default is provided based on the high_availability setting."
+  type        = number
+  default     = null
+}
+locals {
+  bloom_api_task_count = var.bloom_api_task_count != null ? var.bloom_api_task_count : (var.high_availability ? 2 : 1)
+}
+variable "bloom_site_partners_image" {
+  type        = string
+  description = "Container image for the Bloom partners site."
+}
+variable "bloom_site_partners_env_vars" {
+  type        = map(any)
+  description = "Environment variables for the Bloom partners site tasks. This is merged with the default env vars set in the ecs_site_partners_task.tf file, with these variables taking precedence."
+  default     = {}
+}
+variable "bloom_site_partners_task_count" {
+  description = "How many partners site tasks that should be running. Default is provided based on the high_availability setting."
+  type        = number
+  default     = null
+}
+locals {
+  bloom_site_partners_task_count = var.bloom_site_partners_task_count != null ? var.bloom_site_partners_task_count : (var.high_availability ? 2 : 1)
+}
+variable "bloom_site_public_image" {
+  type        = string
+  description = "Container image for the Bloom public site."
+}
+variable "bloom_site_public_env_vars" {
+  type        = map(any)
+  description = "Environment variables for the Bloom public site tasks. This is merged with the default env vars set in the ecs_site_public_task.tf file, with these variables taking precedence."
+  default     = {}
+}
+variable "bloom_site_public_task_count" {
+  description = "How many public site tasks that should be running. Default is provided based on the high_availability setting."
+  type        = number
+  default     = null
+}
+locals {
+  bloom_site_public_task_count = var.bloom_site_public_task_count != null ? var.bloom_site_public_task_count : (var.high_availability ? 2 : 1)
+}
+
+# Create a CloudTrail data store so that audit events are query-able in SQL.
+resource "aws_cloudtrail_event_data_store" "audit" {
+  count = local.is_prod ? 1 : 0
+
+  region                         = var.aws_region
+  name                           = "audit"
+  multi_region_enabled           = true
+  retention_period               = 30
+  termination_protection_enabled = true
+}
+

--- a/infra/tofu_importable_modules/bloom_deployment/vpc.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/vpc.tf
@@ -1,0 +1,408 @@
+# Network design:
+#
+# Provision a private and public subnet for each availability zone in the region. Only load
+# balancers and NAT gateways are provisioned in the public subnets, everything else is provisioned
+# in the private subnets. The Bloom ECS tasks need access to the internet so they can download their
+# docker image and access their dependent services. Access is provided via NAT gateways. Access to
+# AWS services is configured through AWS PrivateLink endpoints so that traffic stays in the AWS
+# internal network rather than going over the internet.
+#
+# Ideally we would use the 10.0.0.0/8 space and provision a /16 range per subnet, incrementing the
+# second octet (10.0.0.0/16, 10.1.0.0/16, etc). This could be achieved by adding secondary cidr
+# ranges to the VPC, but the default quota is 5. It can be increased to 50 but requires approval
+# which takes significant wall time and is not handled very well by the aws tofu provider.
+#
+# So, we use 10.0.0.0/16 IP space and provision /20 blocks (4,096 addresses each) for each
+# subnet. The /20 prefix uses the 4 most significant bits of the third octet, so to increment /20
+# ranges we increment the third octet by 16 (https://cidr.xyz/#10.0.16.0/20 is a good visualization
+# for this). The subnet ranges will therefore be:
+#
+# cidr         | zone | type
+# -------------|------|--------
+# 10.0.0.0/20  |  a   | private
+# 10.0.16.0/20 |  a   | public
+# 10.0.32.0/20 |  b   | private
+# 10.0.48.0/20 |  b   | public
+# 10.0.64.0/20 |  c   | private
+# ...
+data "aws_availability_zones" "zones" {
+  region = var.aws_region
+  state  = "available"
+
+  lifecycle {
+    postcondition {
+      # At the time of writing, the largest region is us-east-1 with 6 availability zones.
+      condition     = length(self.names) <= 8
+      error_message = "The IP provisioning strategy does not support more than 8 availability zones."
+    }
+  }
+}
+locals {
+  zones = data.aws_availability_zones.zones.names
+}
+resource "aws_vpc" "bloom" {
+  region               = var.aws_region
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags = {
+    Name = "bloom"
+  }
+}
+locals {
+  prefix_increment = 16
+  stride           = local.prefix_increment * 2
+  private_subnets = zipmap(
+    local.zones,
+    [for i in range(length(local.zones)) : "10.0.${local.stride * i}.0/20"]
+  )
+  public_subnets = zipmap(
+    local.zones,
+    [for i in range(length(local.zones)) : "10.0.${(local.stride * i) + local.prefix_increment}.0/20"]
+  )
+}
+# What makes a AWS subnet public is a direct route to the internet. This is controlled through the
+# route tables attached to each subnet. By default each route table has a 'local' route for cidr
+# ranges used by the VPC. Add 'catch-all' route for 0.0.0.0/0 that routes to the VPC internet
+# gateway.
+resource "aws_internet_gateway" "bloom" {
+  region = var.aws_region
+  vpc_id = aws_vpc.bloom.id
+}
+resource "aws_subnet" "public" {
+  for_each                = local.public_subnets
+  vpc_id                  = aws_vpc.bloom.id
+  availability_zone       = each.key
+  cidr_block              = each.value
+  map_public_ip_on_launch = false
+  tags = {
+    Name = "bloom-public-${each.key}"
+  }
+}
+resource "aws_route_table" "internet_gateway" {
+  region = var.aws_region
+  vpc_id = aws_vpc.bloom.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.bloom.id
+  }
+  tags = {
+    Name = "bloom-internet-gateway"
+  }
+}
+resource "aws_route_table_association" "public_subnet" {
+  for_each       = aws_subnet.public
+  region         = var.aws_region
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.internet_gateway.id
+}
+# ECS tasks in the private subnets still need access to the internet. This is provided by a NAT
+# gateway. A NAT gateway is a zonal resource so provision one in each availability zone. Each
+# private subnet needs a route table with a similar 'catch-all' route, but instead of going to the
+# VPC internet gateway, it goes to the NAT gateway in the zone.
+resource "aws_eip" "nat" {
+  for_each = aws_subnet.public
+  region   = var.aws_region
+  domain   = "vpc"
+}
+resource "aws_nat_gateway" "bloom" {
+  for_each          = aws_subnet.public
+  region            = var.aws_region
+  connectivity_type = "public"
+  subnet_id         = each.value.id
+  allocation_id     = aws_eip.nat[each.key].id
+  tags = {
+    Name = "bloom-nat-${each.key}"
+  }
+}
+
+# Create private subnets.
+resource "aws_subnet" "private" {
+  for_each                = local.private_subnets
+  vpc_id                  = aws_vpc.bloom.id
+  availability_zone       = each.key
+  cidr_block              = each.value
+  map_public_ip_on_launch = false
+  tags = {
+    Name = "bloom-private-${each.key}"
+  }
+}
+resource "aws_route_table" "nat_gateway" {
+  for_each = aws_subnet.private
+  region   = var.aws_region
+  vpc_id   = aws_vpc.bloom.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.bloom[each.key].id
+  }
+  tags = {
+    Name = "bloom-nat-gateway-${each.key}"
+  }
+}
+resource "aws_route_table_association" "private_subnet" {
+  for_each       = aws_subnet.private
+  region         = var.aws_region
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.nat_gateway[each.key].id
+}
+
+# Create PrivateLink endpoints for AWS services to be accessed via. This keeps the traffic internal
+# to AWS's network and avoids going through the NAT gateway over the internet.
+resource "aws_vpc_endpoint" "secrets_manager" {
+  region              = var.aws_region
+  vpc_id              = aws_vpc.bloom.id
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true # required for the AWS SDKs to use this network path by default instead of through the public internet.
+  service_name        = "com.amazonaws.${var.aws_region}.secretsmanager"
+  subnet_ids          = [for s in aws_subnet.private : s.id]
+  security_group_ids  = [aws_security_group.secrets_manager_endpoint.id]
+  tags = {
+    Name = "bloom-secretsmanager"
+  }
+}
+resource "aws_security_group" "secrets_manager_endpoint" {
+  region      = var.aws_region
+  vpc_id      = aws_vpc.bloom.id
+  name        = "secrets-manager-endpoint"
+  description = "Rules for secrets manager vpc endpoint"
+}
+resource "aws_vpc_security_group_ingress_rule" "bloom_service_tasks" {
+  for_each = {
+    "api" = aws_security_group.api.id
+
+    # If/when the sites need secrets:
+    # "site-partners" = aws_security_group.site_partners.id
+    # "site-public"   = aws_security_group.site_public.id
+  }
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.secrets_manager_endpoint.id
+  referenced_security_group_id = each.value
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+  tags = {
+    Name = "${each.key}-allow"
+  }
+}
+
+# Create security group for database.
+resource "aws_security_group" "db" {
+  region      = var.aws_region
+  vpc_id      = aws_vpc.bloom.id
+  name        = "bloom-db"
+  description = "Rules for Bloom database."
+}
+resource "aws_vpc_security_group_ingress_rule" "db" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.db.id
+  referenced_security_group_id = aws_security_group.api.id
+  ip_protocol                  = "tcp"
+  from_port                    = 5432
+  to_port                      = 5432
+  tags = {
+    Name = "api-allow"
+  }
+}
+
+# Create security group for LB.
+resource "aws_security_group" "lb" {
+  region      = var.aws_region
+  vpc_id      = aws_vpc.bloom.id
+  name        = "bloom-lb"
+  description = "Rules for Bloom load balancer."
+}
+resource "aws_vpc_security_group_ingress_rule" "lb" {
+  region            = var.aws_region
+  security_group_id = aws_security_group.lb.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  tags = {
+    Name = "internet-allow"
+  }
+}
+resource "aws_vpc_security_group_egress_rule" "lb_to_partners_site" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.lb.id
+  referenced_security_group_id = aws_security_group.site_partners.id
+  ip_protocol                  = "tcp"
+  from_port                    = 3001
+  to_port                      = 3001
+  tags = {
+    Name = "site-partners-allow"
+  }
+}
+resource "aws_vpc_security_group_egress_rule" "lb_to_public_site" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.lb.id
+  referenced_security_group_id = aws_security_group.site_public.id
+  ip_protocol                  = "tcp"
+  from_port                    = 3000
+  to_port                      = 3000
+  tags = {
+    Name = "site-public-allow"
+  }
+}
+
+# Create security group for api ECS tasks.
+resource "aws_security_group" "api" {
+  region      = var.aws_region
+  vpc_id      = aws_vpc.bloom.id
+  name        = "bloom-api"
+  description = "Rules for Bloom API tasks."
+}
+resource "aws_vpc_security_group_ingress_rule" "api" {
+  for_each = {
+    "site-partners" = aws_security_group.site_partners.id
+    "site-public"   = aws_security_group.site_public.id
+  }
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.api.id
+  referenced_security_group_id = each.value
+  ip_protocol                  = "tcp"
+  from_port                    = 3100
+  to_port                      = 3100
+  tags = {
+    Name = "${each.key}-allow"
+  }
+}
+resource "aws_vpc_security_group_egress_rule" "api_to_db" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.api.id
+  referenced_security_group_id = aws_security_group.db.id
+  ip_protocol                  = "tcp"
+  from_port                    = 5432
+  to_port                      = 5432
+  tags = {
+    Name = "allow-db"
+  }
+}
+resource "aws_vpc_security_group_egress_rule" "api_to_secretsmanager" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.api.id
+  referenced_security_group_id = aws_security_group.secrets_manager_endpoint.id
+  ip_protocol                  = "tcp"
+  from_port                    = 443
+  to_port                      = 443
+  tags = {
+    Name = "allow-secretsmanager"
+  }
+}
+resource "aws_vpc_security_group_egress_rule" "api_to_nat" {
+  region            = var.aws_region
+  security_group_id = aws_security_group.api.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  tags = {
+    Name = "allow-nat-https"
+  }
+}
+
+# Create security group for partners site ECS tasks.
+resource "aws_security_group" "site_partners" {
+  region      = var.aws_region
+  vpc_id      = aws_vpc.bloom.id
+  name        = "bloom-site-partners"
+  description = "Rules for Bloom partners site tasks."
+}
+resource "aws_vpc_security_group_ingress_rule" "lb_to_site_partners" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.site_partners.id
+  referenced_security_group_id = aws_security_group.lb.id
+  ip_protocol                  = "tcp"
+  from_port                    = 3001
+  to_port                      = 3001
+  tags = {
+    Name = "allow-lb"
+  }
+}
+resource "aws_vpc_security_group_egress_rule" "site_partners_to_api" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.site_partners.id
+  referenced_security_group_id = aws_security_group.api.id
+  ip_protocol                  = "tcp"
+  from_port                    = 3100
+  to_port                      = 3100
+  tags = {
+    Name = "allow-api"
+  }
+}
+# If/when access to secrets manager is needed:
+#resource "aws_vpc_security_group_egress_rule" "site_partners_to_secretsmanager" {
+#  region                       = var.aws_region
+#  security_group_id            = aws_security_group.site_partners.id
+#  referenced_security_group_id = aws_security_group.secrets_manager_endpoint.id
+#  ip_protocol                  = "tcp"
+#  from_port                    = 443
+#  to_port                      = 443
+#  tags = {
+#    Name = "allow-secretsmanager"
+#  }
+#}
+resource "aws_vpc_security_group_egress_rule" "site_partners_to_nat" {
+  region            = var.aws_region
+  security_group_id = aws_security_group.site_partners.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  tags = {
+    Name = "allow-nat-https"
+  }
+}
+
+# Create security group for public site ECS tasks.
+resource "aws_security_group" "site_public" {
+  region      = var.aws_region
+  vpc_id      = aws_vpc.bloom.id
+  name        = "bloom-site-public"
+  description = "Rules for Bloom public site tasks."
+}
+resource "aws_vpc_security_group_ingress_rule" "lb_to_site_public" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.site_public.id
+  referenced_security_group_id = aws_security_group.lb.id
+  ip_protocol                  = "tcp"
+  from_port                    = 3000
+  to_port                      = 3000
+  tags = {
+    Name = "allow-lb"
+  }
+}
+resource "aws_vpc_security_group_egress_rule" "site_public_to_api" {
+  region                       = var.aws_region
+  security_group_id            = aws_security_group.site_public.id
+  referenced_security_group_id = aws_security_group.api.id
+  ip_protocol                  = "tcp"
+  from_port                    = 3100
+  to_port                      = 3100
+  tags = {
+    Name = "allow-api"
+  }
+}
+# If/when access to secrets manager is needed:
+#resource "aws_vpc_security_group_egress_rule" "site_public_to_secretsmanager" {
+#  region                       = var.aws_region
+#  security_group_id            = aws_security_group.site_public.id
+#  referenced_security_group_id = aws_security_group.secrets_manager_endpoint.id
+#  ip_protocol                  = "tcp"
+#  from_port                    = 443
+#  to_port                      = 443
+#  tags = {
+#    Name = "allow-secretsmanager"
+#  }
+#}
+resource "aws_vpc_security_group_egress_rule" "site_public_to_nat" {
+  region            = var.aws_region
+  security_group_id = aws_security_group.site_public.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
+  tags = {
+    Name = "allow-nat-https"
+  }
+}

--- a/infra/tofu_root_modules/bloom_dev/.terraform.lock.hcl
+++ b/infra/tofu_root_modules/bloom_dev/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version     = "6.21.0"
+  constraints = "6.21.0"
+  hashes = [
+    "h1:2LDRo3iQcO6j5CP4Ltfv3Thx+41J+sw5UR0I/j+dVys=",
+    "h1:648ZuBRLeHgJTxpmNWhljc4lnUH5nS0OWBtYLLVY1iA=",
+    "h1:NuXyWDMddEsWGdh6jRbH/+Ybo85eH0NYoYOdVSkbo8Q=",
+    "h1:SN6l++JBiWWyq8M6tQg7neJtQCd4BtJkVwWVMv6sXX0=",
+    "zh:16483145131ad93139c8c903fee4e45d25e38e602810fa35a85d50eea3f47fcd",
+    "zh:177b5054b7b565f8d48733f480ac9bcd9d7d8e713729c7b493ecaf9ebbcbf8de",
+    "zh:2ec199a3ef0afe7559a7085a30702e65308de5aeaa32b7e6951f8346acf6bf1c",
+    "zh:4f8455ed43f57eaee6ff811bd68465bd10c0316d2975eb5f36857005ac602893",
+    "zh:9111c39c8765e0217112206edf5e7a3323c5485dd25480dcf6ab5ec0745aa271",
+    "zh:ba1fb5f1cb15beb5541a6757de3cf5391b93783c6bb11f6f7d8795140290b384",
+    "zh:c5816a1d5b261c0302f4f04b123472add562cdbced73e19d51570910c4f76acf",
+    "zh:e3ae0b43b3e2b4f98a18457021869b28e8c4bb0d7a21c9e0b4b2e70ed01101ca",
+    "zh:ff897b3b30b7fc6fe1d2fe4ef1ced2776f4f51f29e45df5030d5b37e3fcba835",
+  ]
+}

--- a/infra/tofu_root_modules/bloom_dev/README.md
+++ b/infra/tofu_root_modules/bloom_dev/README.md
@@ -1,0 +1,71 @@
+# bloom-dev AWS account
+
+This root module configures the bloom-dev AWS account.
+
+- Partners site: https://partners.core-dev.bloomhousing.dev
+- Public site: https://core-dev.bloomhousing.dev
+
+## First apply
+
+The S3 bucket for the Tofu state and the AWS certificate used need to be created before the rest of
+the Bloom deployment can proceed:
+
+1. Comment out the `backend "s3" { ... }` block at the top of [main.tf](./main.tf).
+2. Run `tofu init`. This downloads the AWS tofu provider to your local system.
+3. Run `tofu apply -exclude=module.bloom_deployment`. This creates a S3 bucket for the Tofu state file and
+   an AWS TLS certificate.
+4. Migrate the Tofu state to the s3 bucket:
+   1. Uncomment the `backend "s3" { ... }` block.
+   2. Run `tofu init` to migrate the state from the local file on your system to the S3 bucket.
+   3. Remove the local state files: `rm terraform.tfstate terraform.tfstate.backup`.
+5. Validate the AWS certificate:
+   1. The `tofu apply` command from step 3 will output the DNS records that need to be added for AWS
+      to issue the certificate. Add the two required CNAME records in the bloomhousing.dev DNS
+      configuration (in CloudFlare). For example, the following records need to be added for the following output:
+
+      Type | Name | Content | Proxy status
+      ---|---|---|---
+      CNAME | _4b8c99d969da11b1e35c36786a74b6fe.core-dev.bloomhousing.dev. | _003be6eab99411307156f79225503c77.jkddzztszm.acm-validations.aws. | disabled (DNS only)
+      CNAME | _aa08a6efc0ba7025472371c5b7b44120.partners.core-dev.bloomhousing.dev. | _fc0aa55094ea4ea64f60830d3a008225.jkddzztszm.acm-validations.aws. | disabled (DNS only)
+
+      ```
+      Outputs:
+
+      certificate_details = {
+        "certificate_status" = "ISSUED"
+        "expires_at" = "2026-12-18T23:59:59Z"
+        "managed_renewal" = {
+          "eligible" = "ELIGIBLE"
+          "status" = tolist([])
+        }
+        "validation_dns_recods" = toset([
+          {
+            "domain_name" = "core-dev.bloomhousing.dev"
+            "resource_record_name" = "_4b8c99d969da11b1e35c36786a74b6fe.core-dev.bloomhousing.dev."
+            "resource_record_type" = "CNAME"
+            "resource_record_value" = "_003be6eab99411307156f79225503c77.jkddzztszm.acm-validations.aws."
+          },
+          {
+            "domain_name" = "partners.core-dev.bloomhousing.dev"
+            "resource_record_name" = "_aa08a6efc0ba7025472371c5b7b44120.partners.core-dev.bloomhousing.dev."
+            "resource_record_type" = "CNAME"
+            "resource_record_value" = "_fc0aa55094ea4ea64f60830d3a008225.jkddzztszm.acm-validations.aws."
+          },
+        ])
+      }
+      ```
+
+6. Run `tofu apply` to deploy Bloom. The output will include a `aws_lb_dns_name`. DNS CNAME records
+   need to be added that point to the load balancer DNS name. For example, the following records
+   need to be added for the following output:
+
+   Type | Name | Content | Proxy status
+   ---|---|---|---
+   CNAME | core-dev | bloom-1787634238.us-west-2.elb.amazonaws.com | disabled (DNS only)
+   CNAME | partners.core-dev | bloom-1787634238.us-west-2.elb.amazonaws.com | disabled (DNS only)
+
+   ```
+   Outputs:
+
+   aws_lb_dns_name = "bloom-1787634238.us-west-2.elb.amazonaws.com"
+   ```

--- a/infra/tofu_root_modules/bloom_dev/main.tf
+++ b/infra/tofu_root_modules/bloom_dev/main.tf
@@ -1,0 +1,106 @@
+terraform {
+  required_providers {
+    aws = {
+      version = "6.21.0"
+      source  = "hashicorp/aws"
+    }
+  }
+  backend "s3" {
+    region       = local.aws_region
+    profile      = local.sso_profile_id
+    bucket       = local.state_bucket_name
+    key          = "state"
+    use_lockfile = true
+  }
+}
+
+locals {
+  sso_profile_id    = "bloom-dev-deployer"
+  state_bucket_name = "bloom-dev-tofu-state"
+
+  aws_account_number = 242477209009
+  aws_region         = "us-west-2"
+
+  domain_name = "core-dev.bloomhousing.dev"
+
+  deletion_protection = false
+}
+
+provider "aws" {
+  profile = local.sso_profile_id
+  region  = local.aws_region
+}
+
+# Create a bucket for this module's tofu state. See the README.md for more details about how this
+# works for the first apply of the module.
+resource "aws_s3_bucket" "tofu_state" {
+  region        = local.aws_region
+  bucket        = local.state_bucket_name
+  force_destroy = !local.deletion_protection
+}
+# https://opentofu.org/docs/v1.11/language/settings/backends/s3/:
+# "It is highly recommended that you enable Bucket Versioning"
+resource "aws_s3_bucket_versioning" "tofu_state" {
+  bucket = aws_s3_bucket.tofu_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# We need to create and validate a certificate for bloom_deployment module to deploy
+# successfully. See the README.md for more details for how to deploy and validate the certificate
+# before deploying the bloom_deployment module.
+locals {
+}
+resource "aws_acm_certificate" "bloom" {
+  region            = local.aws_region
+  validation_method = "DNS"
+  domain_name       = local.domain_name
+  subject_alternative_names = [
+    "partners.${local.domain_name}"
+  ]
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+output "certificate_details" {
+  value = {
+    certificate_status = aws_acm_certificate.bloom.status
+    expires_at         = aws_acm_certificate.bloom.not_after
+    managed_renewal = {
+      eligible = aws_acm_certificate.bloom.renewal_eligibility
+      status   = aws_acm_certificate.bloom.renewal_summary
+    }
+    validation_dns_recods = aws_acm_certificate.bloom.domain_validation_options
+  }
+  description = "DNS records required to be manually added for the LB TLS certificate to be issued."
+}
+
+# Deploy bloom into the account.
+module "bloom_deployment" {
+  source = "../../tofu_importable_modules/bloom_deployment"
+
+  aws_profile        = local.sso_profile_id
+  aws_account_number = local.aws_account_number
+  aws_region         = local.aws_region
+
+  domain_name         = aws_acm_certificate.bloom.domain_name
+  aws_certificate_arn = aws_acm_certificate.bloom.arn
+
+  env_type          = "dev"
+  high_availability = false
+
+  bloom_api_image           = "ghcr.io/bloom-housing/bloom/api:gitsha-f642fc1f3f056b9fa53429c4fa81689c5e856e5a"
+  bloom_site_partners_image = "ghcr.io/bloom-housing/bloom/partners:gitsha-f642fc1f3f056b9fa53429c4fa81689c5e856e5a"
+  bloom_site_public_image   = "ghcr.io/bloom-housing/bloom/public:gitsha-f642fc1f3f056b9fa53429c4fa81689c5e856e5a"
+  bloom_site_public_env_vars = {
+    JURISDICTION_NAME     = "Bloomington"
+    CLOUDINARY_CLOUD_NAME = "exygy"
+    LANGUAGES             = "en,es,zh,vi,tl"
+    RTL_LANGUAGES         = "ar"
+  }
+}
+output "aws_lb_dns_name" {
+  value       = module.bloom_deployment.lb_dns_name
+  description = "DNS name of the load balancer."
+}

--- a/infra/tofu_root_modules/bloom_dev_deployer_permission_set/.terraform.lock.hcl
+++ b/infra/tofu_root_modules/bloom_dev_deployer_permission_set/.terraform.lock.hcl
@@ -5,7 +5,10 @@ provider "registry.opentofu.org/hashicorp/aws" {
   version     = "6.16.0"
   constraints = "6.16.0"
   hashes = [
+    "h1:+KTptRRTlYAy7LaapCKO0EaWFJrx1sUAppIbLxWZbQs=",
+    "h1:0yAImlagvonR1IeQlOR+yFC8qT3rrN+D/0t7hIfYfBg=",
     "h1:BjHgGqMnWWbtQE714zLcCFpfj1InWVZNUu+vSFbDLrQ=",
+    "h1:XF+SPjPQTW+V18Lae+LFZXrzKPu/9yRU9HACjZXLzIQ=",
     "zh:35b8863c15ac346f4927a3bfa103a0a262e0a3f6070e141b822e81a85a31fdd6",
     "zh:4011d6f4671f48cdce37ec6b894fcb3852e024194c8eb7dae143135c5b3f0b74",
     "zh:480697e5f582a7e3f77e5ce438ad7685679ad41aa88d801839a5206247359a1c",

--- a/infra/tofu_root_modules/bloom_dev_deployer_permission_set/main.tf
+++ b/infra/tofu_root_modules/bloom_dev_deployer_permission_set/main.tf
@@ -41,6 +41,7 @@ data "aws_iam_policy_document" "bloom_dev_deployer" {
     sid = "StateBucket"
     actions = [
       "s3:CreateBucket",
+      "s3:DeleteBucket",
       "s3:GetAccelerateConfiguration",
       "s3:GetBucketAcl",
       "s3:GetBucketCors",
@@ -48,13 +49,13 @@ data "aws_iam_policy_document" "bloom_dev_deployer" {
       "s3:GetBucketObjectLockConfiguration",
       "s3:GetBucketPolicy",
       "s3:GetBucketRequestPayment",
+      "s3:GetBucketTagging",
       "s3:GetBucketVersioning",
       "s3:GetBucketWebsite",
       "s3:GetEncryptionConfiguration",
       "s3:GetLifecycleConfiguration",
       "s3:GetReplicationConfiguration",
       "s3:ListBucket",
-      "s3:GetBucketTagging",
       "s3:PutBucketVersioning",
     ]
     resources = ["arn:aws:s3:::bloom-dev-tofu-state"]
@@ -62,13 +63,276 @@ data "aws_iam_policy_document" "bloom_dev_deployer" {
   statement {
     sid = "StateFiles"
     actions = [
+      "s3:DeleteObject",
       "s3:GetObject",
       "s3:PutObject",
-      "s3:DeleteObject"
     ]
     resources = [
       "arn:aws:s3:::bloom-dev-tofu-state/state",
       "arn:aws:s3:::bloom-dev-tofu-state/state.tflock"
     ]
+  }
+  statement {
+    sid = "CloudTrail"
+    actions = [
+      "cloudtrail:CreateEventDataStore",
+      "cloudtrail:DeleteEventDataStore",
+      "cloudtrail:GetEventDataStore",
+      "cloudtrail:ListTags",
+    ]
+    resources = [
+      "arn:aws:cloudtrail:*:*:eventdatastore/*",
+    ]
+  }
+  statement {
+    sid = "ServiceLinkedRole"
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:DeleteServiceLinkedRole",
+      "iam:GetRole",
+      "iam:GetServiceLinkedRoleDeletionStatus",
+    ]
+    resources = [
+      "arn:aws:iam::*:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+      "arn:aws:iam::*:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing",
+    ]
+  }
+  statement {
+    # These calls are not scoped to a specific resource.
+    sid = "DescribeVPC"
+    actions = [
+      "acm:ListCertificates",
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeAddresses",
+      "ec2:DescribeAddressesAttribute",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInternetGateways",
+      "ec2:DescribeNatGateways",
+      "ec2:DescribeNetworkAcls",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribePrefixLists",
+      "ec2:DescribeRouteTables",
+      "ec2:DescribeSecurityGroupRules",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcEndpoints",
+      "ec2:DescribeVpcs",
+      "elasticloadbalancing:DescribeListenerAttributes",
+      "elasticloadbalancing:DescribeListeners",
+      "elasticloadbalancing:DescribeLoadBalancerAttributes",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTargetGroupAttributes",
+      "elasticloadbalancing:DescribeTargetGroups",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid = "ConfigureVPC"
+    actions = [
+      "acm:DeleteCertificate",
+      "acm:DescribeCertificate",
+      "acm:GetCertificate",
+      "acm:ListTagsForCertificate",
+      "acm:RequestCertificate",
+      "ec2:AllocateAddress",
+      "ec2:AssociateRouteTable",
+      "ec2:AssociateVpcCidrBlock",
+      "ec2:AttachInternetGateway",
+      "ec2:AuthorizeSecurityGroupEgress",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateInternetGateway",
+      "ec2:CreateNATGateway",
+      "ec2:CreateNatGateway",
+      "ec2:CreateRoute",
+      "ec2:CreateRouteTable",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateSubnet",
+      "ec2:CreateTags",
+      "ec2:CreateTags",
+      "ec2:CreateVpc",
+      "ec2:CreateVpcEndpoint",
+      "ec2:DeleteInternetGateway",
+      "ec2:DeleteNatGateway",
+      "ec2:DeleteRouteTable",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DeleteSubnet",
+      "ec2:DeleteVPC",
+      "ec2:DeleteVpcEndpoints",
+      "ec2:DescribeVpcAttribute",
+      "ec2:DetachInternetGateway",
+      "ec2:DisassociateRouteTable",
+      "ec2:DisassociateVpcCidrBlock",
+      "ec2:ModifySubnetAttribute",
+      "ec2:ModifyVpcAttribute",
+      "ec2:ModifyVpcEndpoint",
+      "ec2:ReleaseAddress",
+      "ec2:RevokeSecurityGroupEgress",
+      "ec2:RevokeSecurityGroupIngress",
+      "elasticloadbalancing:AddTags",
+      "elasticloadbalancing:CreateListener",
+      "elasticloadbalancing:CreateLoadBalancer",
+      "elasticloadbalancing:CreateRule",
+      "elasticloadbalancing:CreateTargetGroup",
+      "elasticloadbalancing:DeleteListener",
+      "elasticloadbalancing:DeleteLoadBalancer",
+      "elasticloadbalancing:DeleteRule",
+      "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:ModifyLoadBalancerAttributes",
+      "elasticloadbalancing:ModifyTargetGroup",
+      "elasticloadbalancing:ModifyTargetGroupAttributes",
+    ]
+    resources = [
+      "arn:aws:acm:*:*:certificate/*",
+      "arn:aws:ec2:*:*:elastic-ip/*",
+      "arn:aws:ec2:*:*:internet-gateway/*",
+      "arn:aws:ec2:*:*:natgateway/*",
+      "arn:aws:ec2:*:*:route-table/*",
+      "arn:aws:ec2:*:*:security-group-rule/*",
+      "arn:aws:ec2:*:*:security-group/*",
+      "arn:aws:ec2:*:*:subnet/*",
+      "arn:aws:ec2:*:*:vpc-endpoint/*",
+      "arn:aws:ec2:*:*:vpc/*",
+      "arn:aws:elasticloadbalancing:*:*:listener-rule/app/bloom/*",
+      "arn:aws:elasticloadbalancing:*:*:listener/app/bloom/*",
+      "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/bloom/*",
+      "arn:aws:elasticloadbalancing:*:*:targetgroup/bloom-site-partners/*",
+      "arn:aws:elasticloadbalancing:*:*:targetgroup/bloom-site-public/*",
+    ]
+  }
+  statement {
+    sid     = "DisassociateAddress"
+    actions = ["ec2:DisassociateAddress"]
+    # For some reason the DisassociateAdress calls use this resource pattern.
+    resources = ["arn:aws:ec2:*:*:*/*"]
+  }
+  statement {
+    # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAM.ServiceLinkedRoles.html
+    sid = "DBServiceLinkedRole"
+    actions = [
+      "iam:CreateServiceLinkedRole",
+    ]
+    resources = [
+      "arn:aws:iam::*:role/aws-service-role/rds.amazonaws.com/AWSServiceRoleForRDS",
+    ]
+    condition {
+      test     = "StringLike"
+      variable = "iam:AWSServiceName"
+      values   = ["rds.amazonaws.com"]
+    }
+  }
+  statement {
+    sid = "DBMasterUserPassword"
+    actions = [
+      "kms:DescribeKey",
+      "secretsmanager:CreateSecret",
+      "secretsmanager:TagResource",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid       = "DescribeDB"
+    actions   = ["rds:DescribeDBInstances"]
+    resources = ["arn:aws:rds:*:*:db:*"]
+  }
+  statement {
+    # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/security_iam_id-based-policy-examples-create-and-modify-examples.html
+    sid = "ConfigureDB"
+    actions = [
+      "rds:CreateDBInstance",
+      "rds:CreateDBSnapshot",
+      "rds:CreateDBSubnetGroup",
+      "rds:DeleteDBInstance",
+      "rds:DeleteDBSubnetGroup",
+      "rds:DescribeDBInstances",
+      "rds:DescribeDBSubnetGroups",
+      "rds:ListTagsForResource",
+      "rds:ModifyDBInstance",
+    ]
+    resources = [
+      "arn:aws:rds:*:*:db:bloom",
+      "arn:aws:rds:*:*:og:bloom",
+      "arn:aws:rds:*:*:pg:bloom",
+      "arn:aws:rds:*:*:snapshot:bloom-db-finalsnapshot",
+      "arn:aws:rds:*:*:subgrp:bloom",
+    ]
+  }
+  statement {
+    # For some reason the task APIs operate on the * resouce and don't support targeting the
+    # resource directly in the IAM policy.
+    sid = "ECSTaskDefinition"
+    actions = [
+      "ecs:DeregisterTaskDefinition",
+      "ecs:DescribeTaskDefinition",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid = "ConfigureECS"
+    actions = [
+      "ecs:CreateCluster",
+      "ecs:CreateService",
+      "ecs:DeleteCluster",
+      "ecs:DeleteService",
+      "ecs:DescribeClusters",
+      "ecs:DescribeServiceDeployments",
+      "ecs:DescribeServices",
+      "ecs:ListServiceDeployments",
+      "ecs:ListTagsForResource",
+      "ecs:RegisterTaskDefinition",
+      "ecs:UpdateCluster",
+      "ecs:UpdateService",
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:DeleteRolePolicy",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListInstanceProfilesForRole",
+      "iam:ListRolePolicies",
+      "iam:PassRole",
+      "iam:PutRolePolicy",
+      "logs:CreateLogGroup",
+      "logs:DeleteLogGroup",
+      "logs:DescribeLogGroups",
+      "logs:ListTagsForResource",
+      "logs:PutRetentionPolicy",
+      "servicediscovery:CreateHttpNamespace",
+      "servicediscovery:DeleteNamespace",
+      "servicediscovery:GetNamespace",
+      "servicediscovery:GetOperation",
+      "servicediscovery:ListTagsForResource",
+    ]
+    resources = concat(
+      [
+        "arn:aws:ecs:*:*:cluster/bloom",
+        "arn:aws:logs:*:*:log-group::log-stream:",
+        "arn:aws:servicediscovery:*:*:*/*"
+      ],
+      flatten(
+        [for name in ["api", "site-partners", "site-public"] : [
+          "arn:aws:ecs:*:*:service-deployment/bloom/bloom-${name}/*",
+          "arn:aws:ecs:*:*:service/bloom/bloom-${name}",
+          "arn:aws:ecs:*:*:task-definition/bloom-${name}:*",
+          "arn:aws:iam::*:role/bloom-${name}-container",
+          "arn:aws:iam::*:role/bloom-${name}-ecs",
+          "arn:aws:logs:*:*:log-group:bloom-${name}*",
+        ]]
+    ))
+  }
+  statement {
+    sid = "APIJWTKeySecret"
+    actions = [
+      "secretsmanager:CreateSecret",
+      "secretsmanager:DeleteSecret",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetResourcePolicy",
+      "secretsmanager:PutResourcePolicy",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:TagResource",
+    ]
+    resources = ["arn:aws:secretsmanager:*:*:secret:bloom-api-jwt-signing-key*"]
   }
 }


### PR DESCRIPTION
This PR addresses #5450

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

This PR addresses #5438

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Bloom-dev AWS deployment initial infra. Contains:

1. Changes to the bloom-dev-deployer permission set required (already deployed).
2. A bloom-deployment reusable Open Tofu module that deploys Bloom to an AWS account.
3. A bloom-dev root Open Tofu module that uses the bloom-deployment module.

The deployment is currently live at:

https://core-dev.bloomhousing.dev/
https://partners.core-dev.bloomhousing.dev/

I manually seeded the database with the staging seed command.  I will followup automation of that when I add the deployment automation.

## How Can This Be Tested/Reviewed?

1. From repo root: `cd infra/tofu_root_modules/bloom_dev` 
2. Run `tofu destroy -target=module.bloom_deployment`
3. Run `tofu apply`
4. Go to https://d-9067ac8222.awsapps.com/start/#/?tab=accounts and log in to `bloom-dev` as SystemAdministrator.
5. Inspect the VPC, RDS, and ECS pages.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
