### PR TITLE
fix: non-cloudinary directory photos

### DIFF
--- a/shared-helpers/__tests__/photos.test.ts
+++ b/shared-helpers/__tests__/photos.test.ts
@@ -71,4 +71,51 @@ describe("photos helper", () => {
 
     expect(imageUrlFromListing(testListing)[0]).toBe("5678")
   })
+
+  it("should return building asset from listingImages when cloudinary env is set", () => {
+    process.env.CLOUDINARY_CLOUD_NAME = "exygy"
+
+    const testListing = {
+      id: "id456",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      name: "listing with legacy-labeled image in new field",
+      status: ListingsStatusEnum.active,
+      listingImages: [
+        {
+          ordinal: 0,
+          assets: {
+            fileId: "legacy-building-id",
+            label: "building",
+          },
+        },
+      ],
+    } as Listing
+
+    expect(imageUrlFromListing(testListing)[0]).toBe("legacy-building-id")
+  })
+
+  it("should return random-labeled listingImages asset when cloudinary env is not set", () => {
+    delete process.env.CLOUDINARY_CLOUD_NAME
+    delete process.env.cloudinaryCloudName
+
+    const testListing = {
+      id: "id789",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      name: "listing with random label",
+      status: ListingsStatusEnum.active,
+      listingImages: [
+        {
+          ordinal: 0,
+          assets: {
+            fileId: "random-label-id",
+            label: "someRandomLabel",
+          },
+        },
+      ],
+    } as Listing
+
+    expect(imageUrlFromListing(testListing)[0]).toBe("random-label-id")
+  })
 })

--- a/shared-helpers/src/utilities/photos.ts
+++ b/shared-helpers/src/utilities/photos.ts
@@ -32,12 +32,16 @@ export const imageUrlFromListing = (listing: Listing, size = 400): string[] => {
   } else if (Array.isArray(listing?.assets)) {
     imageAssets = listing.assets
   }
+  const cloudinaryCloudName: string | undefined =
+    process.env.cloudinaryCloudName || process.env.CLOUDINARY_CLOUD_NAME
 
-  const imageUrls = imageAssets
-    ?.filter(
+  let imageUrls = imageAssets
+  if (cloudinaryCloudName) {
+    imageUrls = imageUrls.filter(
       (asset: Asset) => asset.label === CLOUDINARY_BUILDING_LABEL || asset.label === "building"
     )
-    ?.map((asset: Asset) => getUrlForListingImage(asset, size) || "")
+  }
+  const assets = imageUrls?.map((asset: Asset) => getUrlForListingImage(asset, size) || "")
 
-  return imageUrls?.length > 0 ? imageUrls : [IMAGE_FALLBACK_URL]
+  return assets?.length > 0 ? assets : [IMAGE_FALLBACK_URL]
 }


### PR DESCRIPTION
## Description

Currently in LA, images are not appearing on the directory page because we are filtering by a Cloudinary label.

## How Can This Be Tested/Reviewed?

This is hard to test in core because you would need to: turn Cloudinary off, and manually insert an image asset whose fileId is a fully formatted URL and whose label is anything but "building". I connected to the LA dev environment to test locally.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
