### PR TITLE
feat: add advocate tab on partners users

### DIFF
--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -201,6 +201,7 @@ export const stagingSeed = async (
         FeatureFlagEnum.enableApplicationStatus,
         FeatureFlagEnum.enableConfigurableRegions,
         FeatureFlagEnum.enableCreditScreeningFee,
+        FeatureFlagEnum.enableHousingAdvocate,
         FeatureFlagEnum.enableHousingDeveloperOwner,
         FeatureFlagEnum.enableLeasingAgentAltText,
         FeatureFlagEnum.enableListingFileNumber,

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -18,6 +18,7 @@ export enum FeatureFlagEnum {
   enableGeocodingPreferences = 'enableGeocodingPreferences',
   enableGeocodingRadiusMethod = 'enableGeocodingRadiusMethod',
   enableHomeType = 'enableHomeType',
+  enableHousingAdvocate = 'enableHousingAdvocate',
   enableHousingDeveloperOwner = 'enableHousingDeveloperOwner',
   enableIsVerified = 'enableIsVerified',
   enableLimitedHowDidYouHear = 'enableLimitedHowDidYouHear',
@@ -141,6 +142,10 @@ export const featureFlagMap: {
   {
     name: FeatureFlagEnum.enableHomeType,
     description: 'When true, home type feature is turned on',
+  },
+  {
+    name: FeatureFlagEnum.enableHousingAdvocate,
+    description: 'When true, partners can view housing advocate users',
   },
   {
     name: FeatureFlagEnum.enableHousingDeveloperOwner,

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -9464,6 +9464,7 @@ export enum FeatureFlagEnum {
   "enableGeocodingPreferences" = "enableGeocodingPreferences",
   "enableGeocodingRadiusMethod" = "enableGeocodingRadiusMethod",
   "enableHomeType" = "enableHomeType",
+  "enableHousingAdvocate" = "enableHousingAdvocate",
   "enableHousingDeveloperOwner" = "enableHousingDeveloperOwner",
   "enableIsVerified" = "enableIsVerified",
   "enableLimitedHowDidYouHear" = "enableLimitedHowDidYouHear",

--- a/sites/partners/page_content/locale_overrides/general.json
+++ b/sites/partners/page_content/locale_overrides/general.json
@@ -751,6 +751,8 @@
   "users.requestResend": "Request resend",
   "users.requestResendDescription": "Your token expired. You will need to have a new confirmation link sent to you.",
   "users.requestResendExplanation": "Please enter your email, and we'll send you a new confirmation link",
+  "users.tabAdvocatesPublic": "Advocates (Public)",
+  "users.tabPartners": "Partners",
   "users.resendInvite": "Resend invite",
   "users.totalUsers": "total users",
   "users.unconfirmed": "Unconfirmed",

--- a/sites/partners/src/components/users/UsersViewHelpers.tsx
+++ b/sites/partners/src/components/users/UsersViewHelpers.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import { NextRouter } from "next/router"
+import { t } from "@bloom-housing/ui-components"
+import { Tabs } from "@bloom-housing/ui-seeds"
+
+export enum UsersIndexEnum {
+  partners = 0,
+  advocates,
+}
+
+export const getUsersTabs = (selectedIndex: UsersIndexEnum, router: NextRouter) => {
+  return (
+    <Tabs
+      verticalSidebar
+      onSelect={(index) => {
+        void router.push(index === UsersIndexEnum.partners ? "/users" : "/users/advocates")
+      }}
+      selectedIndex={selectedIndex}
+    >
+      <Tabs.TabList>
+        <Tabs.Tab data-testid="users-partners-tab">
+          <span>{t("users.tabPartners")}</span>
+        </Tabs.Tab>
+        <Tabs.Tab data-testid="users-advocates-tab">
+          <span>{t("users.tabAdvocatesPublic")}</span>
+        </Tabs.Tab>
+      </Tabs.TabList>
+    </Tabs>
+  )
+}

--- a/sites/partners/src/pages/users/advocates.tsx
+++ b/sites/partners/src/pages/users/advocates.tsx
@@ -1,0 +1,40 @@
+import React, { useContext } from "react"
+import Head from "next/head"
+import { useRouter } from "next/router"
+import { t } from "@bloom-housing/ui-components"
+import { AuthContext } from "@bloom-housing/shared-helpers"
+import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import Layout from "../../layouts"
+import { NavigationHeader } from "../../components/shared/NavigationHeader"
+import TabView from "../../layouts/TabView"
+import { getUsersTabs, UsersIndexEnum } from "../../components/users/UsersViewHelpers"
+
+const Advocates = () => {
+  const { doJurisdictionsHaveFeatureFlagOn } = useContext(AuthContext)
+  const router = useRouter()
+
+  const enableHousingAdvocate = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableHousingAdvocate
+  )
+
+  return (
+    <Layout>
+      <Head>
+        <title>{`Users - ${t("users.tabAdvocatesPublic")} - ${t("nav.siteTitlePartners")}`}</title>
+      </Head>
+      <NavigationHeader className="relative" title={t("nav.users")} />
+      <TabView
+        hideTabs={!enableHousingAdvocate}
+        tabs={getUsersTabs(UsersIndexEnum.advocates, router)}
+      >
+        <section>
+          <article className="flex-row flex-wrap relative max-w-screen-xl mx-auto py-8 px-4">
+            TODO
+          </article>
+        </section>
+      </TabView>
+    </Layout>
+  )
+}
+
+export default Advocates


### PR DESCRIPTION
This PR addresses #5724

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds dummy Advocate tab on partners  `/users`

## How Can This Be Tested/Reviewed?

Switch `enableHousingAdvocate` flag, now on partners `/users` should show additional tab.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
