### PR TITLE
fix: repeated link aria labels

### DIFF
--- a/shared-helpers/package.json
+++ b/shared-helpers/package.json
@@ -17,7 +17,7 @@
     "prettier": "prettier --write \"**/*.ts\""
   },
   "dependencies": {
-    "@bloom-housing/ui-components": "13.0.3",
+    "@bloom-housing/ui-components": "13.0.6",
     "@bloom-housing/ui-seeds": "3.3.1",
     "@heroicons/react": "^2.1.1",
     "axios-cookiejar-support": "^5.0.5",

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bloom-housing/shared-helpers": "^7.7.1",
-    "@bloom-housing/ui-components": "13.0.3",
+    "@bloom-housing/ui-components": "13.0.6",
     "@bloom-housing/ui-seeds": "3.3.1",
     "@heroicons/react": "^2.2.0",
     "@mapbox/mapbox-sdk": "^0.13.0",

--- a/sites/public/cypress/support/commands.js
+++ b/sites/public/cypress/support/commands.js
@@ -63,7 +63,7 @@ Cypress.Commands.add("beginApplicationRejectAutofill", (listingName) => {
   cy.get("[data-testid=sign-in-email-field]").type("admin@example.com")
   cy.get("[data-testid=sign-in-password-field]").type("abcdef")
   cy.getByID("sign-in-button").click()
-  cy.getByID("app-choose-language-button").eq(0).click()
+  cy.getByID("app-choose-language-button-en").eq(0).click()
   cy.getByID("app-next-step-button").click()
   cy.getByID("application-initial-page").then(() => {
     cy.get("h2").then(($header) => {
@@ -86,7 +86,7 @@ Cypress.Commands.add("beginApplicationSignedIn", (listingName, autofill) => {
     cy.get(".is-card-link").contains(listingName).parent().click()
   }
   cy.getByID("listing-view-apply-button").eq(1).click()
-  cy.getByID("app-choose-language-button").eq(0).click()
+  cy.getByID("app-choose-language-button-en").eq(0).click()
   cy.getByID("app-next-step-button").click()
   if (autofill) {
     cy.getByID("autofill-accept").click()

--- a/sites/public/package.json
+++ b/sites/public/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@bloom-housing/shared-helpers": "^7.7.1",
-    "@bloom-housing/ui-components": "13.0.3",
+    "@bloom-housing/ui-components": "13.0.6",
     "@bloom-housing/ui-seeds": "3.3.1",
     "@heroicons/react": "^2.1.1",
     "@mapbox/mapbox-sdk": "^0.13.0",

--- a/sites/public/src/components/shared/FormSummaryDetails.tsx
+++ b/sites/public/src/components/shared/FormSummaryDetails.tsx
@@ -147,7 +147,11 @@ const FormSummaryDetails = ({
           <Heading priority={3} size="xl">
             {header}
           </Heading>
-          {editMode && !validationError && <Link href={appLink}>{t("t.edit")}</Link>}
+          {editMode && !validationError && (
+            <Link href={appLink} ariaLabel={`${t("t.edit")} ${header}`}>
+              {t("t.edit")}
+            </Link>
+          )}
         </Card.Header>
 
         <Card.Section
@@ -191,7 +195,11 @@ const FormSummaryDetails = ({
         <Heading priority={3} size="xl">
           {t("t.you")}
         </Heading>
-        {editMode && <Link href="/applications/contact/name">{t("t.edit")}</Link>}
+        {editMode && (
+          <Link href="/applications/contact/name" ariaLabel={`${t("t.edit")} ${t("t.you")}`}>
+            {t("t.edit")}
+          </Link>
+        )}
       </Card.Header>
 
       <Card.Section className={styles["summary-section"]}>
@@ -311,7 +319,12 @@ const FormSummaryDetails = ({
               {t("application.alternateContact.type.label")}
             </Heading>
             {editMode && !validationError && (
-              <Link href="/applications/contact/alternate-contact-type">{t("t.edit")}</Link>
+              <Link
+                href="/applications/contact/alternate-contact-type"
+                ariaLabel={`${t("t.edit")} ${t("application.alternateContact.type.label")}`}
+              >
+                {t("t.edit")}
+              </Link>
             )}
           </Card.Header>
 
@@ -372,7 +385,12 @@ const FormSummaryDetails = ({
               {t("application.household.householdMembers")}
             </Heading>
             {editMode && !validationError && (
-              <Link href="/applications/household/add-members">{t("t.edit")}</Link>
+              <Link
+                href="/applications/household/add-members"
+                ariaLabel={`${t("t.edit")} ${t("application.household.householdMembers")}`}
+              >
+                {t("t.edit")}
+              </Link>
             )}
           </Card.Header>
 
@@ -435,7 +453,12 @@ const FormSummaryDetails = ({
             {t("application.review.householdDetails")}
           </Heading>
           {editMode && !validationError && (
-            <Link href="/applications/household/preferred-units">{t("t.edit")}</Link>
+            <Link
+              href="/applications/household/preferred-units"
+              ariaLabel={`${t("t.edit")} ${t("application.review.householdDetails")}`}
+            >
+              {t("t.edit")}
+            </Link>
           )}
         </Card.Header>
 
@@ -506,7 +529,12 @@ const FormSummaryDetails = ({
             {t("t.income")}
           </Heading>
           {editMode && !validationError && (
-            <Link href="/applications/financial/vouchers">{t("t.edit")}</Link>
+            <Link
+              href="/applications/financial/vouchers"
+              ariaLabel={`${t("t.edit")} ${t("t.income")}`}
+            >
+              {t("t.edit")}
+            </Link>
           )}
         </Card.Header>
 

--- a/sites/public/src/pages/account/account.module.scss
+++ b/sites/public/src/pages/account/account.module.scss
@@ -4,6 +4,9 @@
     --card-content-padding-inline: var(--seeds-s4);
     --card-content-padding-block: var(--seeds-s6);
   }
+  a {
+    text-decoration: underline;
+  }
 }
 
 .account-settings-label {

--- a/sites/public/src/pages/account/edit.tsx
+++ b/sites/public/src/pages/account/edit.tsx
@@ -291,6 +291,7 @@ const Edit = () => {
                   variant="primary-outlined"
                   loadingMessage={nameLoading ? t("t.loading") : undefined}
                   id={"account-submit-name"}
+                  ariaLabel={`${t("account.settings.update")} ${t("application.name.yourName")}`}
                 >
                   {t("account.settings.update")}
                 </Button>
@@ -334,6 +335,9 @@ const Edit = () => {
                   className="mt-6"
                   loadingMessage={birthdateLoading ? t("t.loading") : undefined}
                   id={"account-submit-dob"}
+                  ariaLabel={`${t("account.settings.update")} ${t(
+                    "application.name.yourDateOfBirth"
+                  )}`}
                 >
                   {t("account.settings.update")}
                 </Button>
@@ -375,6 +379,9 @@ const Edit = () => {
                   variant="primary-outlined"
                   loadingMessage={emailLoading ? t("t.loading") : undefined}
                   id={"account-submit-email"}
+                  ariaLabel={`${t("account.settings.update")} ${t(
+                    "application.name.yourEmailAddress"
+                  )}`}
                 >
                   {t("account.settings.update")}
                 </Button>
@@ -455,6 +462,9 @@ const Edit = () => {
                     variant="primary-outlined"
                     loadingMessage={passwordLoading ? t("t.loading") : undefined}
                     id={"account-submit-password"}
+                    ariaLabel={`${t("account.settings.update")} ${t(
+                      "authentication.createAccount.password"
+                    )}`}
                   >
                     {t("account.settings.update")}
                   </Button>

--- a/sites/public/src/pages/applications/household/add-members.tsx
+++ b/sites/public/src/pages/applications/household/add-members.tsx
@@ -52,14 +52,16 @@ const ApplicationAddMembers = () => {
   const membersSection = application.householdMember.map((member, index) => {
     return (
       <CardSection divider="inset" key={index}>
-        <HouseholdMemberForm
-          editMember={editMember}
-          key={index}
-          memberFirstName={member.firstName}
-          memberId={index}
-          memberLastName={member.lastName}
-          subtitle={t("application.household.householdMember")}
-        />
+        <li>
+          <HouseholdMemberForm
+            editMember={editMember}
+            key={index}
+            memberFirstName={member.firstName}
+            memberId={index}
+            memberLastName={member.lastName}
+            subtitle={t("application.household.householdMember")}
+          />
+        </li>
       </CardSection>
     )
   })
@@ -106,16 +108,20 @@ const ApplicationAddMembers = () => {
             register={register}
             validate={true}
           />
-          <CardSection divider="inset">
-            <HouseholdMemberForm
-              editMember={editMember}
-              editMode={!application.autofilled}
-              memberFirstName={applicant.firstName}
-              memberLastName={applicant.lastName}
-              subtitle={t("application.household.primaryApplicant")}
-            />
-          </CardSection>
-          {membersSection}
+          <ul>
+            <CardSection divider="inset">
+              <li>
+                <HouseholdMemberForm
+                  editMember={editMember}
+                  editMode={!application.autofilled}
+                  memberFirstName={applicant.firstName}
+                  memberLastName={applicant.lastName}
+                  subtitle={t("application.household.primaryApplicant")}
+                />
+              </li>
+            </CardSection>
+            {membersSection}
+          </ul>
           <CardSection divider={"flush"} className={"border-none"}>
             <Button
               onClick={onAddMember}

--- a/sites/public/src/pages/applications/start/choose-language.tsx
+++ b/sites/public/src/pages/applications/start/choose-language.tsx
@@ -210,7 +210,7 @@ const ApplicationChooseLanguage = () => {
                         onLanguageSelect(lang)
                       }}
                       key={index}
-                      id={"app-choose-language-button"}
+                      id={`app-choose-language-button-${lang}`}
                     >
                       {t(`languages.${lang}`)}
                     </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,10 +1006,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@13.0.3":
-  version "13.0.3"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-13.0.3.tgz#7120699d7fce6603b7f5c1636baa06bb7edafb67"
-  integrity sha512-yMi1aIjWO7iNEJeX1YkRRvd1pemzJ9/Td3gpG9DiPkXh5gsnRH/CT5EATJAOzPtzq6w5VCpJ3yTOvbHraOVr0w==
+"@bloom-housing/ui-components@13.0.6":
+  version "13.0.6"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-13.0.6.tgz#d9f5a75780b1a2e3280fae550396952d9c8f5735"
+  integrity sha512-1xguoeK3QmDzTxrLusCDIgP4x5ZbOTWaYFtOrm8zwI2PiGKl8yaSwlG2JDDDTtphl6x5xWWKY932tjDvTxxKSg==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.1.1"
     "@fortawesome/free-regular-svg-icons" "^6.1.1"


### PR DESCRIPTION
This PR addresses parts of related issues like #2240 #2241 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

In our public site forms, we should not have repeated links with the same text without an appropriate aria label that gives context. Buttons with the same IDs can also cause issues with screen readers.

This PR also turns the housing members page into a list so it's clear there will be repeated sections.

## How Can This Be Tested/Reviewed?

With a screen reader on, you can navigate through the household members page and hear it read the members as a list, or visit the application summary page and hear the new labels on the Edit links.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
