### PR TITLE
fix: add missing credit screening fee string

### DIFF
--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -408,6 +408,7 @@
   "listings.sections.communityTypeSubtitle": "Are there any requirements that applicants need to meet?",
   "listings.sections.communityType.tellUs": "Tell us about any additional community types related to this listing.",
   "listings.sections.costsNotIncluded": "Costs not included",
+  "listings.sections.creditScreeningFee": "Credit screening fee",
   "listings.sections.depositHelperText": "Deposit helper text",
   "listings.sections.housingPreferencesSubtext": "Tell us about any preferences that will be used to rank qualifying applicants.",
   "listings.sections.housingProgramsSubtext": "Tell us about any additional housing programs related to this listing.",


### PR DESCRIPTION
This PR addresses #5489

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Don't even ask 😅 

## How Can This Be Tested/Reviewed?

On partners edit / add listing for Angelopolis, check additional fees section it should have now proper string (not key).

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
