### PR TITLE
fix: set non regulated flag on draft listings

### DIFF
--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -263,7 +263,7 @@ const ListingForm = ({
   )
 
   useEffect(() => {
-    if (enableNonRegulatedListings && isNonRegulated) {
+    if (enableNonRegulatedListings) {
       setValue(
         "listingType",
         isNonRegulated ? ListingTypeEnum.nonRegulated : ListingTypeEnum.regulated


### PR DESCRIPTION
## Description

On draft regulated listings in Lakeview, the listing type is coming through as undefined, so checks that the type should be regulated are failing when they should pass.

## How Can This Be Tested/Reviewed?

One way you can ensure the proper value is coming through is that a draft Lakeview listing should still show the Year built field (it currently is not).

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
