### PR TITLE
feat: add search and pagination features to new Preferences table

### DIFF
--- a/sites/partners/src/lib/hooks.ts
+++ b/sites/partners/src/lib/hooks.ts
@@ -428,12 +428,14 @@ export function useJurisdictionalMultiselectQuestionList(
     orderDir: OrderByEnum[]
     search?: string
     limit?: number
+    page?: number
   } = {
     filter: [],
     orderBy: [],
     orderDir: [],
     search: undefined,
     limit: undefined,
+    page: undefined,
   }
   params.filter.push({
     $comparison: EnumMultiselectQuestionFilterParamsComparison["IN"],
@@ -461,6 +463,9 @@ export function useJurisdictionalMultiselectQuestionList(
   }
   if (tableSettings?.limit) {
     params.limit = tableSettings.limit
+  }
+  if (tableSettings?.page) {
+    params.page = tableSettings.page
   }
   if (applicationSection) {
     params.filter.push({

--- a/sites/partners/src/pages/settings/multiselectquestions/preferences.tsx
+++ b/sites/partners/src/pages/settings/multiselectquestions/preferences.tsx
@@ -181,8 +181,8 @@ const MultiselectQuestionsPreferences = () => {
                 data={{
                   items,
                   loading: loading,
-                  totalItems: items.length, // TODO
-                  totalPages: 1, // TODO
+                  totalItems: data?.meta?.totalItems,
+                  totalPages: data?.meta?.totalPages,
                 }}
                 search={{
                   setSearch: tableOptions.filter.setFilterValue,


### PR DESCRIPTION
This PR addresses #5648 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The MSGV2 preferences table now can sort by the various columns as well as allow searching by preference name.

## How Can This Be Tested/Reviewed?

It's sort of hard to test the pagination without adding lots of preferences, but you can also modify line 132 in sites/partners/src/pages/settings/multiselectquestions/preferences.tsx like so:

```js
limit: tableOptions.pagination.itemsPerPage - 6,
```

to show only 2 items per page, etc.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
