### PR TITLE
feat: default db translations

### DIFF
--- a/api/scripts/db-translation-input.example.json
+++ b/api/scripts/db-translation-input.example.json
@@ -1,23 +1,14 @@
 {
-  "accountRemoval": {
-    "subject": "Bloom Housing scheduled account removal due to inactivity",
-    "courtesyText": "This is a courtesy email to let you know that because your Bloom Housing Portal account has been inactive for 3 years, your account will be deleted in 30 days per our Terms of Use and Privacy Policy. If you’d like to keep your account, please log in sometime in the next month and we’ll consider your account active again.",
-    "signIn": "Sign in to Bloom Housing"
+  "t": {
+    "hello": "What's up"
   },
-  "advocateApproved": {
-    "subject": "Your account has been approved",
-    "hello": "Hello",
-    "approvalMessage": "Your account at %{appUrl} has been approved.",
-    "approvalInfo": "It will now be easier for you to start, save, and submit online applications <strong>on behalf of housing applicants</strong> for listings that appear on the site.",
-    "completeMessage": "To complete your account creation, please click the link below:",
-    "createAccount": "Create my account"
+  "footer": {
+    "footer": "New footer"
   },
-  "advocateRejected": {
-    "subject": "Update about your account request",
-    "hello": "Hello",
-    "rejectionMessageStart": "Thank you for your interest in creating an account on %{appUrl}.",
-    "rejectionMessageEnd": "We are not able to approve your account at this time.",
-    "rejectionInfoStart": "If you believe this decision was made in error or have questions about eligibility, please contact us at",
-    "rejectionInfoEnd": "for more information."
+  "confirmation": {
+    "subject": "Your Application Confirmation Updated",
+    "eligible": {
+      "fcfs": "Updated fcfs copy"
+    }
   }
 }


### PR DESCRIPTION
This PR addresses #5872

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Sets default translations in the null jurisdiction for all DB strings in all languages using the new db translation script.

## How Can This Be Tested/Reviewed?

Setup the db on main, then change to this branch and run `yarn db:migration:run`. Ensure that the translations table has default translations for the null jurisdiction, which serves as the fallback in jurisdictions if a jurisdiction row does not exist.

Strings that need customization, like to insert the jurisdiction name or email, are handled in migrations within forks.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
