### PR TITLE
fix: render if markdown

### DIFF
--- a/sites/public/src/lib/helpers.tsx
+++ b/sites/public/src/lib/helpers.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { ReactElement } from "react"
 import dayjs from "dayjs"
 import { useRouter } from "next/router"
 import InfoIcon from "@heroicons/react/20/solid/InformationCircleIcon"
@@ -522,7 +522,7 @@ export const fetchFavoriteListingIds = async (userId: string, userService: UserS
 }
 
 // RenderIf component to render content based on language (used in markdown components)
-export const RenderIf = (props: { language: string; children: React.ReactNode }) => {
+export const RenderIf = (props: { language: string; children: ReactElement }) => {
   const router = useRouter()
 
   if (


### PR DESCRIPTION
## Description

We need this function in order to do translations in markdown files, which we need for terms content in LA. For whatever reason we manually added this helper into new Detroit and did not pull it back.

## How Can This Be Tested/Reviewed?

We use this function in Detroit on this page for example: https://homeconnect.detroitmi.gov/terms

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
