### PR TITLE
fix: add image description for listings page listing card

### DIFF
--- a/sites/public/src/components/browse/ListingCard.tsx
+++ b/sites/public/src/components/browse/ListingCard.tsx
@@ -156,7 +156,9 @@ export const ListingCard = ({
                 className={styles["image-background"]}
                 style={{ backgroundImage: `url(${imageUrl})` }}
                 role="img"
-                aria-label={t("listings.buildingImageAltText")}
+                aria-label={
+                  listing.listingImages?.[0]?.description || t("listings.buildingImageAltText")
+                }
               />
             </div>
           </div>


### PR DESCRIPTION
This PR addresses #5600 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

It's a fix from comment, adding descriptions for listings list images

## How Can This Be Tested/Reviewed?

For angelopolis use screen reader while focusing on image on public `/listings` page. It should read custom alt text set on partners. If it has no alt text (so other jurisdictions) it should still read `A picture of a building`

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
