### PR TITLE
fix: clear deposit on save and continue

### DIFF
--- a/api/src/decorators/validate-listing-deposit.decorator.ts
+++ b/api/src/decorators/validate-listing-deposit.decorator.ts
@@ -31,34 +31,27 @@ export class DepositValueConstraint implements ValidatorConstraintInterface {
     const { depositValue, depositMin, depositMax, listingType } =
       args.object as Listing;
 
-    console.log(depositValue, depositMin, depositMax, listingType);
-
     if (!listingType || listingType === ListingTypeEnum.regulated) {
       return true;
     }
 
-    // Verify if both fields are either filled or empty
-    const areRangeFieldsInvalid =
-      (this.isFieldEmpty(depositMin) && !this.isFieldEmpty(depositMax)) ||
-      (!this.isFieldEmpty(depositMin) && this.isFieldEmpty(depositMax));
-
     if (value === DepositTypeEnum.fixedDeposit) {
-      return (
-        this.isFieldEmpty(depositMin) &&
-        this.isFieldEmpty(depositMax) &&
-        !this.isFieldEmpty(depositValue)
-      );
+      return this.isFieldEmpty(depositMin) && this.isFieldEmpty(depositMax);
+    }
+    if (value === DepositTypeEnum.depositRange) {
+      return this.isFieldEmpty(depositValue);
     }
 
-    return this.isFieldEmpty(depositValue) && !areRangeFieldsInvalid;
+    // If no Deposit type is selected then validate that it's either just depositValue or just the range values
+    return (
+      this.isFieldEmpty(depositValue) ||
+      (this.isFieldEmpty(depositMin) && this.isFieldEmpty(depositMax))
+    );
   }
   defaultMessage(args?: ValidationArguments): string {
     const value = args.value as DepositTypeEnum;
-    const { listingType } = args.object as Listing;
 
-    if (!listingType || listingType === ListingTypeEnum.regulated) {
-      return 'The "depositMin" and "depositMax" fields must be filled';
-    } else if (value === DepositTypeEnum.fixedDeposit) {
+    if (value === DepositTypeEnum.fixedDeposit) {
       return 'When deposit is of type "fixedDeposit" the "depositValue" must be filled and the "depositMin"|"depositMax" fields must be null';
     }
     return 'When deposit is of type "depositRange" the "depositMin" and "depositMax" fields must be filled and "depositValue" must be null';

--- a/sites/partners/src/components/listings/PaperListingForm/sections/AdditionalFees.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/AdditionalFees.tsx
@@ -13,6 +13,7 @@ import {
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 import styles from "../ListingForm.module.scss"
 import { GridRow } from "@bloom-housing/ui-seeds/src/layout/Grid"
+import { ListingContext } from "../../ListingContext"
 
 type AdditionalFeesProps = {
   existingUtilities: ListingUtilities
@@ -22,6 +23,7 @@ type AdditionalFeesProps = {
 const AdditionalFees = (props: AdditionalFeesProps) => {
   const formMethods = useFormContext()
   const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
+  const listing = useContext(ListingContext)
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, watch, errors, clearErrors, setValue } = formMethods
 
@@ -56,6 +58,14 @@ const AdditionalFees = (props: AdditionalFeesProps) => {
       setValue("utilities", undefined)
     }
   }, [enableUtilitiesIncluded, setValue])
+
+  // After submitting the deposit max, min, and value can be removed via AdditionalMetadataFormatter.
+  // On a save and continue flow the values need to be updated in the form
+  useEffect(() => {
+    setValue("depositMax", listing?.depositMax)
+    setValue("depositMin", listing?.depositMin)
+    setValue("depositValue", listing?.depositValue)
+  }, [listing?.depositMax, listing?.depositMin, listing?.depositValue, setValue])
 
   const showAsNonRegulated =
     enableNonRegulatedListings && listingType === EnumListingListingType.nonRegulated


### PR DESCRIPTION
This is a PR into https://github.com/bloom-housing/bloom/pull/5455 to fix an issue

fixes the following two scenarios:

## Saving a listing
1. Create a listing and add a Fixed Deposit value
2. Save the listing
3. Reopen the edit page, change to "Deposit Range", add "Deposit min" and "Deposit max" values.
4. Click "save"
5. Both the Fixed Deposit and Deposit Range values are on the page if you toggle between the two
This is happening because it saved correctly, but we aren't updating the form values.

Note about this one: I believe this would be better fixed with a refactor in how listing values are updated using the context but that has larger implications so making a more targeted fix in the meantime.

## Creating a draft listing is requiring fields
1. If you create a draft listing and don't fill out anything in the deposit section
2. Click save and the backend throws an error that the field needs to be filled out.
We need to handle the case where they haven't filled out most of the fields yet in order to save the draft. This has been fixed by simplifying our backend validator to only verify that the incorrect values aren't being sent rather than forcing the values to be there.

