### PR TITLE
chore: create more disk space for docker compose CI

### DIFF
--- a/.github/workflows/docker_compose_ci.yml
+++ b/.github/workflows/docker_compose_ci.yml
@@ -18,6 +18,16 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v6
 
+      # Blame claude if this messes with stuff
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /usr/local/share/boost
+          sudo docker image prune --all --force
+
       - name: build
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Attempt to fix recent flakiness in docker compose CI action: https://github.com/bloom-housing/bloom/actions/workflows/docker_compose_ci.yml.

Runs are failing with `Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20260212-220158-utc.log' `: https://github.com/bloom-housing/bloom/actions/runs/21965943732