### PR TITLE
fix: add historical user on pii deletion

### DIFF
--- a/api/prisma/migrations/54_add_historical_user_id/migration.sql
+++ b/api/prisma/migrations/54_add_historical_user_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "applications" ADD COLUMN     "historical_user_id" UUID;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -391,6 +391,8 @@ model Applications {
   demographicsId                 String?                       @unique() @map("demographics_id") @db.Uuid
   // Signifies when PII data should be cleared
   expireAfter                    DateTime?                     @map("expire_after") @db.Timestamp(6)
+  // If a user is deleted we want the historic data of what applications were associated with that user
+  historicalUserId               String?                       @map("historical_user_id") @db.Uuid
   householdExpectingChanges      Boolean?                      @map("household_expecting_changes")
   householdSize                  Int?                          @map("household_size")
   householdStudent               Boolean?                      @map("household_student")

--- a/api/src/services/application.service.ts
+++ b/api/src/services/application.service.ts
@@ -1477,6 +1477,7 @@ export class ApplicationService {
       select: {
         id: true,
         mailingAddressId: true,
+        userId: true,
         applicant: {
           select: {
             id: true,
@@ -1603,6 +1604,7 @@ export class ApplicationService {
         data: {
           additionalPhoneNumber: null,
           wasPIICleared: true,
+          historicalUserId: application.userId,
         },
         where: {
           id: application.id,

--- a/api/test/integration/application.e2e-spec.ts
+++ b/api/test/integration/application.e2e-spec.ts
@@ -2383,6 +2383,9 @@ describe('Application Controller Tests', () => {
         data: jurisdictionFactory(),
       });
       await reservedCommunityTypeFactoryAll(juris.id, prisma);
+      const user = await prisma.userAccounts.create({
+        data: await userFactory({}),
+      });
       const listing = await prisma.listings.create({
         data: await listingFactory(juris.id, prisma, {
           status: ListingsStatusEnum.active,
@@ -2392,6 +2395,7 @@ describe('Application Controller Tests', () => {
       // Application that is the newest for a user
       const newestApplication = await prisma.applications.create({
         data: await applicationFactory({
+          userId: user.id,
           listingId: listing.id,
           isNewest: true,
           expireAfter: dayjs(new Date()).subtract(180, 'days').toDate(),
@@ -2400,6 +2404,7 @@ describe('Application Controller Tests', () => {
       // Application that expires in the future
       const futureApplication = await prisma.applications.create({
         data: await applicationFactory({
+          userId: user.id,
           listingId: listing.id,
           isNewest: false,
           expireAfter: dayjs(new Date()).add(3, 'days').toDate(),
@@ -2408,6 +2413,7 @@ describe('Application Controller Tests', () => {
       // This application should have the PII script run against it
       const applicationToBeCleaned = await prisma.applications.create({
         data: await applicationFactory({
+          userId: user.id,
           listingId: listing.id,
           isNewest: false,
           additionalPhone: '(123) 456-7890',
@@ -2523,6 +2529,7 @@ describe('Application Controller Tests', () => {
       });
       expect(application1.wasPIICleared).toBe(true);
       expect(application1.additionalPhoneNumber).toBeNull();
+      expect(application1.historicalUserId).toBe(user.id);
 
       // Verify that the other applications didn't have their data cleared
       const application2 = await prisma.applications.findFirst({


### PR DESCRIPTION
This PR addresses #6095 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When a user is deleted from the system we want a historical record of all of the applications tied to this user. A new field called historicalUserId is added to applications when the PII information is deleted so if historical data modeling is needed that information is not lost

## How Can This Be Tested/Reviewed?

1. Seed the data
2. create a public account and apply to a listing
3. Use the swagger doc to hit the [user delete endpoint](http://localhost:3100/api#/user/delete). You'll need to get the user id of the account you created and make sure the `shouldRemoveApplication` is set to true
4. Validate that the historical_user_id is populated on the application you applied to on step 2

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 