### PR TITLE
fix: media query precedence issue

### DIFF
--- a/sites/public/src/patterns/SiteHeader.module.scss
+++ b/sites/public/src/patterns/SiteHeader.module.scss
@@ -144,15 +144,15 @@
       }
 
       .links-container-desktop {
-        @media (--sm-only) {
-          display: none;
-        }
         display: flex;
         flex-direction: row;
         align-items: flex-end;
         flex-wrap: wrap;
         margin-inline-start: auto;
         justify-content: flex-end;
+        @media (--sm-only) {
+          display: none;
+        }
       }
       .links-container-mobile {
         display: none;


### PR DESCRIPTION
## Description

After the upgrade to SASS, we need to ensure that media queries that target specific styles always come after the default styles, as the way precedence is calculated has changed.

We have one instance in order where the ordering was incorrect, leading to the mobile site header still showing the desktop links and look like the following:
<img width="474" height="294" alt="Screenshot 2026-01-12 at 11 37 48 AM" src="https://github.com/user-attachments/assets/79396a1a-6494-4a38-a4b0-3aef1c08a13e" />

## How Can This Be Tested/Reviewed?

Ensure on mobile, the desktop links do not show in the site header (you can check the [deploy preview](https://deploy-preview-5759--bloom-public-seeds.netlify.app/))

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
