### PR TITLE
fix: rds pool fix 2

### DIFF
--- a/api/src/services/prisma.service.ts
+++ b/api/src/services/prisma.service.ts
@@ -42,6 +42,7 @@ export class PrismaService
         keepAlive: true,
         keepAliveInitialDelayMillis: KEEP_ALIVE_DELAY_MS,
         ssl: { rejectUnauthorized: false }, // use SSL, but don't validate DB cert
+        options: '-c timezone=UTC',
       });
       super({ adapter: new PrismaPg(pool) });
       this.pool = pool;
@@ -54,6 +55,7 @@ export class PrismaService
           process.env.DB_NO_SSL === 'TRUE'
             ? undefined
             : { rejectUnauthorized: false },
+        options: '-c timezone=UTC',
       });
       super({ adapter: new PrismaPg(pool) });
       this.pool = pool;


### PR DESCRIPTION
## Description

Resolves local yarn setup issues

We had replaced the standard prisma engine with prismapg driver - when PostgreSQL returns a timestamptz value, it formats it using the server's local timezone, then fails to parse the format back. The fix is to force the postgres session timezone to UTC in the pool configuration so timestamptz values are returned as +00:00.

## How Can This Be Tested/Reviewed?

Run `yarn setup` in `api` locally and ensure it succeeds.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
