### PR TITLE
fix: msq backend bugs

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -2796,10 +2796,10 @@ export class ListingService implements OnModuleInit {
 
       // if the listing is closed for the first time the expire_after value should be set on all applications
       void this.setExpireAfterValueOnApplications(mappedListing.id);
+    }
 
-      if (enableV2MSQ) {
-        void this.multiselectQuestionService.retireMultiselectQuestions();
-      }
+    if (enableV2MSQ) {
+      void this.multiselectQuestionService.retireMultiselectQuestions();
     }
 
     await this.cachePurge(
@@ -2981,7 +2981,8 @@ export class ListingService implements OnModuleInit {
     const invalid = [];
     for (const msq of multiselectQuestions) {
       if (
-        msq.status === MultiselectQuestionsStatusEnum.toRetire &&
+        (msq.status === MultiselectQuestionsStatusEnum.toRetire ||
+          msq.status === MultiselectQuestionsStatusEnum.retired) &&
         previousMultiselectQuestionIds.length
       ) {
         if (!previousMultiselectQuestionIds.includes(msq.id)) {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -6112,6 +6112,10 @@ describe('Testing listing service', () => {
           status: MultiselectQuestionsStatusEnum.active,
         },
       ]);
+
+      expect(
+        multiselectQuestionServiceMock.retireMultiselectQuestions,
+      ).toHaveBeenCalled();
     });
 
     it('should update a simple listing to closed with a toRetire multiselectQuestion when enableV2MSQ is true', async () => {
@@ -6907,6 +6911,56 @@ describe('Testing listing service', () => {
           ]),
       ).rejects.toThrowError(
         `The following multiselectQuestions provided are not in a valid state to be associated to this listing: toRetire MSQ`,
+      );
+
+      expect(prisma.multiselectQuestions.findMany).toHaveBeenCalledWith({
+        select: { id: true, name: true, status: true },
+        where: { id: { in: multiselectQuestionIds } },
+      });
+    });
+
+    it('should pass with a retired multiselectQuestion that was previously attached', async () => {
+      const id = randomUUID();
+      prisma.multiselectQuestions.findMany = jest.fn().mockResolvedValue([
+        {
+          id: id,
+          name: 'retired MSQ',
+          status: MultiselectQuestionsStatusEnum.retired,
+        },
+      ]);
+
+      const multiselectQuestionIds = [id];
+
+      await service.validateMultiselectQuestions(
+        multiselectQuestionIds,
+        multiselectQuestionIds,
+      );
+
+      expect(prisma.multiselectQuestions.findMany).toHaveBeenCalledWith({
+        select: { id: true, name: true, status: true },
+        where: { id: { in: multiselectQuestionIds } },
+      });
+    });
+
+    it('should error with a retired multiselectQuestion that was not previously attached', async () => {
+      const id = randomUUID();
+      prisma.multiselectQuestions.findMany = jest.fn().mockResolvedValue([
+        {
+          id: id,
+          name: 'retired MSQ',
+          status: MultiselectQuestionsStatusEnum.retired,
+        },
+      ]);
+
+      const multiselectQuestionIds = [id];
+
+      await expect(
+        async () =>
+          await service.validateMultiselectQuestions(multiselectQuestionIds, [
+            randomUUID(),
+          ]),
+      ).rejects.toThrowError(
+        `The following multiselectQuestions provided are not in a valid state to be associated to this listing: retired MSQ`,
       );
 
       expect(prisma.multiselectQuestions.findMany).toHaveBeenCalledWith({


### PR DESCRIPTION
This PR addresses [#(6111)](https://github.com/bloom-housing/bloom/issues/6111) [#(6112)](https://github.com/bloom-housing/bloom/issues/6112)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Fixes two backend msq bugs.
1. MSQs in toRetire state were only being moved to retired when a listing closed, needed to account for removing MSQ from listing.
2. Editing a closed listing with a retired MSQ prevented the listing edit from saving. Now if the retired MSQ was already associated with the listing, it can be edited and saved.

## How Can This Be Tested/Reviewed?

Run `yarn setup --msqV2` in the `api` dir
Launch app
Create 2 new preferences in the UI
Attach them both to an active listing
In the Preferences UI, set both toRetire
On the listing, remove one of the preferences. Verify it moves to `retired` in the db and is not visible in the UI
Close the listing. Other preference should move to `retired`
Edit and save the closed listing

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
