### PR TITLE
feat: rework VPC to use a /22 range

### DIFF
--- a/infra/tofu_importable_modules/bloom_deployment/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/main.tf
@@ -28,6 +28,23 @@ variable "aws_region" {
     error_message = "Must be 'us-east-1', 'us-east-2', 'us-west-1', or 'us-west-2'."
   }
 }
+variable "vpc_cidr_range" {
+  type        = string
+  description = "The CIDR range to use for the Bloom VPC. Must be a /22 block in the RFC 1918 private IP space."
+  default     = "10.0.0.0/22"
+  validation {
+    condition = (
+      cidrcontains("10.0.0.0/8", var.vpc_cidr_range) ||
+      cidrcontains("172.16.0.0/12", var.vpc_cidr_range) ||
+      cidrcontains("192.168.0.0/16", var.vpc_cidr_range)
+    )
+    error_message = "Must be in the RFC 1918 private IP space."
+  }
+  validation {
+    condition     = cidrnetmask(var.vpc_cidr_range) == cidrnetmask("10.0.0.0/22")
+    error_message = "Must be a /22."
+  }
+}
 variable "high_availability" {
   type        = bool
   description = "Deploy the Bloom services in a highly-available manner. If true, a minimum of 2 instances will be running for each Bloom service."


### PR DESCRIPTION
This PR addresses #5571

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Reworks the Bloom VPC to expect a /22 CIDR range.

## How Can This Be Tested/Reviewed?

I re-deployed the bloom-dev environment, the subnets have the expected CIDR ranges: 
<img width="1628" height="606" alt="image" src="https://github.com/user-attachments/assets/388e3dac-f93d-4d49-8bf1-632e3895cfcf" />
