### PR TITLE
refactor: public dynamic imports

### DIFF
--- a/sites/public/.jest/mocks/LazyMarkdown.tsx
+++ b/sites/public/.jest/mocks/LazyMarkdown.tsx
@@ -1,0 +1,13 @@
+import React from "react"
+
+/**
+ * Jest mock for LazyMarkdown so next/dynamic doesn't delay rendering.
+ * Renders children as text so tests can find content with getByText.
+ * Strips HTML tags so raw "<" does not appear in the DOM (matches test expectations).
+ */
+export default function LazyMarkdown(props: { children?: React.ReactNode; [key: string]: unknown }) {
+  const content = props.children
+  const text =
+    typeof content === "string" ? content.replace(/<[^>]*>/g, "") : content
+  return <span data-testid="lazy-markdown">{text}</span>
+}

--- a/sites/public/__tests__/components/listing/listing_sections/RentSummary.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/RentSummary.test.tsx
@@ -62,7 +62,7 @@ describe("<RentSummary>", () => {
     expect(screen.getAllByText("Unit type").length).toBe(2)
     expect(screen.getAllByText("Minimum income").length).toBe(2)
     expect(screen.getAllByText("Availability").length).toBe(2)
-    expect(screen.getByText("Section 8 Housing Choice Voucher")).toBeDefined()
+    expect(screen.getByText(/Section 8 Housing Choice Voucher/)).toBeDefined()
   })
   it("shows nothing if no data", () => {
     render(

--- a/sites/public/jest.config.js
+++ b/sites/public/jest.config.js
@@ -41,5 +41,6 @@ module.exports = {
   moduleNameMapper: {
     "\\.(scss|css|less)$": "identity-obj-proxy",
     "\\.module\\.scss$": "identity-obj-proxy",
+    "^.*core/LazyMarkdown$": "<rootDir>/.jest/mocks/LazyMarkdown.tsx",
   },
 }

--- a/sites/public/next.config.js
+++ b/sites/public/next.config.js
@@ -109,8 +109,8 @@ if (process.env.SENTRY_ORG) {
       // Upload a larger set of source maps for prettier stack traces (increases build time)
       widenClientFileUpload: true,
 
-      // Transpiles SDK to be compatible with IE11 (increases bundle size)
-      transpileClientSDK: true,
+      // Do not transpile the client SDK for IE11 to avoid extra bundle size
+      transpileClientSDK: false,
 
       // Routes browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers (increases server load)
       tunnelRoute: "/monitoring",

--- a/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
+++ b/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
@@ -138,7 +138,7 @@ const ApplicationMultiselectQuestionStep = ({
         if (body.current.options[step].extraData[0]?.value) {
           setFoundAddress({})
           setVerifyAddress(true)
-          findValidatedAddress(
+          void findValidatedAddress(
             body.current.options[step].extraData[0]?.value,
             setFoundAddress,
             setNewAddressSelected

--- a/sites/public/src/components/applications/ValidateAddress.tsx
+++ b/sites/public/src/components/applications/ValidateAddress.tsx
@@ -1,6 +1,5 @@
 import { Address, MultiLineAddress, t } from "@bloom-housing/ui-components"
 import { Button } from "@bloom-housing/ui-seeds"
-import GeocodeService from "@mapbox/mapbox-sdk/services/geocoding"
 
 export interface FoundAddress {
   newAddress?: Address
@@ -13,17 +12,20 @@ export const findValidatedAddress = (
   setFoundAddress: React.Dispatch<React.SetStateAction<FoundAddress>>,
   setNewAddressSelected: React.Dispatch<React.SetStateAction<boolean>>
 ) => {
-  const geocodingClient = GeocodeService({
-    accessToken: process.env.mapBoxToken || process.env.MAPBOX_TOKEN,
-  })
+  void import("@mapbox/mapbox-sdk/services/geocoding")
+    .then(({ default: GeocodeService }) => {
+      const geocodingClient = GeocodeService({
+        accessToken: process.env.mapBoxToken || process.env.MAPBOX_TOKEN,
+      })
 
-  geocodingClient
-    .forwardGeocode({
-      query: `${address.street}, ${address.city}, ${address.state} ${address.zipCode}, United States`,
-      limit: 1,
-      types: ["address"],
+      return geocodingClient
+        .forwardGeocode({
+          query: `${address.street}, ${address.city}, ${address.state} ${address.zipCode}, United States`,
+          limit: 1,
+          types: ["address"],
+        })
+        .send()
     })
-    .send()
     .then((response) => {
       const [street, city, region] = response.body.features[0].place_name.split(", ")
       const coordinates = response.body.features[0].geometry?.coordinates

--- a/sites/public/src/components/applications/ValidateAddress.tsx
+++ b/sites/public/src/components/applications/ValidateAddress.tsx
@@ -11,8 +11,8 @@ export const findValidatedAddress = (
   address: Address,
   setFoundAddress: React.Dispatch<React.SetStateAction<FoundAddress>>,
   setNewAddressSelected: React.Dispatch<React.SetStateAction<boolean>>
-) => {
-  void import("@mapbox/mapbox-sdk/services/geocoding")
+): Promise<void> => {
+  return import("@mapbox/mapbox-sdk/services/geocoding")
     .then(({ default: GeocodeService }) => {
       const geocodingClient = GeocodeService({
         accessToken: process.env.mapBoxToken || process.env.MAPBOX_TOKEN,

--- a/sites/public/src/components/content-pages/DisclaimerDeprecated.tsx
+++ b/sites/public/src/components/content-pages/DisclaimerDeprecated.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useContext } from "react"
+import Markdown from "markdown-to-jsx"
 import { PageHeader, MarkdownSection, t } from "@bloom-housing/ui-components"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
 import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
-import LazyMarkdown from "../core/LazyMarkdown"
 
 const DisclaimerDeprecated = () => {
   const { profile } = useContext(AuthContext)
@@ -23,7 +23,7 @@ const DisclaimerDeprecated = () => {
     <Layout pageTitle={t("pageTitle.disclaimer")}>
       <PageHeader inverse={true} title={pageTitle} />
       <MarkdownSection>
-        <LazyMarkdown>{pageContent.toString()}</LazyMarkdown>
+        <Markdown>{pageContent.toString()}</Markdown>
       </MarkdownSection>
     </Layout>
   )

--- a/sites/public/src/components/content-pages/DisclaimerDeprecated.tsx
+++ b/sites/public/src/components/content-pages/DisclaimerDeprecated.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useContext } from "react"
 import { PageHeader, MarkdownSection, t } from "@bloom-housing/ui-components"
-import Markdown from "markdown-to-jsx"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
 import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
+import LazyMarkdown from "../core/LazyMarkdown"
 
 const DisclaimerDeprecated = () => {
   const { profile } = useContext(AuthContext)
@@ -23,7 +23,7 @@ const DisclaimerDeprecated = () => {
     <Layout pageTitle={t("pageTitle.disclaimer")}>
       <PageHeader inverse={true} title={pageTitle} />
       <MarkdownSection>
-        <Markdown>{pageContent.toString()}</Markdown>
+        <LazyMarkdown>{pageContent.toString()}</LazyMarkdown>
       </MarkdownSection>
     </Layout>
   )

--- a/sites/public/src/components/content-pages/DisclaimerSeeds.tsx
+++ b/sites/public/src/components/content-pages/DisclaimerSeeds.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useContext } from "react"
 import { t } from "@bloom-housing/ui-components"
-import Markdown from "markdown-to-jsx"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
 import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
 import { PageHeaderLayout } from "../../patterns/PageHeaderLayout"
 import styles from "../../patterns/PageHeaderLayout.module.scss"
+import LazyMarkdown from "../core/LazyMarkdown"
 
 const DisclaimerSeeds = () => {
   const { profile } = useContext(AuthContext)
@@ -26,7 +26,7 @@ const DisclaimerSeeds = () => {
         subheading="A design approach is a general philosophy that may or may not include a guide for specific methods."
         inverse
       >
-        <Markdown className={styles["markdown"]}>{pageContent.toString()}</Markdown>
+        <LazyMarkdown className={styles["markdown"]}>{pageContent.toString()}</LazyMarkdown>
       </PageHeaderLayout>
     </Layout>
   )

--- a/sites/public/src/components/content-pages/DisclaimerSeeds.tsx
+++ b/sites/public/src/components/content-pages/DisclaimerSeeds.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from "react"
+import Markdown from "markdown-to-jsx"
 import { t } from "@bloom-housing/ui-components"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
@@ -6,7 +7,6 @@ import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
 import { PageHeaderLayout } from "../../patterns/PageHeaderLayout"
 import styles from "../../patterns/PageHeaderLayout.module.scss"
-import LazyMarkdown from "../core/LazyMarkdown"
 
 const DisclaimerSeeds = () => {
   const { profile } = useContext(AuthContext)
@@ -26,7 +26,7 @@ const DisclaimerSeeds = () => {
         subheading="A design approach is a general philosophy that may or may not include a guide for specific methods."
         inverse
       >
-        <LazyMarkdown className={styles["markdown"]}>{pageContent.toString()}</LazyMarkdown>
+        <Markdown className={styles["markdown"]}>{pageContent.toString()}</Markdown>
       </PageHeaderLayout>
     </Layout>
   )

--- a/sites/public/src/components/content-pages/PrivacyDeprecated.tsx
+++ b/sites/public/src/components/content-pages/PrivacyDeprecated.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useContext } from "react"
 import { PageHeader, MarkdownSection, t } from "@bloom-housing/ui-components"
-import Markdown from "markdown-to-jsx"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
 import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
+import LazyMarkdown from "../core/LazyMarkdown"
 
 const PrivacyDeprecated = () => {
   const { profile } = useContext(AuthContext)
@@ -23,7 +23,7 @@ const PrivacyDeprecated = () => {
     <Layout pageTitle={t("pageTitle.privacy")}>
       <PageHeader inverse={true} title={pageTitle} />
       <MarkdownSection>
-        <Markdown>{pageContent.toString()}</Markdown>
+        <LazyMarkdown>{pageContent.toString()}</LazyMarkdown>
       </MarkdownSection>
     </Layout>
   )

--- a/sites/public/src/components/content-pages/PrivacyDeprecated.tsx
+++ b/sites/public/src/components/content-pages/PrivacyDeprecated.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useContext } from "react"
+import Markdown from "markdown-to-jsx"
 import { PageHeader, MarkdownSection, t } from "@bloom-housing/ui-components"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
 import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
-import LazyMarkdown from "../core/LazyMarkdown"
 
 const PrivacyDeprecated = () => {
   const { profile } = useContext(AuthContext)
@@ -23,7 +23,7 @@ const PrivacyDeprecated = () => {
     <Layout pageTitle={t("pageTitle.privacy")}>
       <PageHeader inverse={true} title={pageTitle} />
       <MarkdownSection>
-        <LazyMarkdown>{pageContent.toString()}</LazyMarkdown>
+        <Markdown>{pageContent.toString()}</Markdown>
       </MarkdownSection>
     </Layout>
   )

--- a/sites/public/src/components/content-pages/PrivacySeeds.tsx
+++ b/sites/public/src/components/content-pages/PrivacySeeds.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useContext } from "react"
 import { t } from "@bloom-housing/ui-components"
-import Markdown from "markdown-to-jsx"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
 import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
 import { PageHeaderLayout } from "../../patterns/PageHeaderLayout"
 import styles from "../../patterns/PageHeaderLayout.module.scss"
+import LazyMarkdown from "../core/LazyMarkdown"
 
 const Privacy = () => {
   const { profile } = useContext(AuthContext)
@@ -22,7 +22,7 @@ const Privacy = () => {
   return (
     <Layout pageTitle={t("pageTitle.privacy")}>
       <PageHeaderLayout heading={t("pageTitle.privacy")} inverse>
-        <Markdown className={styles["markdown"]}>{pageContent.toString()}</Markdown>
+        <LazyMarkdown className={styles["markdown"]}>{pageContent.toString()}</LazyMarkdown>
       </PageHeaderLayout>
     </Layout>
   )

--- a/sites/public/src/components/content-pages/PrivacySeeds.tsx
+++ b/sites/public/src/components/content-pages/PrivacySeeds.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from "react"
+import Markdown from "markdown-to-jsx"
 import { t } from "@bloom-housing/ui-components"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../../lib/constants"
@@ -6,7 +7,6 @@ import Layout from "../../layouts/application"
 import pageContent from "../../static_content/generic_content.md"
 import { PageHeaderLayout } from "../../patterns/PageHeaderLayout"
 import styles from "../../patterns/PageHeaderLayout.module.scss"
-import LazyMarkdown from "../core/LazyMarkdown"
 
 const Privacy = () => {
   const { profile } = useContext(AuthContext)
@@ -22,7 +22,7 @@ const Privacy = () => {
   return (
     <Layout pageTitle={t("pageTitle.privacy")}>
       <PageHeaderLayout heading={t("pageTitle.privacy")} inverse>
-        <LazyMarkdown className={styles["markdown"]}>{pageContent.toString()}</LazyMarkdown>
+        <Markdown className={styles["markdown"]}>{pageContent.toString()}</Markdown>
       </PageHeaderLayout>
     </Layout>
   )

--- a/sites/public/src/components/core/LazyMarkdown.tsx
+++ b/sites/public/src/components/core/LazyMarkdown.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import dynamic from "next/dynamic"
+
+const Markdown = dynamic(() => import("markdown-to-jsx"), {
+  // Keep SSR so content is still rendered on the server for SEO
+  ssr: true,
+})
+
+type LazyMarkdownProps = {
+  children: string
+  [key: string]: unknown
+}
+
+const LazyMarkdown = ({ children, ...props }: LazyMarkdownProps) => {
+  return <Markdown {...props}>{children}</Markdown>
+}
+
+export default LazyMarkdown

--- a/sites/public/src/components/listing/GetApplication.tsx
+++ b/sites/public/src/components/listing/GetApplication.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react"
-import Markdown from "markdown-to-jsx"
 import { ListingsStatusEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import {
   Address,
@@ -13,6 +12,7 @@ import {
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
 import { useForm } from "react-hook-form"
 import { downloadExternalPDF } from "../../lib/helpers"
+import LazyMarkdown from "../core/LazyMarkdown"
 export interface PaperApplication {
   fileURL: string
   languageString: string
@@ -145,10 +145,9 @@ const GetApplication = (props: ApplicationsProps) => {
                 {props.strings?.officeHoursHeading ?? t("leasingAgent.officeHours")}
               </Heading>
               <p className="text-gray-800 text-sm markdown">
-                <Markdown
-                  children={props.applicationPickUpAddressOfficeHours}
-                  options={{ disableParsingRawHTML: true }}
-                />
+                <LazyMarkdown options={{ disableParsingRawHTML: true }}>
+                  {props.applicationPickUpAddressOfficeHours}
+                </LazyMarkdown>
               </p>
             </>
           )}

--- a/sites/public/src/components/listing/ListingView.tsx
+++ b/sites/public/src/components/listing/ListingView.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react"
 import ReactDOMServer from "react-dom/server"
-import Markdown from "markdown-to-jsx"
 import {
   AdditionalFees,
   ApplicationStatus,
@@ -69,6 +68,7 @@ import {
   ReviewOrderTypeEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { DownloadLotteryResults } from "./DownloadLotteryResults"
+import LazyMarkdown from "../core/LazyMarkdown"
 
 interface ListingProps {
   listing: Listing
@@ -547,7 +547,7 @@ export const ListingView = (props: ListingProps) => {
       <div className="info-card">
         <h3 className="text-serif-xl">{cardTitle}</h3>
         <p className="text-xs text-gray-700 break-words">
-          <Markdown children={cardData} options={{ disableParsingRawHTML: true }} />
+          <LazyMarkdown children={cardData} options={{ disableParsingRawHTML: true }} />
         </p>
       </div>
     )
@@ -707,9 +707,9 @@ export const ListingView = (props: ListingProps) => {
           )}
           {listing.section8Acceptance && (
             <div className="my-2">
-              <Markdown className="custom-counter__subtitle">
+              <LazyMarkdown className="custom-counter__subtitle">
                 {t("listings.section8VoucherInfo")}
-              </Markdown>
+              </LazyMarkdown>
             </div>
           )}
         </div>
@@ -780,7 +780,7 @@ export const ListingView = (props: ListingProps) => {
                     <>
                       <br />
                       <br />
-                      <Markdown>{t("listings.section8VoucherInfo")}</Markdown>
+                      <LazyMarkdown>{t("listings.section8VoucherInfo")}</LazyMarkdown>
                     </>
                   )}
                 </div>
@@ -935,16 +935,18 @@ export const ListingView = (props: ListingProps) => {
             {lotterySection}
             {listing.whatToExpect && (
               <ExpandableSection
-                content={<Markdown className={"bloom-markdown"}>{listing.whatToExpect}</Markdown>}
+                content={
+                  <LazyMarkdown className={"bloom-markdown"}>{listing.whatToExpect}</LazyMarkdown>
+                }
                 expandableContent={
                   listing.whatToExpectAdditionalText &&
                   isFeatureFlagOn(
                     jurisdiction,
                     FeatureFlagEnum.enableWhatToExpectAdditionalField
                   ) ? (
-                    <Markdown className={"bloom-markdown"}>
+                    <LazyMarkdown className={"bloom-markdown"}>
                       {listing.whatToExpectAdditionalText}
-                    </Markdown>
+                    </LazyMarkdown>
                   ) : undefined
                 }
                 strings={{

--- a/sites/public/src/components/listing/ListingViewSeeds.tsx
+++ b/sites/public/src/components/listing/ListingViewSeeds.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
-import Markdown from "markdown-to-jsx"
 import {
   EnumListingListingType,
   FeatureFlagEnum,
@@ -50,6 +49,7 @@ import styles from "./ListingViewSeeds.module.scss"
 import { ReadMore } from "../../patterns/ReadMore"
 import { OtherFeatures } from "./listing_sections/OtherFeatures"
 import { PropertyDetailsCard } from "./listing_sections/PropertyDetailsCard"
+import LazyMarkdown from "../core/LazyMarkdown"
 
 interface ListingProps {
   listing: Listing
@@ -159,7 +159,7 @@ export const ListingViewSeeds = ({ listing, jurisdiction, profile, preview }: Li
       {listing.whatToExpect && (
         <InfoCard heading={t("whatToExpect.label")}>
           <div className={"bloom-markdown"}>
-            <Markdown>{listing.whatToExpect}</Markdown>
+            <LazyMarkdown>{listing.whatToExpect}</LazyMarkdown>
           </div>
           {listing.whatToExpectAdditionalText &&
             isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableWhatToExpectAdditionalField) && (

--- a/sites/public/src/components/listing/SubmitApplication.tsx
+++ b/sites/public/src/components/listing/SubmitApplication.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
-import Markdown from "markdown-to-jsx"
 import { Address, Heading, OrDivider, ContactAddress } from "@bloom-housing/ui-components"
+import LazyMarkdown from "../core/LazyMarkdown"
 
 export interface ApplicationAddressesProps {
   /** The dropoff address for paper applications */
@@ -58,10 +58,9 @@ const SubmitApplication = ({
                   {strings.officeHoursHeader}
                 </Heading>
                 <p className="mt-4 text-sm text-gray-750">
-                  <Markdown
-                    children={applicationDropOffAddressOfficeHours}
-                    options={{ disableParsingRawHTML: true }}
-                  />
+                  <LazyMarkdown options={{ disableParsingRawHTML: true }}>
+                    {applicationDropOffAddressOfficeHours}
+                  </LazyMarkdown>
                 </p>
               </>
             )}

--- a/sites/public/src/components/listing/listing_sections/Apply.tsx
+++ b/sites/public/src/components/listing/listing_sections/Apply.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react"
 import dayjs from "dayjs"
-import Markdown from "markdown-to-jsx"
 import { Address, AuthContext, getPostmarkString } from "@bloom-housing/shared-helpers"
 import { Button, Card, Heading } from "@bloom-housing/ui-seeds"
 import {
@@ -20,6 +19,7 @@ import {
 } from "../ListingViewSeedsHelpers"
 import listingStyles from "../ListingViewSeeds.module.scss"
 import styles from "./Apply.module.scss"
+import LazyMarkdown from "../../core/LazyMarkdown"
 
 type ApplyProps = {
   listing: Listing
@@ -177,7 +177,7 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
                   <Heading size={"md"} priority={4} className={"seeds-m-be-header"}>
                     {t("leasingAgent.officeHours")}
                   </Heading>
-                  <Markdown children={listing.applicationPickUpAddressOfficeHours} />
+                  <LazyMarkdown>{listing.applicationPickUpAddressOfficeHours}</LazyMarkdown>
                 </div>
               )}
             </div>
@@ -205,7 +205,7 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
                   <Heading size={"md"} priority={4} className={"seeds-m-be-header"}>
                     {t("leasingAgent.officeHours")}
                   </Heading>
-                  <Markdown children={listing.applicationDropOffAddressOfficeHours} />
+                  <LazyMarkdown>{listing.applicationDropOffAddressOfficeHours}</LazyMarkdown>
                 </div>
               )}
             </div>

--- a/sites/public/src/components/listing/listing_sections/RentSummary.tsx
+++ b/sites/public/src/components/listing/listing_sections/RentSummary.tsx
@@ -11,7 +11,7 @@ import {
   getUnitGroupSummariesTable,
 } from "@bloom-housing/shared-helpers"
 import styles from "./RentSummary.module.scss"
-import Markdown from "markdown-to-jsx"
+import LazyMarkdown from "../../core/LazyMarkdown"
 
 type RentSummaryProps = {
   amiValues: number[]
@@ -97,7 +97,7 @@ export const RentSummary = ({
       {rentTable}
       {section8Acceptance && (
         <div className={"seeds-p-bs-4"}>
-          <Markdown>{t("listings.section8VoucherInfo")}</Markdown>
+          <LazyMarkdown>{t("listings.section8VoucherInfo")}</LazyMarkdown>
         </div>
       )}
     </div>

--- a/sites/public/src/layouts/application-form.tsx
+++ b/sites/public/src/layouts/application-form.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import Markdown from "markdown-to-jsx"
 import { UseFormMethods } from "react-hook-form"
 import { BloomCard, CustomIconMap } from "@bloom-housing/shared-helpers"
 import { Alert, Button, Heading, Icon, Message } from "@bloom-housing/ui-seeds"
@@ -7,6 +6,7 @@ import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import { t, ProgressNav, StepHeader } from "@bloom-housing/ui-components"
 import ApplicationConductor from "../lib/applications/ApplicationConductor"
 import styles from "./application-form.module.scss"
+import LazyMarkdown from "../components/core/LazyMarkdown"
 
 interface ApplicationFormLayoutProps {
   listingName: string
@@ -120,7 +120,7 @@ const ApplicationFormLayout = (props: ApplicationFormLayoutProps) => {
         <>
           {isAdvocate && (
             <Message fullwidth variant="warn">
-              <Markdown>{t("application.form.general.advocateWarning")}</Markdown>
+              <LazyMarkdown>{t("application.form.general.advocateWarning")}</LazyMarkdown>
             </Message>
           )}
           {props.children}

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useState } from "react"
 import dayjs from "dayjs"
 import { NextRouter, useRouter } from "next/router"
-import Markdown from "markdown-to-jsx"
 import Head from "next/head"
 import HomeIcon from "@heroicons/react/24/solid/HomeIcon"
 import { Message, Toast, Icon } from "@bloom-housing/ui-seeds"
@@ -13,6 +12,7 @@ import { MetaTags } from "../components/shared/MetaTags"
 import CustomSiteFooter from "../components/shared/CustomSiteFooter"
 import { HeaderLink, SiteHeader } from "../patterns/SiteHeader"
 import styles from "./application.module.scss"
+import LazyMarkdown from "../components/core/LazyMarkdown"
 
 const isMessageActive = (windowEnv: string) => {
   let isActive = false
@@ -92,14 +92,14 @@ const getSiteHeaderDeprecated = (
       {showMaintenanceMessage && (
         <div className={`${styles["site-banner-container"]} ${styles["site-banner-alert-bg"]}`}>
           <Message className={styles["site-alert-banner-content"]} variant={"alert"}>
-            <Markdown>{t("alert.maintenance")}</Markdown>
+            <LazyMarkdown>{t("alert.maintenance")}</LazyMarkdown>
           </Message>
         </div>
       )}
       {showGenericSiteMessage && (
         <div className={`${styles["site-banner-container"]} ${styles["site-banner-primary-bg"]}`}>
           <Message className={styles["site-alert-banner-content"]} variant={"primary"}>
-            <Markdown>{t("siteMessage.generic")}</Markdown>
+            <LazyMarkdown>{t("siteMessage.generic")}</LazyMarkdown>
           </Message>
         </div>
       )}

--- a/sites/public/src/pages/account/application/[id]/lottery-results.tsx
+++ b/sites/public/src/pages/account/application/[id]/lottery-results.tsx
@@ -17,7 +17,7 @@ import {
   ApplicationListingCard,
 } from "../../../../components/account/ApplicationCards"
 import styles from "../../../../../styles/lottery-results.module.scss"
-import Markdown from "markdown-to-jsx"
+import LazyMarkdown from "../../../../components/core/LazyMarkdown"
 
 const LotteryResults = () => {
   const router = useRouter()
@@ -179,11 +179,11 @@ const LotteryResults = () => {
                       <Heading priority={3} size={"xl"} className={`${styles["section-heading"]}`}>
                         {t("account.application.lottery.preferencesHeader")}
                       </Heading>
-                      <Markdown>
+                      <LazyMarkdown>
                         {t("account.application.lottery.preferences", {
                           closedListingPageLink: `/listing/${listing?.id}`,
                         })}
-                      </Markdown>
+                      </LazyMarkdown>
                     </div>
                     <div>
                       <Button

--- a/sites/public/src/pages/applications/contact/address.tsx
+++ b/sites/public/src/pages/applications/contact/address.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState, useMemo } from "react"
 import { useForm } from "react-hook-form"
-import { FormErrorMessage } from "@bloom-housing/ui-seeds"
+import { FormErrorMessage, LoadingState } from "@bloom-housing/ui-seeds"
 import { Field, FieldGroup, Form, PhoneField, Select, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
@@ -32,6 +32,7 @@ import ApplicationFormLayout, {
 const ApplicationAddress = () => {
   const { profile } = useContext(AuthContext)
   const [verifyAddress, setVerifyAddress] = useState(false)
+  const [addressValidationLoading, setAddressValidationLoading] = useState(false)
   const [foundAddress, setFoundAddress] = useState<FoundAddress>({})
   const [newAddressSelected, setNewAddressSelected] = useState(true)
 
@@ -69,11 +70,12 @@ const ApplicationAddress = () => {
     if (!verifyAddress) {
       setFoundAddress({})
       setVerifyAddress(true)
+      setAddressValidationLoading(true)
       void findValidatedAddress(
         data.applicant.applicantAddress,
         setFoundAddress,
         setNewAddressSelected
-      )
+      ).finally(() => setAddressValidationLoading(false))
       window.scrollTo({ top: 0 })
 
       return // Skip rest of the submit process
@@ -712,9 +714,11 @@ const ApplicationAddress = () => {
           </div>
           <CardSection>
             {verifyAddress && (
-              <AddressValidationSelection
-                {...{ foundAddress, newAddressSelected, setNewAddressSelected, setVerifyAddress }}
-              />
+              <LoadingState loading={addressValidationLoading} className={"seeds-p-be-8"}>
+                <AddressValidationSelection
+                  {...{ foundAddress, newAddressSelected, setNewAddressSelected, setVerifyAddress }}
+                />
+              </LoadingState>
             )}
           </CardSection>
         </ApplicationFormLayout>

--- a/sites/public/src/pages/applications/review/confirmation.tsx
+++ b/sites/public/src/pages/applications/review/confirmation.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from "react"
 import { useRouter } from "next/router"
-import Markdown from "markdown-to-jsx"
 import { t, ApplicationTimeline } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
@@ -21,6 +20,7 @@ import { AppSubmissionContext } from "../../../lib/applications/AppSubmissionCon
 import { UserStatus } from "../../../lib/constants"
 import { isFeatureFlagOn, isUnitGroupAppBase, isUnitGroupAppWaitlist } from "../../../lib/helpers"
 import { AccountTypeDialog } from "../../../components/account/AccountTypeDialog"
+import LazyMarkdown from "../../../components/core/LazyMarkdown"
 
 const ApplicationConfirmation = () => {
   const { application, listing, conductor } = useContext(AppSubmissionContext)
@@ -121,13 +121,13 @@ const ApplicationConfirmation = () => {
               <div className="markdown markdown-informational">
                 <ApplicationTimeline />
 
-                <Markdown options={{ disableParsingRawHTML: true }}>{contentText}</Markdown>
+                <LazyMarkdown options={{ disableParsingRawHTML: true }}>{contentText}</LazyMarkdown>
               </div>
             </CardSection>
 
             <CardSection divider={"inset"}>
               <div className="markdown markdown-informational">
-                <Markdown options={{ disableParsingRawHTML: true }}>
+                <LazyMarkdown options={{ disableParsingRawHTML: true }}>
                   {t(
                     `application.review.confirmation.needToMakeUpdates${
                       isAdvocate ? ".advocate" : ""
@@ -139,16 +139,16 @@ const ApplicationConfirmation = () => {
                       agentOfficeHours: listing?.leasingAgentOfficeHours || "",
                     }
                   )}
-                </Markdown>
+                </LazyMarkdown>
               </div>
             </CardSection>
 
             {initialStateLoaded && !profile && (
               <CardSection divider={"flush"} className={"border-none"}>
                 <div className="markdown markdown-informational">
-                  <Markdown options={{ disableParsingRawHTML: true }}>
+                  <LazyMarkdown options={{ disableParsingRawHTML: true }}>
                     {t("application.review.confirmation.createAccount")}
-                  </Markdown>
+                  </LazyMarkdown>
                 </div>
               </CardSection>
             )}

--- a/sites/public/src/pages/applications/review/terms.tsx
+++ b/sites/public/src/pages/applications/review/terms.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
-import Markdown from "markdown-to-jsx"
 import { t, FieldGroup, Form, AlertBox } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
@@ -29,6 +28,7 @@ import {
 import ApplicationFormLayout from "../../../layouts/application-form"
 import styles from "../../../layouts/application-form.module.scss"
 import { Button } from "@bloom-housing/ui-seeds"
+import LazyMarkdown from "../../../components/core/LazyMarkdown"
 
 const ApplicationTerms = () => {
   const router = useRouter()
@@ -180,17 +180,17 @@ const ApplicationTerms = () => {
             <div className="markdown">
               {listing?.applicationDueDate && (
                 <>
-                  <Markdown options={{ disableParsingRawHTML: true }}>
+                  <LazyMarkdown options={{ disableParsingRawHTML: true }}>
                     {t("application.review.terms.textSubmissionDate", {
                       applicationDueDate: applicationDueDate,
                     })}
-                  </Markdown>
+                  </LazyMarkdown>
                   <br />
                   <br />
                 </>
               )}
 
-              <Markdown
+              <LazyMarkdown
                 options={{
                   disableParsingRawHTML: true,
                   overrides: {
@@ -205,7 +205,7 @@ const ApplicationTerms = () => {
                 }}
               >
                 {content.text}
-              </Markdown>
+              </LazyMarkdown>
 
               <div className="mt-6">
                 <FieldGroup

--- a/sites/public/src/pages/applications/start/what-to-expect.tsx
+++ b/sites/public/src/pages/applications/start/what-to-expect.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useContext, useMemo } from "react"
 import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
-import Markdown from "markdown-to-jsx"
 import { ReviewOrderTypeEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { t, Form } from "@bloom-housing/ui-components"
 import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
@@ -13,6 +12,7 @@ import { UserStatus } from "../../../lib/constants"
 import ApplicationFormLayout from "../../../layouts/application-form"
 import styles from "../../../layouts/application-form.module.scss"
 import { isUnitGroupAppBase, isUnitGroupAppWaitlist } from "../../../lib/helpers"
+import LazyMarkdown from "../../../components/core/LazyMarkdown"
 
 const ApplicationWhatToExpect = () => {
   const { profile } = useContext(AuthContext)
@@ -93,7 +93,7 @@ const ApplicationWhatToExpect = () => {
       >
         <CardSection>
           <div className="markdown">
-            <Markdown
+            <LazyMarkdown
               options={{
                 disableParsingRawHTML: true,
                 overrides: {
@@ -108,9 +108,9 @@ const ApplicationWhatToExpect = () => {
               }}
             >
               {content.steps}
-            </Markdown>
+            </LazyMarkdown>
 
-            <Markdown
+            <LazyMarkdown
               options={{
                 disableParsingRawHTML: true,
                 overrides: {
@@ -125,7 +125,7 @@ const ApplicationWhatToExpect = () => {
               }}
             >
               {content.finePrint}
-            </Markdown>
+            </LazyMarkdown>
           </div>
         </CardSection>
         <CardSection className={styles["application-form-action-footer"]}>

--- a/sites/public/src/pages/faq.tsx
+++ b/sites/public/src/pages/faq.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useContext } from "react"
-import Markdown from "markdown-to-jsx"
 import { t } from "@bloom-housing/ui-components"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { Button, Card, Heading } from "@bloom-housing/ui-seeds"
@@ -12,6 +11,7 @@ import Layout from "../layouts/application"
 import { PageHeaderLayout } from "../patterns/PageHeaderLayout"
 import FrequentlyAskedQuestions from "../patterns/FrequentlyAskedQuestions"
 import { getGenericFaqContent } from "../static_content/generic_faq_content"
+import LazyMarkdown from "../components/core/LazyMarkdown"
 import pageStyles from "../components/content-pages/FaqPage.module.scss"
 import styles from "../patterns/PageHeaderLayout.module.scss"
 import { fetchJurisdictionByName } from "../lib/hooks"
@@ -52,7 +52,7 @@ const FaqPage = ({ jurisdiction }: { jurisdiction: Jurisdiction }) => {
           </Card.Header>
           <Card.Section>
             <div className={"seeds-m-be-6"}>
-              <Markdown>{t("faq.stillHaveQuestionsContent")}</Markdown>
+              <LazyMarkdown>{t("faq.stillHaveQuestionsContent")}</LazyMarkdown>
             </div>
             {enableResources && (
               <Button href={"/additional-resources"}>{t("faq.viewResourcePage")}</Button>

--- a/sites/public/src/pages/faq.tsx
+++ b/sites/public/src/pages/faq.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useContext } from "react"
+import Markdown from "markdown-to-jsx"
 import { t } from "@bloom-housing/ui-components"
 import { PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
 import { Button, Card, Heading } from "@bloom-housing/ui-seeds"
@@ -11,7 +12,6 @@ import Layout from "../layouts/application"
 import { PageHeaderLayout } from "../patterns/PageHeaderLayout"
 import FrequentlyAskedQuestions from "../patterns/FrequentlyAskedQuestions"
 import { getGenericFaqContent } from "../static_content/generic_faq_content"
-import LazyMarkdown from "../components/core/LazyMarkdown"
 import pageStyles from "../components/content-pages/FaqPage.module.scss"
 import styles from "../patterns/PageHeaderLayout.module.scss"
 import { fetchJurisdictionByName } from "../lib/hooks"
@@ -52,7 +52,7 @@ const FaqPage = ({ jurisdiction }: { jurisdiction: Jurisdiction }) => {
           </Card.Header>
           <Card.Section>
             <div className={"seeds-m-be-6"}>
-              <LazyMarkdown>{t("faq.stillHaveQuestionsContent")}</LazyMarkdown>
+              <Markdown>{t("faq.stillHaveQuestionsContent")}</Markdown>
             </div>
             {enableResources && (
               <Button href={"/additional-resources"}>{t("faq.viewResourcePage")}</Button>

--- a/sites/public/src/patterns/ReadMore.tsx
+++ b/sites/public/src/patterns/ReadMore.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react"
-import Markdown from "markdown-to-jsx"
 import { t } from "@bloom-housing/ui-components"
 import styles from "./ReadMore.module.scss"
+import LazyMarkdown from "../components/core/LazyMarkdown"
 
 interface ReadMoreProps {
   /** Full content to display */
@@ -43,9 +43,9 @@ export const ReadMore = (props: ReadMoreProps) => {
 
   return (
     <div className={`${styles["read-more"]} ${props.className}`} aria-live={"polite"}>
-      <Markdown id={"read-more-content"} className={"bloom-markdown"}>
+      <LazyMarkdown id={"read-more-content"} className={"bloom-markdown"}>
         {expanded ? props.content : truncatedContent}
-      </Markdown>
+      </LazyMarkdown>
       {shouldTruncate && (
         <button
           className={`${styles["read-more-button"]} seeds-m-bs-text`}

--- a/sites/public/src/static_content/generic_faq_content.tsx
+++ b/sites/public/src/static_content/generic_faq_content.tsx
@@ -1,7 +1,7 @@
-import Markdown from "markdown-to-jsx"
 import { Link } from "@bloom-housing/ui-seeds"
 import { t } from "@bloom-housing/ui-components"
 import { FaqCategory, FaqContent } from "../patterns/FrequentlyAskedQuestions"
+import LazyMarkdown from "../components/core/LazyMarkdown"
 
 export const getGenericFaqContent = (): FaqContent => {
   const faqContentSection: FaqCategory = {
@@ -10,9 +10,9 @@ export const getGenericFaqContent = (): FaqContent => {
       {
         question: t("faq.howDoesThisWork"),
         answer: (
-          <Markdown>{`${t("content.genericParagraph")} ${t("content.genericParagraph")} ${t(
+          <LazyMarkdown>{`${t("content.genericParagraph")} ${t("content.genericParagraph")} ${t(
             "content.genericParagraph"
-          )}`}</Markdown>
+          )}`}</LazyMarkdown>
         ),
       },
       {


### PR DESCRIPTION
## Description

Reduces some client page-level bundle sizes on the public site by lazy-loading two heavy dependencies - markdown and Mapbox geocoding.

Added LazyMarkdown which wraps markdown-to-jsx in next/dynamic so it is shipped in a separate chunk. We were importing markdown in the main application layout because we use it if the maintenance banner is on - but that doesn't mean we should be loading it on every single page including ones that don't actually use the package.

In ValidateAddress.tsx, we now load @mapbox/mapbox-sdk/services/geocoding via dynamic import() inside findValidatedAddress so the package is only requested when the user runs address validation vs page load.

## How Can This Be Tested/Reviewed?

The main shared first load is unchanged - savings are in page-specific chunks. Some examples:
`/` from 10.7kb --> 8.36kb
`/account/dashboard` from 4.62kb --> 2.48kb
`/get-assistance` from 5.24kb --> 3.08kb

These aren't super noticeable but the hope is lazy loading will allow the browser to be interactive quicker on slow connections.

To test I would submit an application. You can see markdown on the what to expect, terms, and confirmation pages. We can test the geocoding on the address verification page, and there is a new loading spinner more easily seen when throttling the network.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
