### PR TITLE
fix: tag docker images with latest

### DIFF
--- a/.github/workflows/docker_image_build.yml
+++ b/.github/workflows/docker_image_build.yml
@@ -80,6 +80,7 @@ jobs:
           # the 'tags' and 'labels' fields are 'newline-delimited string': https://github.com/docker/build-push-action#inputs.
           tags: |
             ${{ env.image_base }}/${{ matrix.container }}:gitsha-${{ github.sha }}
+            ${{ env.image_base }}/${{ matrix.container }}:latest
           # The org.opencontainers.image.source label Connects the image to the repository:
           # https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package.
           labels: |


### PR DESCRIPTION
Fixes https://github.com/bloom-housing/bloom-la/actions/runs/23308323624/job/67789136629?pr=42

Tested:
- image build succeeds: https://github.com/bloom-housing/bloom/actions/runs/23308990549
- images now have 'latest' tag: https://github.com/bloom-housing/bloom/pkgs/container/bloom%2Finfra-dev