### PR TITLE
feat: use updated MSQ schema for public & partners listing detail pages

### DIFF
--- a/sites/partners/src/components/listings/PaperListingDetails/sections/DetailPreferences.tsx
+++ b/sites/partners/src/components/listings/PaperListingDetails/sections/DetailPreferences.tsx
@@ -29,7 +29,11 @@ const DetailPreferences = () => {
       listingSectionQuestions(listing, MultiselectQuestionsApplicationSectionEnum.preferences)?.map(
         (listingPreference, index) => ({
           order: { content: index + 1 },
-          name: { content: listingPreference?.multiselectQuestions?.text },
+          name: {
+            content:
+              listingPreference?.multiselectQuestions?.name ||
+              listingPreference?.multiselectQuestions?.text,
+          },
           description: { content: listingPreference?.multiselectQuestions?.description },
         })
       ),

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -231,7 +231,9 @@ export const ListingView = (props: ListingProps) => {
         return {
           ordinal: listingMultiselectQuestion.ordinal || index + 1,
           links: listingMultiselectQuestion?.multiselectQuestions?.links,
-          title: listingMultiselectQuestion?.multiselectQuestions?.name,
+          title:
+            listingMultiselectQuestion?.multiselectQuestions?.name ||
+            listingMultiselectQuestion?.multiselectQuestions?.text,
           description: listingMultiselectQuestion?.multiselectQuestions?.description,
         }
       })

--- a/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
+++ b/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
@@ -596,7 +596,7 @@ export const getEligibilitySections = (
         <OrderedCardList
           cardContent={sortedPreferences.map((question) => {
             return {
-              heading: question.multiselectQuestions.name,
+              heading: question.multiselectQuestions.name || question.multiselectQuestions.text,
               description: question.multiselectQuestions.description,
             }
           })}


### PR DESCRIPTION
This PR addresses #5685 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The updated preference name schema is used for the listing detail view on both the Public site and the Partners site.

## How Can This Be Tested/Reviewed?

After saving a listing with preferences with the MSQV2 db seed in place or in the proper review app, you will see the preference displayed correctly when viewing the public listing or on partners prior to editing.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
