### PR TITLE
fix: pass properly applicant name to application update email template

### DIFF
--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -511,10 +511,8 @@ export class EmailService {
       jurisdiction.emailFromAddress,
       subject,
       this.template('application-update')({
-        appOptions: {
-          listingName: listing.name,
-          applicantName,
-        },
+        appOptions: { listingName: listing.name },
+        applicantName,
         summaryItems,
         loginUrl,
         contactEmail: contactEmail,


### PR DESCRIPTION
This PR addresses #5534

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

I changed approach in displaying applicantName last minute in #5534, but i forgot to pass it properly as a different key.
This one fixes that so we can send email without name that does not look like `Hello ,` but `Hello,`

## How Can This Be Tested/Reviewed?

Same as [this](https://github.com/bloom-housing/bloom/pull/5817) but fill firstName or lastName, or both

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
