### PR TITLE
fix: no amenities configured should not appear

### DIFF
--- a/sites/partners/__tests__/components/listings/PaperListingDetails/sections/DetailNeighborhoodAmenities.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingDetails/sections/DetailNeighborhoodAmenities.test.tsx
@@ -1,0 +1,240 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { AuthContext } from "@bloom-housing/shared-helpers"
+import { listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import {
+  FeatureFlagEnum,
+  Jurisdiction,
+  ListingNeighborhoodAmenities,
+  NeighborhoodAmenitiesEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { ListingContext } from "../../../../../src/components/listings/ListingContext"
+import DetailNeighborhoodAmenities from "../../../../../src/components/listings/PaperListingDetails/sections/DetailNeighborhoodAmenities"
+
+import * as hooks from "../../../../../src/lib/hooks"
+
+jest.mock("../../../../../src/lib/hooks")
+
+const mockUseJurisdiction = hooks.useJurisdiction as jest.MockedFunction<
+  typeof hooks.useJurisdiction
+>
+
+type mockUseJurisdictionReturnValue = {
+  data: Jurisdiction
+  loading: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error: any
+}
+
+describe("DetailNeighborhoodAmenities", () => {
+  beforeEach(() => {
+    mockUseJurisdiction.mockReturnValue({
+      data: {
+        visibleNeighborhoodAmenities: [
+          NeighborhoodAmenitiesEnum.groceryStores,
+          NeighborhoodAmenitiesEnum.publicTransportation,
+          NeighborhoodAmenitiesEnum.schools,
+        ],
+      },
+    } as mockUseJurisdictionReturnValue)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should not render when enableNeighborhoodAmenities feature flag is off", () => {
+    const { container } = render(
+      <AuthContext.Provider
+        value={{
+          doJurisdictionsHaveFeatureFlagOn: () => false,
+        }}
+      >
+        <ListingContext.Provider value={{ ...listing }}>
+          <DetailNeighborhoodAmenities />
+        </ListingContext.Provider>
+      </AuthContext.Provider>
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("should not render when no visible amenities are configured, even if data exists", () => {
+    mockUseJurisdiction.mockReturnValue({
+      data: {
+        visibleNeighborhoodAmenities: [],
+      },
+    } as mockUseJurisdictionReturnValue)
+
+    const { container } = render(
+      <AuthContext.Provider
+        value={{
+          doJurisdictionsHaveFeatureFlagOn: (flag) =>
+            flag === FeatureFlagEnum.enableNeighborhoodAmenities,
+        }}
+      >
+        <ListingContext.Provider
+          value={{
+            ...listing,
+            listingNeighborhoodAmenities: {
+              groceryStores: "0.5 miles",
+              publicTransportation: "2 blocks",
+              schools: "1 mile",
+            } as ListingNeighborhoodAmenities,
+          }}
+        >
+          <DetailNeighborhoodAmenities />
+        </ListingContext.Provider>
+      </AuthContext.Provider>
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("should render visible amenities with their values", () => {
+    render(
+      <AuthContext.Provider
+        value={{
+          doJurisdictionsHaveFeatureFlagOn: (flag) =>
+            flag === FeatureFlagEnum.enableNeighborhoodAmenities,
+        }}
+      >
+        <ListingContext.Provider
+          value={{
+            ...listing,
+            listingNeighborhoodAmenities: {
+              groceryStores: "0.5 miles",
+              publicTransportation: "2 blocks",
+              schools: "1 mile",
+            } as ListingNeighborhoodAmenities,
+          }}
+        >
+          <DetailNeighborhoodAmenities />
+        </ListingContext.Provider>
+      </AuthContext.Provider>
+    )
+
+    expect(screen.getByText("Neighborhood amenities")).toBeInTheDocument()
+    expect(screen.getByText("Grocery stores")).toBeInTheDocument()
+    expect(screen.getByText("0.5 miles")).toBeInTheDocument()
+    expect(screen.getByText("Public transportation")).toBeInTheDocument()
+    expect(screen.getByText("2 blocks")).toBeInTheDocument()
+    expect(screen.getByText("Schools")).toBeInTheDocument()
+    expect(screen.getByText("1 mile")).toBeInTheDocument()
+  })
+
+  it("should render 'None' for amenities without values", () => {
+    render(
+      <AuthContext.Provider
+        value={{
+          doJurisdictionsHaveFeatureFlagOn: (flag) =>
+            flag === FeatureFlagEnum.enableNeighborhoodAmenities,
+        }}
+      >
+        <ListingContext.Provider
+          value={{
+            ...listing,
+            listingNeighborhoodAmenities: {
+              groceryStores: "0.5 miles",
+              publicTransportation: "",
+              schools: null,
+            } as ListingNeighborhoodAmenities,
+          }}
+        >
+          <DetailNeighborhoodAmenities />
+        </ListingContext.Provider>
+      </AuthContext.Provider>
+    )
+
+    expect(screen.getByText("Grocery stores")).toBeInTheDocument()
+    expect(screen.getByText("0.5 miles")).toBeInTheDocument()
+    expect(screen.getByText("Public transportation")).toBeInTheDocument()
+    expect(screen.getByText("Schools")).toBeInTheDocument()
+    const noneTexts = screen.getAllByText("None")
+    expect(noneTexts.length).toBe(2)
+  })
+
+  it("should only render amenities that are in the visible list", () => {
+    mockUseJurisdiction.mockReturnValue({
+      data: {
+        visibleNeighborhoodAmenities: [NeighborhoodAmenitiesEnum.groceryStores],
+      },
+    } as mockUseJurisdictionReturnValue)
+    render(
+      <AuthContext.Provider
+        value={{
+          doJurisdictionsHaveFeatureFlagOn: (flag) =>
+            flag === FeatureFlagEnum.enableNeighborhoodAmenities,
+        }}
+      >
+        <ListingContext.Provider
+          value={{
+            ...listing,
+            listingNeighborhoodAmenities: {
+              groceryStores: "0.5 miles",
+              publicTransportation: "2 blocks",
+              schools: "1 mile",
+              pharmacies: "0.3 miles",
+            } as ListingNeighborhoodAmenities,
+          }}
+        >
+          <DetailNeighborhoodAmenities />
+        </ListingContext.Provider>
+      </AuthContext.Provider>
+    )
+
+    expect(screen.getByText("Grocery stores")).toBeInTheDocument()
+    expect(screen.queryByText("Public transportation")).not.toBeInTheDocument()
+    expect(screen.queryByText("Schools")).not.toBeInTheDocument()
+    expect(screen.queryByText("Pharmacies")).not.toBeInTheDocument()
+  })
+
+  it("should render all configured visible amenities from jurisdiction", () => {
+    mockUseJurisdiction.mockReturnValue({
+      data: {
+        visibleNeighborhoodAmenities: [
+          NeighborhoodAmenitiesEnum.groceryStores,
+          NeighborhoodAmenitiesEnum.publicTransportation,
+          NeighborhoodAmenitiesEnum.schools,
+          NeighborhoodAmenitiesEnum.parksAndCommunityCenters,
+          NeighborhoodAmenitiesEnum.pharmacies,
+        ],
+      },
+    } as mockUseJurisdictionReturnValue)
+
+    render(
+      <AuthContext.Provider
+        value={{
+          doJurisdictionsHaveFeatureFlagOn: (flag) =>
+            flag === FeatureFlagEnum.enableNeighborhoodAmenities,
+        }}
+      >
+        <ListingContext.Provider
+          value={{
+            ...listing,
+            listingNeighborhoodAmenities: {
+              groceryStores: "Close",
+              publicTransportation: "Very close",
+              schools: "Medium",
+              parksAndCommunityCenters: "Far",
+              pharmacies: null,
+            } as ListingNeighborhoodAmenities,
+          }}
+        >
+          <DetailNeighborhoodAmenities />
+        </ListingContext.Provider>
+      </AuthContext.Provider>
+    )
+
+    expect(screen.getByText("Grocery stores")).toBeInTheDocument()
+    expect(screen.getByText("Close")).toBeInTheDocument()
+    expect(screen.getByText("Public transportation")).toBeInTheDocument()
+    expect(screen.getByText("Very close")).toBeInTheDocument()
+    expect(screen.getByText("Schools")).toBeInTheDocument()
+    expect(screen.getByText("Medium")).toBeInTheDocument()
+    expect(screen.getByText("Parks and community centers")).toBeInTheDocument()
+    expect(screen.getByText("Far")).toBeInTheDocument()
+    expect(screen.getByText("Pharmacies")).toBeInTheDocument()
+    expect(screen.getByText("None")).toBeInTheDocument()
+  })
+})

--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailNeighborhoodAmenities.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailNeighborhoodAmenities.tsx
@@ -29,34 +29,26 @@ const DetailNeighborhoodAmenities = () => {
     )
   }, [jurisdictionData?.visibleNeighborhoodAmenities])
 
-  if (!enableNeighborhoodAmenities) {
+  if (!enableNeighborhoodAmenities || visibleAmenities.length === 0) {
     return <></>
   }
 
   return (
     <SectionWithGrid heading={t("listings.sections.neighborhoodAmenitiesTitle")} inset>
-      {visibleAmenities.length === 0 ? (
-        <Grid.Row>
-          <Grid.Cell>{t("t.none")}</Grid.Cell>
-        </Grid.Row>
-      ) : (
-        <>
-          {visibleAmenities.map((amenity) => {
-            return (
-              <Grid.Row key={amenity}>
-                <Grid.Cell>
-                  <FieldValue
-                    id={`neighborhoodAmenities.${amenity}`}
-                    label={t(`listings.amenities.${amenity}`)}
-                  >
-                    {getDetailFieldString(listing.listingNeighborhoodAmenities?.[amenity])}
-                  </FieldValue>
-                </Grid.Cell>
-              </Grid.Row>
-            )
-          })}
-        </>
-      )}
+      {visibleAmenities.map((amenity) => {
+        return (
+          <Grid.Row key={amenity}>
+            <Grid.Cell>
+              <FieldValue
+                id={`neighborhoodAmenities.${amenity}`}
+                label={t(`listings.amenities.${amenity}`)}
+              >
+                {getDetailFieldString(listing.listingNeighborhoodAmenities?.[amenity])}
+              </FieldValue>
+            </Grid.Cell>
+          </Grid.Row>
+        )
+      })}
     </SectionWithGrid>
   )
 }


### PR DESCRIPTION
This PR addresses #5822

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

If there are no neighborhood amenities configured on the jurisdiction, the section is blank but it should not appear.

## How Can This Be Tested/Reviewed?

Example before:
<img width="873" height="264" alt="Screenshot 2026-02-02 at 11 34 33 AM" src="https://github.com/user-attachments/assets/f6ce117d-d87e-4327-ae46-919de3e3792f" />

I have fixed deployed envs but locally manually removed the jurisdiction config in the db.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
