### PR TITLE
feat: make aws_profile optional in bloom_deployment input parameters

### DIFF
--- a/infra/tofu_importable_modules/bloom_deployment/ecs.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs.tf
@@ -67,7 +67,7 @@ resource "aws_secretsmanager_secret" "api_jwt_signing_key" {
     fi
 
     if ! aws secretsmanager put-secret-value \
-         --profile ${var.aws_profile} \
+         ${var.aws_profile != "" ? "--profile ${var.aws_profile}" : ""} \
          --region ${var.aws_region} \
          --secret-id ${self.id} \
          --secret-string "$s"

--- a/infra/tofu_importable_modules/bloom_deployment/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/main.tf
@@ -9,7 +9,8 @@ terraform {
 
 variable "aws_profile" {
   type        = string
-  description = "AWS CLI profile to use when running aws commands in local-exec provisioners."
+  description = "Optional AWS CLI profile to use when running aws commands in local-exec provisioners. IMPORTANT: if not specified, you must authenticate the AWS CLI some other way like with environment variables."
+  default     = ""
 }
 variable "aws_account_number" {
   type        = number


### PR DESCRIPTION
This PR addresses #[5764](https://github.com/bloom-housing/bloom/issues/5764)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Makes the `aws_profile` input parameter in tofu_importable_modules/bloom_deployment optional.  LA will use environment variables to configure the AWS CLI credentials.

## How Can This Be Tested/Reviewed?

I tested on a branch in the bloom-exygy fork: https://github.com/bloom-housing/bloom-exygy/compare/main...bloom-housing:bloom-exygy:avritt/profile-test.

On the bloom_dev root module, I ran `tofu apply -replace=module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key` in 3 testing scenarios:

1. Still passed the `aws_profile`:

  Local exec passed --profile in aws cli and it succeeded:

```
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): Executing: ["/usr/bin/env" "bash" "-c" "if ! type -P aws &>/dev/null; then\n  echo 'ERROR: aws required'\n  exit 1\nfi\nif ! type -P openssl &>/dev/null; then\n  echo 'ERROR: openssl required'\n  exit 1\nfi\nif ! type -P tr &>/dev/null; then\n  echo 'ERROR: tr required'\n  exit 1\nfi\n\nif ! s=$(openssl rand -base64 256 | tr -d '\\n'); then\n    echo 'ERROR: failed to generate random value'\n    exit 1\nfi\n\nif ! aws secretsmanager put-secret-value \\\n     --profile bloom-dev-deployer \\\n     --region us-west-2 \\\n     --secret-id arn:aws:secretsmanager:us-west-2:242477209009:secret:bloom-api-jwt-signing-key20260114033101387200000001-fcEYEU \\\n     --secret-string \"$s\"\nthen\n    echo 'ERROR: failed to put secret value'\n    exit 1\nfi\n"]
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): {
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "ARN": "arn:aws:secretsmanager:us-west-2:242477209009:secret:bloom-api-jwt-signing-key20260114033101387200000001-fcEYEU",
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "Name": "bloom-api-jwt-signing-key20260114033101387200000001",
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "VersionId": "69fb8be7-c94e-41dc-99f3-c0f8590ec59c",
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "VersionStages": [
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):         "AWSCURRENT"
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     ]
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): }
``` 


3. Did not pass in `aws_profile`, did not set AWS environment variables:

  Local exec did not pass in --profile and aws cli failed:

```
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): Executing: ["/usr/bin/env" "bash" "-c" "if ! type -P aws &>/dev/null; then\n  echo 'ERROR: aws required'\n  exit 1\nfi\nif ! type -P openssl &>/dev/null; then\n  echo 'ERROR: openssl required'\n  exit 1\nfi\nif ! type -P tr &>/dev/null; then\n  echo 'ERROR: tr required'\n  exit 1\nfi\n\nif ! s=$(openssl rand -base64 256 | tr -d '\\n'); then\n    echo 'ERROR: failed to generate random value'\n    exit 1\nfi\n\nif ! aws secretsmanager put-secret-value \\\n      \\\n     --region us-west-2 \\\n     --secret-id arn:aws:secretsmanager:us-west-2:242477209009:secret:bloom-api-jwt-signing-key20260114034009296700000001-DyZwcF \\\n     --secret-string \"$s\"\nthen\n    echo 'ERROR: failed to put secret value'\n    exit 1\nfi\n"]

module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): Unable to locate credentials. You can configure credentials by running "aws login".
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): ERROR: failed to put secret value
```

4. Did not pass in `aws_profile`, set AWS_PROFILE:
   
  Local exec did not pass in --profile and aws cli succeeded:

```
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): Executing: ["/usr/bin/env" "bash" "-c" "if ! type -P aws &>/dev/null; then\n  echo 'ERROR: aws required'\n  exit 1\nfi\nif ! type -P openssl &>/dev/null; then\n  echo 'ERROR: openssl required'\n  exit 1\nfi\nif ! type -P tr &>/dev/null; then\n  echo 'ERROR: tr required'\n  exit 1\nfi\n\nif ! s=$(openssl rand -base64 256 | tr -d '\\n'); then\n    echo 'ERROR: failed to generate random value'\n    exit 1\nfi\n\nif ! aws secretsmanager put-secret-value \\\n      \\\n     --region us-west-2 \\\n     --secret-id arn:aws:secretsmanager:us-west-2:242477209009:secret:bloom-api-jwt-signing-key20260114034146697000000001-1hjLnS \\\n     --secret-string \"$s\"\nthen\n    echo 'ERROR: failed to put secret value'\n    exit 1\nfi\n"]
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): {
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "ARN": "arn:aws:secretsmanager:us-west-2:242477209009:secret:bloom-api-jwt-signing-key20260114034146697000000001-1hjLnS",
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "Name": "bloom-api-jwt-signing-key20260114034146697000000001",
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "VersionId": "c6404979-97ed-4848-b3ff-553c27ea6cf5",
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     "VersionStages": [
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):         "AWSCURRENT"
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec):     ]
module.bloom_deployment.aws_secretsmanager_secret.api_jwt_signing_key (local-exec): }
```

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
