### PR TITLE
fix: allow copy with marketing flyers

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -1868,8 +1868,13 @@ export class ListingService implements OnModuleInit {
         id: question.multiselectQuestionId,
         ordinal: question.ordinal,
       })),
-      listingsMarketingFlyerFile,
-      listingsAccessibleMarketingFlyerFile,
+      listingsMarketingFlyerFile: mappedListing.listingsMarketingFlyerFile
+        ? listingsMarketingFlyerFile
+        : undefined,
+      listingsAccessibleMarketingFlyerFile:
+        mappedListing.listingsAccessibleMarketingFlyerFile
+          ? listingsAccessibleMarketingFlyerFile
+          : undefined,
       lotteryLastRunAt: undefined,
       lotteryLastPublishedAt: undefined,
       lotteryStatus: undefined,


### PR DESCRIPTION
This PR addresses #5826

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

You're currently unable to copy a listing that has marketing flyers attached and it's throwing a unique ID constraint.

## How Can This Be Tested/Reviewed?

We needed to recreate the flyers as we do for other assets. Locally, add both flyers as a PDF upload to an Angelopolis listing and copy the listing. Ensure the copy succeeds.

When the Angelopolis Cypress test PR goes in, I'll add a listing copy to the end of those tests which should be a very minimal amount of time.

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
