### PR TITLE
fix: dont fetch closed with seeds

### DIFF
--- a/sites/public/src/pages/listings.tsx
+++ b/sites/public/src/pages/listings.tsx
@@ -62,6 +62,7 @@ export async function getServerSideProps(context: { req: any; query: any }) {
   let openListings
   let closedListings
   let areFiltersActive = false
+  const isUsingNewSeedsDesign = Boolean(process.env.showNewSeedsDesigns)
 
   if (isFiltered(context.query)) {
     const filterData = decodeQueryToFilterData(context.query)
@@ -70,7 +71,9 @@ export async function getServerSideProps(context: { req: any; query: any }) {
     areFiltersActive = true
   } else {
     openListings = await fetchOpenListings(context.req, Number(context.query.page) || 1)
-    closedListings = await fetchClosedListings(context.req, Number(context.query.page) || 1)
+    if (!isUsingNewSeedsDesign) {
+      closedListings = await fetchClosedListings(context.req, Number(context.query.page) || 1)
+    }
   }
   const jurisdiction = await fetchJurisdictionByName(context.req)
   const multiselectData = isFeatureFlagOn(


### PR DESCRIPTION
## Description

When seeds is off, the listings page fetches open listings and up to `MAX_BROWSE_LISTINGS` for closed listings which we usually have set at 20, as it displays both open and closed.

When seeds is on and we have pagination and tabs, the main listings page should only be fetching open listings, but right now its fetching open and closed. This PR puts the closed fetch behind seeds being off. The seeds closed listings page is a totally different file and still fetches closed listings.

## How Can This Be Tested/Reviewed?

Ensure you have a closed listing locally in your jurisdiction, then in the network tab, inspect the response to the listings call and ensure you see:
"closedListings": [],

In [core dev](https://bloom-public-seeds.netlify.app/listings) if you do the same you can see it come back with closed listings.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
