### PR TITLE
fix: partners amenities and features

### DIFF
--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailAdditionalFees.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailAdditionalFees.tsx
@@ -3,7 +3,7 @@ import { t } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { ListingContext } from "../../ListingContext"
 import { getDetailFieldNumber, getDetailFieldString } from "./helpers"
-import { AuthContext } from "@bloom-housing/shared-helpers"
+import { AuthContext, listingUtilities } from "@bloom-housing/shared-helpers"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 import {
   EnumListingDepositType,
@@ -27,16 +27,18 @@ const DetailAdditionalFees = () => {
 
   const getUtilitiesIncluded = () => {
     let utilitiesExist = false
-    const utilities = Object.keys(listing?.listingUtilities ?? {}).map((utility) => {
-      if (listing?.listingUtilities[utility]) {
-        utilitiesExist = true
-        return (
-          <li key={utility} className={"list-disc mx-5 mb-1 md:w-1/3 w-full grow"}>
-            {t(`listings.utilities.${utility}`)}
-          </li>
-        )
-      }
-    })
+    const utilities = Object.keys(listing?.listingUtilities ?? {})
+      .filter((feature) => listingUtilities.includes(feature))
+      .map((utility) => {
+        if (listing?.listingUtilities[utility]) {
+          utilitiesExist = true
+          return (
+            <li key={utility} className={"list-disc mx-5 mb-1 md:w-1/3 w-full grow"}>
+              {t(`listings.utilities.${utility}`)}
+            </li>
+          )
+        }
+      })
     return utilitiesExist ? <ul className={"flex flex-wrap"}>{utilities}</ul> : <>{t("t.none")}</>
   }
 

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailBuildingFeatures.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailBuildingFeatures.tsx
@@ -3,7 +3,7 @@ import { t } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { ListingContext } from "../../ListingContext"
 import { getDetailFieldString } from "./helpers"
-import { AuthContext } from "@bloom-housing/shared-helpers"
+import { AuthContext, listingFeatures } from "@bloom-housing/shared-helpers"
 import SectionWithGrid from "../../../shared/SectionWithGrid"
 import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
@@ -13,16 +13,18 @@ const DetailBuildingFeatures = () => {
 
   const getAccessibilityFeatures = () => {
     let featuresExist = false
-    const features = Object.keys(listing?.listingFeatures ?? {}).map((feature) => {
-      if (listing?.listingFeatures[feature]) {
-        featuresExist = true
-        return (
-          <li className={"list-disc mx-5 mb-1 md:w-1/3 w-full grow"} key={feature}>
-            {t(`eligibility.accessibility.${feature}`)}
-          </li>
-        )
-      }
-    })
+    const features = Object.keys(listing?.listingFeatures ?? {})
+      .filter((feature) => listingFeatures.includes(feature))
+      .map((feature) => {
+        if (listing?.listingFeatures[feature]) {
+          featuresExist = true
+          return (
+            <li className={"list-disc mx-5 mb-1 md:w-1/3 w-full grow"} key={feature}>
+              {t(`eligibility.accessibility.${feature}`)}
+            </li>
+          )
+        }
+      })
     return featuresExist ? <ul className={"flex flex-wrap"}>{features}</ul> : <>{t("t.none")}</>
   }
 


### PR DESCRIPTION
This PR addresses #5738

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

On the partners details pages, the accessibility features and unit features should not show the object values.

## How Can This Be Tested/Reviewed?

These are screenshots from prod:
<img width="594" height="151" alt="Screenshot 2026-01-07 at 1 48 00 PM" src="https://github.com/user-attachments/assets/6203f0e0-2590-45c6-9384-ee4ef571ef76" />
<img width="650" height="144" alt="Screenshot 2026-01-07 at 1 48 05 PM" src="https://github.com/user-attachments/assets/ab734724-c3b3-4c96-9ab3-993ef7c26e88" />

Ensure these sections on a listing never show the object values on the partners detail pages (you can use the [partner deploy preview](https://deploy-preview-5743--partners-bloom-dev.netlify.app/)).


## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
