### PR TITLE
fix: fix aws deployment guide diagram styling

### DIFF
--- a/infra/aws_deployment_guide/6_apply_bloom_deployment_tofu_modules.md
+++ b/infra/aws_deployment_guide/6_apply_bloom_deployment_tofu_modules.md
@@ -85,7 +85,7 @@ graph TB
   class LEGEND legendStyle
 
   %% Apply terraform style (green)
-  class CREATED,DEV,VPC_DEV,RDS_DEV,ELB_DEV,ECS_DEV,PROD,VPC_PROD,RDS_PROD,ELB_PROD,ECS_PROD tofu
+  class CREATED,VPC_DEV,RDS_DEV,ELB_DEV,ECS_DEV,VPC_PROD,RDS_PROD,ELB_PROD,ECS_PROD tofu
 ```
 
 ## Required permissions


### PR DESCRIPTION
## Description

Fix diagram styling. The AWS accounts are not created by terraform.
