### PR TITLE
feat: infra CI checks

### DIFF
--- a/.github/workflows/cypress_partners.yml
+++ b/.github/workflows/cypress_partners.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 env:
   PORT: 3100
   EMAIL_API_KEY: 'SOME-LONG-SECRET-KEY'

--- a/.github/workflows/cypress_partners_listingapproval.yml
+++ b/.github/workflows/cypress_partners_listingapproval.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 env:
   PORT: 3100
   EMAIL_API_KEY: 'SOME-LONG-SECRET-KEY'

--- a/.github/workflows/cypress_public.yml
+++ b/.github/workflows/cypress_public.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 env:
   PORT: 3100
   EMAIL_API_KEY: 'SOME-LONG-SECRET-KEY'

--- a/.github/workflows/docker_image_build.yml
+++ b/.github/workflows/docker_image_build.yml
@@ -74,7 +74,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: ${{ matrix.platforms }}
           tags: |
-            ${{ env.image_base }}/${{ matrix.container }}:latest
+            ${{ env.image_base }}/${{ matrix.container }}:gitbranch-${{ github.ref_name }}-latest
             ${{ env.image_base }}/${{ matrix.container }}:gitsha-${{ github.sha }}
           # Connects the image to the repository: https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package.
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}

--- a/.github/workflows/infra_ci.yml
+++ b/.github/workflows/infra_ci.yml
@@ -1,0 +1,85 @@
+name: Infra CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/infra_ci.yml'
+      - 'infra/**'
+
+permissions:
+  contents: read
+
+jobs:
+  check-tofu-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Check tofu fmt
+        shell: bash
+        run: |
+          if ! docker container run --rm \
+               -v ./infra:/infra \
+               --workdir /infra \
+               --entrypoint tofu \
+               ghcr.io/${{ github.repository }}/infra-dev:gitbranch-main-latest \
+               fmt -check -diff -recursive
+          then
+            echo 'ERROR: not all tofu files are correctly formatted'
+            exit 1
+          fi
+
+  check-tofu-provider-lock:
+    strategy:
+      matrix:
+        root_module:
+          - bloom_dev
+          - bloom_dev_deployer_permission_set_policy
+          # TODO: add once root mod is added: bloom_prod
+          - bloom_prod_deployer_permission_set_policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+
+      - name: Check tofu providers lock
+        shell: bash
+        run: |
+          if ! docker container run --rm \
+               -v ./infra:/infra \
+               --workdir /infra/tofu_root_modules/${{ matrix.root_module }} \
+               --entrypoint bash \
+               ghcr.io/${{ github.repository }}/infra-dev:gitbranch-main-latest \
+               -c 'sha256sum .terraform.lock.hcl > hash'
+          then
+            echo 'ERROR: recording sha256 of .terraform.lock.hcl failed'
+            exit 1
+          fi
+
+          if ! docker container run --rm \
+               -v ./infra:/infra \
+               --workdir /infra/tofu_root_modules/${{ matrix.root_module }} \
+               --entrypoint bash \
+               ghcr.io/${{ github.repository }}/infra-dev:gitbranch-main-latest \
+               -c 'tofu init -backend=false && tofu providers lock -platform=linux_amd64 -platform=linux_arm64 -platform=darwin_amd64 -platform=darwin_arm64'
+          then
+            echo 'ERROR: tofu providers lock did not run successfully'
+            exit 1
+          fi
+
+          if ! docker container run --rm \
+               -v ./infra:/infra \
+               --workdir /infra/tofu_root_modules/${{ matrix.root_module }} \
+               --entrypoint bash \
+               ghcr.io/${{ github.repository }}/infra-dev:gitbranch-main-latest \
+               -c 'sha256sum -c hash'
+          then
+            echo 'ERROR: .terraform.lock.hcl changed after running tofu providers lock'
+            exit 1
+          fi

--- a/.github/workflows/integration_tests_api.yml
+++ b/.github/workflows/integration_tests_api.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 env:
   PORT: 3100
   EMAIL_API_KEY: 'SG.SOME-LONG-SECRET-KEY'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 
 jobs:
   run-linters:

--- a/.github/workflows/missing-translations.yml
+++ b/.github/workflows/missing-translations.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 
 jobs:
   shared-helpers-unit:

--- a/.github/workflows/unit_tests_api.yml
+++ b/.github/workflows/unit_tests_api.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 env:
   APP_SECRET: 'SOME-LONG-SECRET-KEY'
   DATABASE_URL: postgres://bloom-dev:bloom@127.0.0.1:5432/bloom

--- a/.github/workflows/unit_tests_shared_helpers.yml
+++ b/.github/workflows/unit_tests_shared_helpers.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 
 jobs:
   shared-helpers-unit:

--- a/.github/workflows/unit_tests_sites_partners.yml
+++ b/.github/workflows/unit_tests_sites_partners.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 
 jobs:
   partners-unit:

--- a/.github/workflows/unit_tests_sites_public.yml
+++ b/.github/workflows/unit_tests_sites_public.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'infra/**'
 
 jobs:
   public-unit:

--- a/infra/DEVELOPMENT.md
+++ b/infra/DEVELOPMENT.md
@@ -56,14 +56,14 @@ docker container run --rm -it \
 -v ./infra:/infra:z \
 -v "${HOME}/.aws/cli":/home/.aws/cli:z \
 -v "${HOME}/.aws/sso/cache":/home/.aws/sso/cache:z \
-ghcr.io/bloom-housing/bloom/infra-dev \
+ghcr.io/bloom-housing/bloom/infra-dev:gitbranch-main-latest \
 [[--skip-sso] | [--skip-init]] <ROOT_MODULE_NAME> <OPEN_TOFU_ARGS>
 ```
 
 You may find it convenient to add an alias. From the root of the Bloom repo:
 
 ```bash
-alias bloomtofu="docker container run --rm -it --user $(id -u):$(id -g) -v ${PWD}/infra:/infra:z -v ${HOME}/.aws/cli:/home/.aws/cli:z -v ${HOME}/.aws/sso/cache:/home/.aws/sso/cache:z ghcr.io/bloom-housing/bloom/infra-dev"
+alias bloomtofu="docker container run --rm -it --user $(id -u):$(id -g) -v ${PWD}/infra:/infra:z -v ${HOME}/.aws/cli:/home/.aws/cli:z -v ${HOME}/.aws/sso/cache:/home/.aws/sso/cache:z ghcr.io/bloom-housing/bloom/infra-dev:gitbranch-main-latest"
 
 bloomtofu -ss -si bloom_dev apply
 ```

--- a/infra/Dockerfile.dev
+++ b/infra/Dockerfile.dev
@@ -42,6 +42,7 @@ RUN <<EOF
 dnf update -y
 dnf install -y shadow-utils # make groupadd and useradd available.
 dnf install -y openssl
+dnf install -y diffutils # used in the .github/workflows/infra_ci.yml check.
 dnf clean all # clean the dnf cache from the final image.
 EOF
 

--- a/sites/partners/netlify.toml
+++ b/sites/partners/netlify.toml
@@ -1,7 +1,14 @@
 [build]
 
 command = "yarn run build"
-ignore = "/bin/false"
+
+# From https://docs.netlify.com/build/configure-builds/ignore-builds/:
+#
+# > An exit code of 1 indicates the contents have changed and the build process continues as
+# > usual. An exit code of 0 indicates that there are no changes and the build should stop.
+#
+# Ignore builds for pull requsets with only infra changes.
+ignore = "if [[ $PULL_REQUEST == 'false' ]]; then exit 1; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ':(exclude)infra/'; fi"
 
 
 [build.environment]

--- a/sites/public/netlify.toml
+++ b/sites/public/netlify.toml
@@ -1,5 +1,13 @@
 [build]
 
+# From https://docs.netlify.com/build/configure-builds/ignore-builds/:
+#
+# > An exit code of 1 indicates the contents have changed and the build process continues as
+# > usual. An exit code of 0 indicates that there are no changes and the build should stop.
+#
+# Ignore builds for pull requsets with only infra changes.
+ignore = "if [[ $PULL_REQUEST == 'false' ]]; then exit 1; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ':(exclude)infra/'; fi"
+
 [build.environment]
 
 NODE_VERSION = "22.21.1"


### PR DESCRIPTION
## Description

- Adds infra specific CI checks
- Prevents JS CI checks from running on PRs that only have changes to infra/ files.
- Prevents Netlify PR preview builds for PRs that only have changes to infra/ files.
- Changes the docker image 'latest' tag to have the git branch name it was build from, so instead of multiple branches being able to push 'latest' tags, each branch pushes to 'gitbranch-<branch>-latest'. Note this causes the new infra CI actions to fail on this PR because this PR needs to be submitted before there a `infra-dev:gitbranch-main-latest` image is tagged.

## How Can This Be Tested/Reviewed?

I pushed to my fork then made 2 PRs. Each have the expected actions:

- PR with /infra change: https://github.com/avrittrohwer/bloom/pull/2
- PR with changes outside of /infra: https://github.com/avrittrohwer/bloom/pull/3
