### PR TITLE
chore: add asterisks to the unit form labels

### DIFF
--- a/sites/partners/__tests__/components/listings/PaperListingForm/UnitForm.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/UnitForm.test.tsx
@@ -69,10 +69,10 @@ describe("UnitForm", () => {
     expect(screen.getByRole("textbox", { name: "Unit number" })).toBeInTheDocument()
 
     // Unit type dropdown selector
-    const unitTypeSelector = screen.getByRole("combobox", { name: "Unit type" })
+    const unitTypeSelector = screen.getByRole("combobox", { name: /unit type/i })
     expect(unitTypeSelector).toBeInTheDocument()
     expect(within(unitTypeSelector).getAllByRole("option")).toHaveLength(8)
-    expect(within(unitTypeSelector).getByRole("option", { name: "Unit type" })).toBeInTheDocument()
+    expect(within(unitTypeSelector).getByRole("option", { name: /unit type/i })).toBeInTheDocument()
     expect(within(unitTypeSelector).getByRole("option", { name: "Studio" })).toBeInTheDocument()
     expect(within(unitTypeSelector).getByRole("option", { name: "SRO" })).toBeInTheDocument()
     expect(
@@ -153,15 +153,15 @@ describe("UnitForm", () => {
 
     expect(screen.getByRole("heading", { name: "Eligibility", level: 2 })).toBeInTheDocument()
 
-    const amiChartSelector = screen.getByRole("combobox", { name: "AMI chart" })
+    const amiChartSelector = screen.getByRole("combobox", { name: /ami chart/i })
     expect(amiChartSelector).toBeInTheDocument()
     expect(within(amiChartSelector).getAllByRole("option")).toHaveLength(3)
-    expect(within(amiChartSelector).getByRole("option", { name: "AMI chart" })).toBeInTheDocument()
+    expect(within(amiChartSelector).getByRole("option", { name: /ami chart/i })).toBeInTheDocument()
     // These values are populated by the amiCharts api call
     expect(within(amiChartSelector).getByRole("option", { name: "Mock AMI" })).toBeInTheDocument()
     expect(within(amiChartSelector).getByRole("option", { name: "Mock AMI 2" })).toBeInTheDocument()
 
-    const amiChartPercentageSelector = screen.getByRole("combobox", { name: "Percentage of AMI" })
+    const amiChartPercentageSelector = screen.getByRole("combobox", { name: /percentage of ami/i })
     // Selector is disabled and No options are available until a chart is selected
     expect(amiChartPercentageSelector).toBeDisabled()
     expect(within(amiChartPercentageSelector).getAllByRole("option")).toHaveLength(1)
@@ -226,15 +226,15 @@ describe("UnitForm", () => {
     // Wait for API calls to finish
     await screen.findByRole("option", { name: "Mock AMI" })
 
-    const amiChartSelector = screen.getByRole("combobox", { name: "AMI chart" })
+    const amiChartSelector = screen.getByRole("combobox", { name: /ami chart/i })
     expect(amiChartSelector).toBeInTheDocument()
     expect(within(amiChartSelector).getAllByRole("option")).toHaveLength(3)
-    expect(within(amiChartSelector).getByRole("option", { name: "AMI chart" })).toBeInTheDocument()
+    expect(within(amiChartSelector).getByRole("option", { name: /ami chart/i })).toBeInTheDocument()
     // These values are populated by the amiCharts api call
     expect(within(amiChartSelector).getByRole("option", { name: "Mock AMI" })).toBeInTheDocument()
     expect(within(amiChartSelector).getByRole("option", { name: "Mock AMI 2" })).toBeInTheDocument()
 
-    const amiChartPercentageSelector = screen.getByRole("combobox", { name: "Percentage of AMI" })
+    const amiChartPercentageSelector = screen.getByRole("combobox", { name: /percentage of ami/i })
     // Selector is disabled and No options are available until a chart is selected
     expect(amiChartPercentageSelector).toBeDisabled()
     expect(within(amiChartPercentageSelector).getAllByRole("option")).toHaveLength(1)
@@ -244,7 +244,7 @@ describe("UnitForm", () => {
     await screen.findByRole("option", { name: "30" })
 
     const newAmiChartPercentageSelector = screen.getByRole("combobox", {
-      name: "Percentage of AMI",
+      name: /percentage of ami/i,
     })
     // Selector is now enabled and has valued
     expect(newAmiChartPercentageSelector).not.toBeDisabled()

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -15,7 +15,7 @@ import {
   useUnitTypeList,
   useWatchOnFormNumberFieldsChange,
 } from "../../../lib/hooks"
-import { arrayToFormOptions, getRentType, fieldHasError } from "../../../lib/helpers"
+import { arrayToFormOptions, getRentType, fieldHasError, addAsterisk } from "../../../lib/helpers"
 import SectionWithGrid from "../../shared/SectionWithGrid"
 import styles from "./ListingForm.module.scss"
 
@@ -416,7 +416,7 @@ const UnitForm = ({
                     <Select
                       id="unitTypes.id"
                       name="unitTypes.id"
-                      label={t("listings.unit.type")}
+                      label={addAsterisk(t("listings.unit.type"))}
                       placeholder={t("listings.unit.type")}
                       register={register}
                       controlClassName="control"
@@ -507,7 +507,7 @@ const UnitForm = ({
                     <Select
                       id="amiChart.id"
                       name="amiChart.id"
-                      label={t("listings.unit.amiChart")}
+                      label={addAsterisk(t("listings.unit.amiChart"))}
                       placeholder={t("listings.unit.amiChart")}
                       register={register}
                       controlClassName="control"
@@ -535,7 +535,7 @@ const UnitForm = ({
                     <Select
                       id={"amiPercentage"}
                       name="amiPercentage"
-                      label={t("listings.unit.amiPercentage")}
+                      label={addAsterisk(t("listings.unit.amiPercentage"))}
                       placeholder={t("listings.unit.amiPercentage")}
                       register={register}
                       controlClassName="control"


### PR DESCRIPTION
This PR addresses [#1439](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/1439)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds asterisks to the following labels in the `Add Unit` form drawer:
* unit type
* AMI chart
* percentage of AMI

## How Can This Be Tested/Reviewed?

1. Seed the database
* Go to the partners' site dashboard landing page
* Click the `Add Listing` button and select a jurisdiction for which units have been enabled
* Scroll down to the `Listing units` section and click the `Add Unit` button
* The form for creating a new unit now should have the required fields with asterisks added to the fields listed in the description

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
