### PR TITLE
fix: remove flakiness from property test

### DIFF
--- a/api/src/services/multiselect-question.service.ts
+++ b/api/src/services/multiselect-question.service.ts
@@ -157,7 +157,6 @@ export class MultiselectQuestionService {
             })),
           });
         } else if (filter[MultiselectQuestionFilterKeys.status]) {
-          console.log(filter[MultiselectQuestionFilterKeys.status]);
           const builtFilter = buildFilter({
             $comparison: filter.$comparison,
             $include_nulls: false,

--- a/api/test/integration/property.e2e-spec.ts
+++ b/api/test/integration/property.e2e-spec.ts
@@ -112,10 +112,16 @@ describe('Properties Controller Tests', () => {
 
       expect(res.body.items.length).toBeGreaterThanOrEqual(2);
 
+      // The two expected properties might not be in the response because other tests could add more properties and
+      // make it so there are more than 10 meaning these two properties might be on page 2
       expect(res.body.items).toEqual(
         expect.arrayContaining([
-          expect.objectContaining(mockProperties[0]),
-          expect.objectContaining(mockProperties[1]),
+          expect.objectContaining({
+            name: expect.anything(),
+            description: expect.anything(),
+            url: expect.anything(),
+            urlTitle: expect.anything(),
+          }),
         ]),
       );
       expect(res.body.meta).toEqual(


### PR DESCRIPTION
This PR addresses failing CI job

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Occasionally the `property.e2e.spec.ts` fails when running in CI. [Example of it failing](https://github.com/bloom-housing/bloom/actions/runs/20938748541/job/60167952323?pr=5654). This is because we are checking for the two properties created in the test suite however there can be properties created in other tests. Specifically this test can fail because we are not passing any parameters meaning all properties in the system are returned but only the first page of 10. So if there are more than 10 properties the two properties we are testing for might be on page two and not returned.

The fix is to just make sure at least 2 are returned and the returned object has the correct fields but not for the values within those fields. The other tests in this file already validate specific properties are returned with passed in parameters

## How Can This Be Tested/Reviewed?

The full e2e test suite should run successfully

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
