### PR TITLE
fix: more precision on column selection

### DIFF
--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -75,6 +75,8 @@ includeViews.csv = {
     },
   },
   userAccounts: true,
+  units: { select: { id: true } },
+  unitGroups: { select: { id: true } },
 };
 const NUMBER_TO_PAGINATE_BY = 100;
 
@@ -434,11 +436,7 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
               new Promise(async (resolve) => {
                 // grab listings NUMBER_TO_PAGINATE_BY at a time
                 const paginatedListings = await this.prisma.listings.findMany({
-                  include: {
-                    ...includeViews.csv,
-                    units: { select: { id: true } },
-                    unitGroups: { select: { id: true } },
-                  },
+                  include: includeViews.csv,
                   where: {
                     id: {
                       in: optionParams.listings


### PR DESCRIPTION
## Description
This limits the number of columns we query by to hopefully reduce the mem footprint of this running in heroku
nothing should change with the export but now the selects should be more narrow

## How Can This Be Tested/Reviewed?
generate a listing export and verify the values are the same before this pr and after 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
