### PR TITLE
fix: property optional

### DIFF
--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -326,9 +326,9 @@ export const ListingViewSeeds = ({ listing, jurisdiction, profile, preview }: Li
           {isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableProperties) && (
             <PropertyDetailsCard
               heading={t("listings.propertyCardTitle")}
-              linkText={listing.property.urlTitle}
-              linkUrl={listing.property.url}
-              propertyDescription={listing.property.description}
+              linkText={listing.property?.urlTitle}
+              linkUrl={listing.property?.url}
+              propertyDescription={listing.property?.description}
             />
           )}
           <Availability listing={listing} jurisdiction={jurisdiction} />

--- a/sites/public/src/components/listing/listing_sections/MainDetails.tsx
+++ b/sites/public/src/components/listing/listing_sections/MainDetails.tsx
@@ -213,9 +213,9 @@ export const MainDetails = ({
         {isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableProperties) && (
           <PropertyDetailsCard
             heading={t("listings.propertyCardTitle")}
-            linkText={property.urlTitle}
-            linkUrl={property.url}
-            propertyDescription={property.description}
+            linkText={property?.urlTitle}
+            linkUrl={property?.url}
+            propertyDescription={property?.description}
           />
         )}
         <Availability listing={listing} jurisdiction={jurisdiction} />


### PR DESCRIPTION
Follow up to [this PR](https://github.com/bloom-housing/bloom/pull/5856) to allow listings to load without a property