### PR TITLE
fix: docker compose ci: use un-cached build, add API smoke test, add missing error exits

### DIFF
--- a/.github/workflows/docker_compose_ci.yml
+++ b/.github/workflows/docker_compose_ci.yml
@@ -60,6 +60,21 @@ jobs:
             exit 1
           fi
 
+      - name: api-smoke-test
+        shell: bash
+        run: |
+          if ! docker compose up --wait api
+          then
+            echo 'ERROR: api did not start successfully. Logs:'
+            docker compose logs api
+            exit 1
+          fi
+
+          if ! docker compose down; then
+            echo 'ERROR: docker compose down failed'
+            exit 1
+          fi
+
       - name: dbreadonlycheck
         shell: bash
         run: |


### PR DESCRIPTION
## Description

1. Adds `--no-cache` to build step. Addresses an issue with the dbinit image using an out-of-date check script.  I think this is due to image layer caching (https://github.com/bloom-housing/bloom/actions/runs/22082647627/job/63810841839?pr=5881).
2. Adds API smoke test. This prevents issues with the API from being surfaced in the dbreadonlycheck step: https://github.com/bloom-housing/bloom/actions/runs/22082647627/job/63810841839?pr=5881
3. Adds missing `exit 1` in error branches.  If build fails, the `build` step should fail, not downstream steps (addresses https://github.com/bloom-housing/bloom/actions/runs/22109309976/job/63900917283)