### PR TITLE
refactor: update generate translations

### DIFF
--- a/shared-helpers/package.json
+++ b/shared-helpers/package.json
@@ -38,6 +38,7 @@
     "@types/react-transition-group": "^4.4.12",
     "@google-cloud/translate": "^9.2.0",
     "csv-parse": "^5.5.5",
+    "dotenv": "^17.2.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.5.3",
     "next": "^15.5.7",

--- a/shared-helpers/src/scripts/.env.template
+++ b/shared-helpers/src/scripts/.env.template
@@ -1,0 +1,6 @@
+# google translate api email
+GOOGLE_API_EMAIL=
+# google translate api id
+GOOGLE_API_ID=
+# google translate api key
+GOOGLE_API_KEY=

--- a/shared-helpers/src/scripts/get-machine-translations.ts
+++ b/shared-helpers/src/scripts/get-machine-translations.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires, import/no-unresolved */
 // Finds missing translations and automatically translates them using Google Translate API
 // Prints out translations in the JSON translation file format: "key": "translated string"
-// You will need to add the environment variables for Google Translate API access from the api env file, but ensure you do not commit them!
+// You will need to add the environment variables for Google Translate API access from the api env file into this env file
 // Example: `ts-node get-machine-translations.ts > any-filename-here.json`
 import { Translate } from "@google-cloud/translate/build/src/v2"
+import dotenv from "dotenv"
+dotenv.config({ quiet: true })
 
 async function main() {
   enum LanguagesEnum {
@@ -16,10 +18,9 @@ async function main() {
     "bn" = "bn",
   }
 
-  // DO NOT COMMIT THESE VALUES! REMOVE BEFORE COMMITTING
-  const GOOGLE_API_EMAIL = ``
-  const GOOGLE_API_ID = ``
-  const GOOGLE_API_KEY = ``
+  const GOOGLE_API_EMAIL = process.env.GOOGLE_API_EMAIL || ``
+  const GOOGLE_API_ID = process.env.GOOGLE_API_ID || ``
+  const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY || ``
 
   const makeTranslateService = () => {
     return new Translate({


### PR DESCRIPTION
## Description

Updates our generate machine translations script to make it easier - previously we needed to first run the missing translations script, then manually add each language one by one into a CSV and pass it into the machine translations script. Now this script does both.

In development, you can just add the English keys in the general file and then run this script.

Hoping this will help our translations dev efficiency!

## How Can This Be Tested/Reviewed?

There are instructions in the file, but add the google translate keys, and from within the shared-helpers script folder run `ts-node generate-machine-translations.ts > translated-strings.json`.

You'll need to manually remove some non-English keys to see the appropriate output.

I will update the existing Notion docs for these scripts post-merge.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
