### PR TITLE
test: randomize jurisdiction names

### DIFF
--- a/api/prisma/seed-helpers/jurisdiction-factory.ts
+++ b/api/prisma/seed-helpers/jurisdiction-factory.ts
@@ -11,7 +11,9 @@ import { RaceEthnicityConfiguration } from '../../src/dtos/jurisdictions/race-et
 import { SpokenLanguageEnum } from '../../src/enums/applications/spoken-language-enum';
 
 export const jurisdictionFactory = (
-  jurisdictionName = randomName(),
+  jurisdictionName = `${randomName()} ${Math.random()
+    .toString(16)
+    .substring(2, 8)}`,
   optionalFields?: {
     listingApprovalPermissions?: UserRoleEnum[];
     duplicateListingPermissions?: UserRoleEnum[];


### PR DESCRIPTION
## Description

[These kinds of test failures](https://github.com/bloom-housing/bloom/actions/runs/22455966581/job/65037106406?pr=5961) happen not too infrequently.

const newJurisdiction = await prisma.jurisdictions.create(
    Unique constraint failed on the fields: (`name`)

## How Can This Be Tested/Reviewed?

Adds a set of random characters at the end, resulting in names like `Fulfilling Chestnuthaven ac91d5` or `Fascinating Walnuthaven 4b0db1`.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
