### PR TITLE
fix: filter agency by jurisdiction

### DIFF
--- a/api/src/services/agency.service.ts
+++ b/api/src/services/agency.service.ts
@@ -3,8 +3,10 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from './prisma.service';
 import { AgencyQueryParams } from '../dtos/agency/agency-query-params.dto';
+import { AgencyFilterKeys } from '../enums/agency/filter-key-enum';
 import AgencyCreate from '../dtos/agency/agency-create.dto';
 import { AgencyUpdate } from '../dtos/agency/agency-update.dto';
 import {
@@ -44,6 +46,7 @@ export class AgencyService {
       include: {
         jurisdictions: true,
       },
+      where: this.buildWhereClause(params),
     });
 
     const agencies = mapTo(Agency, agenciesRaw);
@@ -51,6 +54,28 @@ export class AgencyService {
     return {
       items: agencies,
       meta: buildPaginationMetaInfo(params, count, agencies.length),
+    };
+  }
+
+  buildWhereClause(params: AgencyQueryParams): Prisma.AgencyWhereInput {
+    const filters: Prisma.AgencyWhereInput[] = [];
+
+    const jurisdictionId = params?.filter?.find(
+      (filter) => filter[AgencyFilterKeys.jurisdiction],
+    )?.[AgencyFilterKeys.jurisdiction];
+
+    if (jurisdictionId) {
+      filters.push({
+        jurisdictions: {
+          is: {
+            id: jurisdictionId,
+          },
+        },
+      });
+    }
+
+    return {
+      AND: filters,
     };
   }
 

--- a/sites/public/src/lib/hooks.ts
+++ b/sites/public/src/lib/hooks.ts
@@ -374,7 +374,7 @@ export async function fetchAgencies(req: any, jurisdictionId: string) {
     } = {
       filter: [
         {
-          $comparison: EnumAgencyFilterParamsComparison["IN"],
+          $comparison: EnumAgencyFilterParamsComparison["="],
           jurisdiction: jurisdictionId && jurisdictionId !== "" ? jurisdictionId : undefined,
         },
       ],


### PR DESCRIPTION
## Description

We're not currently filtering the agency dropdown by jurisdiction.

## How Can This Be Tested/Reviewed?

Reseed, and in Angelopolis, ensure the create advocate form has only agencies appended by `- Angelopolis`, and that the same is true if you login to advocate@example.com for the dashboard edit account details page dropdown as well.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
