### PR TITLE
feat: 5628/Add password parameters to change password screen

### DIFF
--- a/sites/public/src/pages/reset-password.tsx
+++ b/sites/public/src/pages/reset-password.tsx
@@ -107,7 +107,6 @@ const ResetPassword = () => {
                 type="submit"
                 variant="primary"
                 loadingMessage={loading ? t("t.loading") : undefined}
-                className="rounded-full py-2"
               >
                 {t("authentication.forgotPassword.changePassword")}
               </Button>


### PR DESCRIPTION
This PR addresses #5628

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The purpose of this ticket was to add the same password guidance that's on the create account page to the password reset page: 

Must be at least 12 characters and include at least one lowercase letter, one uppercase letter, one number, and one special character (#?!@$%^&*-)." that's also on the create account page

Please include a summary of the change and which issue(s) is addressed.

## How Can This Be Tested/Reviewed?


1. Navigate to the public site
2. In the navbar click on sign in
3. Click on forgot password
4. Enter you email and click send email
5. You will get an email  with the link to reset your pass (change my password)
6. click on it. You will be redirect to this screen.

<img width="682" height="656" alt="image" src="https://github.com/user-attachments/assets/e40da724-497d-40d4-a5a5-5ba27a3310ac" />


Provide instructions so we can review, including any needed configuration, and the test cases that need to be QAd.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
