### PR TITLE
fix: non-rds keep alive

### DIFF
--- a/api/src/services/prisma.service.ts
+++ b/api/src/services/prisma.service.ts
@@ -4,7 +4,6 @@ import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { Signer } from '@aws-sdk/rds-signer';
 
-const SSL_CONFIG = { rejectUnauthorized: false };
 const KEEP_ALIVE_DELAY_MS = 10000;
 
 /*
@@ -42,7 +41,7 @@ export class PrismaService
         },
         keepAlive: true,
         keepAliveInitialDelayMillis: KEEP_ALIVE_DELAY_MS,
-        ssl: SSL_CONFIG, // use SSL, but don't validate DB cert
+        ssl: { rejectUnauthorized: false }, // use SSL, but don't validate DB cert
       });
       super({ adapter: new PrismaPg(pool) });
       this.pool = pool;
@@ -51,7 +50,6 @@ export class PrismaService
         connectionString: process.env.DATABASE_URL,
         keepAlive: true,
         keepAliveInitialDelayMillis: KEEP_ALIVE_DELAY_MS,
-        ssl: process.env.NODE_ENV === 'production' ? SSL_CONFIG : false,
       });
       super({ adapter: new PrismaPg(pool) });
       this.pool = pool;


### PR DESCRIPTION
## Description

Hypothesis for why we are getting "Can't reach database" in LA Heroku environments:
* Heroku Postgres closes idle connections server-side after ~300s. With low traffic, Prisma's pool held connections open long enough for them to go stale, causing "Can't reach database server" on the next request
* Switched the non-RDS path from Prisma's default connection handling (super()) to an explicit pg Pool with keepAlive: true, which sends TCP keepalive packets to prevent the server from dropping idle connections
* Added keepAlive to the RDS path as well for consistency
* Added onModuleDestroy to gracefully drain the pool on shutdown

## How Can This Be Tested/Reviewed?

This branch was put up as a PR in the LA repo and directly deployed to the demo environment. We bashed on that environment and are no longer seeing the issue.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
