### PR TITLE
fix: accessible feature lists

### DIFF
--- a/sites/public/src/components/listing/ListingViewSeeds.module.scss
+++ b/sites/public/src/components/listing/ListingViewSeeds.module.scss
@@ -11,7 +11,8 @@
   --subheading-margin: var(--seeds-s1);
   --subheading-margin-sm: var(--seeds-spacer-header);
 
-  &, p {
+  &,
+  p {
     overflow-wrap: anywhere;
   }
 }
@@ -133,4 +134,17 @@
 
 .link-no-gap {
   --link-interior-gap: 0;
+}
+
+.two-column-list {
+  columns: 2;
+  column-gap: var(--seeds-spacer-section);
+  @media (--md-down) {
+    columns: 1;
+  }
+}
+
+.list-item {
+  list-style: disc;
+  margin-inline-start: var(--seeds-s5);
 }

--- a/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
+++ b/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
@@ -34,6 +34,7 @@ import { CardList, ContentCardProps } from "../../patterns/CardList"
 import { OrderedCardList } from "../../patterns/OrderedCardList"
 import { ReadMore } from "../../patterns/ReadMore"
 import { DateSectionFlyer } from "./listing_sections/DateSection"
+import styles from "./ListingViewSeeds.module.scss"
 
 export const getFilteredMultiselectQuestions = (
   multiselectQuestions: ListingMultiselectQuestion[],
@@ -140,15 +141,24 @@ export const getAccessibilityFeatures = (listing: Listing) => {
   const enabledFeatures = Object.entries(listing?.listingFeatures ?? {})
     .filter(([_, value]) => value)
     .map((item) => item[0])
+  const COLUMN_BREAKPOINT = 6
   if (enabledFeatures.length > 0) {
-    return enabledFeatures.map((feature, index) => {
-      return `${t(`eligibility.accessibility.${feature}`)}${
-        index < enabledFeatures.length - 1 ? ", " : ""
-      }`
-    })
+    return (
+      <ul className={enabledFeatures.length > COLUMN_BREAKPOINT ? styles["two-column-list"] : ""}>
+        {enabledFeatures
+          .sort((a, b) =>
+            t(`eligibility.accessibility.${a}`).localeCompare(t(`eligibility.accessibility.${b}`))
+          )
+          .map((feature, index) => (
+            <li key={index} className={styles["list-item"]}>
+              {t(`eligibility.accessibility.${feature}`)}
+            </li>
+          ))}
+      </ul>
+    )
   }
 
-  return []
+  return null
 }
 
 export const getUtilitiesIncluded = (listing: Listing) => {
@@ -194,8 +204,11 @@ export const getFeatures = (
   const enableAccessibilityFeatures = jurisdiction?.featureFlags?.some(
     (flag) => flag.name === "enableAccessibilityFeatures" && flag.active
   )
-  if (!!accessibilityFeatures.length && enableAccessibilityFeatures) {
-    features.push({ heading: t("t.accessibility"), subheading: accessibilityFeatures })
+  if (!!accessibilityFeatures && enableAccessibilityFeatures) {
+    features.push({
+      heading: t("t.accessibility"),
+      content: accessibilityFeatures,
+    })
   }
   if (listing.accessibility) {
     features.push({ heading: t("t.additionalAccessibility"), subheading: listing.accessibility })

--- a/sites/public/src/components/listing/listing_sections/Features.tsx
+++ b/sites/public/src/components/listing/listing_sections/Features.tsx
@@ -8,7 +8,8 @@ type FeaturesProps = {
   children: React.ReactNode
   features: {
     heading: string
-    subheading: string
+    subheading?: string
+    content?: React.ReactNode
   }[]
 }
 
@@ -22,13 +23,18 @@ export const Features = ({ children, features }: FeaturesProps) => {
       <div className={`${styles["mobile-inline-collapse-padding"]} seeds-m-bs-section`}>
         {features.map((feature, index) => {
           return (
-            <HeadingGroup
-              heading={feature.heading}
-              subheading={feature.subheading}
-              headingProps={{ size: "lg", priority: 3 }}
-              className={`${styles["heading-group"]} seeds-m-be-section`}
-              key={index}
-            />
+            <>
+              <HeadingGroup
+                heading={feature.heading}
+                subheading={feature.subheading}
+                headingProps={{ size: "lg", priority: 3 }}
+                className={`${styles["heading-group"]} ${
+                  !feature.content ? "seeds-m-be-section" : "seeds-m-be-label"
+                }`}
+                key={index}
+              />
+              <div className={"seeds-m-be-section"}>{feature.content}</div>
+            </>
           )
         })}
         {children}


### PR DESCRIPTION
This PR addresses #5726

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Updates the currently comma-separated accessibility features list into an actual list for ... accessibility!

## How Can This Be Tested/Reviewed?

The list of accessibility features under the Features section on a listing should now appear as an actual list. If there are more than 6, it will split into 2 columns, though go back to 1 on mobile. We are now also sorting alphabetically.

Example > 6 listing with [before](https://bloom-public-seeds.netlify.app/listing/b12830cf-8516-4268-bdbe-2c257e351ef7/kc_apt_test_available_units_fcfs_2_65_montezuma_st_san_francisco_ca) and [after](https://deploy-preview-5725--bloom-public-seeds.netlify.app/listing/b12830cf-8516-4268-bdbe-2c257e351ef7/kc_apt_test_available_units_fcfs_2_65_montezuma_st_san_francisco_ca)

<img width="646" height="182" alt="Image" src="https://github.com/user-attachments/assets/90473933-4c13-45bd-b2d6-0512eb3d19c3" />
<img width="623" height="254" alt="Image" src="https://github.com/user-attachments/assets/7b6483a2-3c71-4584-a238-bec54614d2d9" />

Example <= 6 with [before](https://bloom-public-seeds.netlify.app/listing/2beb8989-b406-4514-b541-7afa6700f3cf/kc_apt_test_waitlist_fcfs_2_65_montezuma_st_san_francisco_ca) and [after](https://deploy-preview-5725--bloom-public-seeds.netlify.app/listing/2beb8989-b406-4514-b541-7afa6700f3cf/kc_apt_test_waitlist_fcfs_2_65_montezuma_st_san_francisco_ca)

<img width="630" height="111" alt="Image" src="https://github.com/user-attachments/assets/134dba9f-ddd5-4872-8485-cc51b927a3ce" />
<img width="392" height="197" alt="Image" src="https://github.com/user-attachments/assets/01a48349-e646-4fbc-aa1f-c317e711f7ed" />

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
