### PR TITLE
fix: show lottery tab for waitlist lottery

### DIFF
--- a/sites/partners/src/pages/listings/[id]/applications/index.tsx
+++ b/sites/partners/src/pages/listings/[id]/applications/index.tsx
@@ -143,7 +143,8 @@ const ApplicationsList = () => {
             lotteryLabel:
               listingDto?.status === ListingsStatusEnum.closed &&
               listingDto?.lotteryOptIn &&
-              listingDto?.reviewOrderType === ReviewOrderTypeEnum.lottery
+              (listingDto?.reviewOrderType === ReviewOrderTypeEnum.lottery ||
+                listingDto?.reviewOrderType === ReviewOrderTypeEnum.waitlistLottery)
                 ? t("listings.lotteryTitle")
                 : undefined,
           }}

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -360,7 +360,8 @@ const Lottery = (props: { listing: Listing | undefined }) => {
                 lotteryLabel:
                   listing.status === ListingsStatusEnum.closed &&
                   listing?.lotteryOptIn &&
-                  listing?.reviewOrderType === ReviewOrderTypeEnum.lottery
+                  (listing?.reviewOrderType === ReviewOrderTypeEnum.lottery ||
+                    listing?.reviewOrderType === ReviewOrderTypeEnum.waitlistLottery)
                     ? t("listings.lotteryTitle")
                     : undefined,
               }}


### PR DESCRIPTION
This PR addresses #5505 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

While bashing Doorway release a waitlist lottery bug was found where the link to the "lottery" page was not always showing. https://github.com/metrotranscom/doorway/pull/1468#issuecomment-3607683097.

This is because there was a spot missed that needs the new "waitlistLottery" enum.

Note: there is also an existing issue where you can directly get to the lottery page if you have the right access but the listing is not in the right state. That is not being solved by this PR

## How Can This Be Tested/Reviewed?

1. Create a listing that is of type "waitlistLottery" (listing availability of "open waitlist" and review order of "lottery"), has "Will the lottery be run in the partner portal?" set to true, and is closed
2. The "Lottery" tab should appear when you are on all three of the listing pages (Listing, Applications, and Lottery)

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
