### PR TITLE
feat: support database emergency recovery

### DIFF
--- a/infra/aws_deployment_guide/7_operations_playbook.md
+++ b/infra/aws_deployment_guide/7_operations_playbook.md
@@ -68,6 +68,50 @@ To view the list of tables, run:
 bloom_prisma=> \dt
 ```
 
+### Accessing as the database master user
+
+Prefer accessing the database as the bloom_readonly user so that you can not accidentally delete
+data. In emergency scenarios, you can connect to the database using the master user. This requires
+more permissions than the deployers permission set has.
+
+1. Authenticate to the AWS account as the SystemAdministrator permission set.
+2. Create a cloudshell environment in the bloom VPC and any private subnet. Select the Security
+   Group with the tag 'bloom-api'.
+3. Go to the 'Aurora and RDS > Databases > bloom' page in the AWS web console. **Note the instance
+   Endpoint.** If viewing the 'Connecting using > Code snippets' section, you can copy the example
+   line from it to your Cloudshell:
+
+   ```bash
+   export RDSHOST="bloom.exampleid.us-west-2.rds.amazonaws.com"
+   ```
+
+4. Connect to the database:
+
+   ```bash
+   psql "host=$RDSHOST port=5432 dbname=postgres user=master"
+   ```
+
+   You will be prompted for the password.
+
+5. In the 'Connect using' section of the database overview page, under the 'Secret Manger' section,
+   click the 'Generate secret' then 'Copy secret' buttons. Paste it to cloudshell.
+
+## Recovering from a bad database migration
+
+Bloom database migrations are run by the API on task start. If a new API version being deployed
+contains a bad migration that causes the database to enter a broken state, the database can either
+be recovered through manual psql surgery or by initiating a RDS recovery. RDS recovery works by
+creating a new database instance which can take many minutes. In some cases, the database may be
+easily recovered with minimal risk of data loss through manual psql surgery. If in doubt, prefer the
+RDS recovery method:
+
+1. Determine a timestamp before the API ran the bad migration. This is the timestamp RDS will
+   restore the DB state to.
+2. Set the `bloom_api_image` root module parameter to the previous good API version.
+3. Set the `database_restore_timestamp` to the value determined in step 1.
+4. Set the `trigger_database_restore` root module parameter to `true`.
+5. Apply the root module. A `bloom-emergency-restore` database instance will be created and used.
+
 ## Manually accessing the Bloom API
 
 Find the IP addresses of the Bloom API tasks:
@@ -96,4 +140,3 @@ The API endpoint is documented at:
    ```
 3. Read the `export class RootService {` in `/shared-helpers/src/types/backend-swagger.ts` file on the Git commit of the deployed
    Bloom API ECS task.
-

--- a/infra/tofu_importable_modules/bloom_deployer_permission_set_policy/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployer_permission_set_policy/main.tf
@@ -378,11 +378,11 @@ data "aws_iam_policy_document" "deployer" {
       "rds:ModifyDBInstance",
     ]
     resources = [
-      "arn:aws:rds:${local.region_account}:db:bloom",
-      "arn:aws:rds:${local.region_account}:og:bloom",
-      "arn:aws:rds:${local.region_account}:pg:bloom",
-      "arn:aws:rds:${local.region_account}:snapshot:bloom-db-finalsnapshot",
-      "arn:aws:rds:${local.region_account}:subgrp:bloom",
+      "arn:aws:rds:${local.region_account}:db:bloom*",
+      "arn:aws:rds:${local.region_account}:og:bloom*",
+      "arn:aws:rds:${local.region_account}:pg:bloom*",
+      "arn:aws:rds:${local.region_account}:snapshot:bloom*",
+      "arn:aws:rds:${local.region_account}:subgrp:bloom*",
     ]
   }
   statement {

--- a/infra/tofu_importable_modules/bloom_deployment/db.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/db.tf
@@ -40,7 +40,54 @@ resource "aws_db_instance" "bloom" {
   final_snapshot_identifier = "bloom-db-finalsnapshot"
   skip_final_snapshot       = !local.is_prod
 }
+resource "aws_db_instance" "bloom_emergency_restore" {
+  count = var.trigger_database_restore ? 1 : 0
+  restore_to_point_in_time {
+    source_db_instance_identifier = aws_db_instance.bloom.identifier
+    restore_time = var.database_restore_timestamp
+  }
+
+  identifier                      = "bloom-emergency-restore"
+  deletion_protection             = local.is_prod
+  engine                          = "postgres"
+  engine_version                  = "17"
+  instance_class                  = local.database_config.instance_class
+  multi_az                        = var.high_availability
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade", "iam-db-auth-error"]
+  username                        = "master"
+  manage_master_user_password     = true
+
+  # Monitoring
+  performance_insights_enabled          = "true"
+  performance_insights_retention_period = 7 # minimum
+  database_insights_mode                = "standard"
+
+  # Networking
+  vpc_security_group_ids              = [aws_security_group.bloom["db"].id]
+  iam_database_authentication_enabled = true
+  db_subnet_group_name                = aws_db_subnet_group.bloom.id
+
+  # Updates
+  apply_immediately           = true # If false, any changes are applied in the next maintenance window instead of when tofu apply runs.
+  engine_lifecycle_support    = "open-source-rds-extended-support"
+  allow_major_version_upgrade = false
+  auto_minor_version_upgrade  = true
+
+  # Storage
+  storage_encrypted         = true
+  storage_type              = "gp2"
+  allocated_storage         = local.database_config.starting_storage_gb
+  max_allocated_storage     = local.database_config.max_storage_gb
+  backup_retention_period   = local.database_config.backup_retention_days
+  final_snapshot_identifier = "bloom-emergency-restore-db-finalsnapshot"
+  skip_final_snapshot       = !local.is_prod
+}
+locals {
+  bloom_db_instance = var.trigger_database_restore ? aws_db_instance.bloom_emergency_restore[0] : aws_db_instance.bloom
+}
+
 output "db_dns_name" {
-  value       = aws_db_instance.bloom.address
+  value       = local.bloom_db_instance.address
   description = "DNS name of the database."
 }
+

--- a/infra/tofu_importable_modules/bloom_deployment/ecs.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs.tf
@@ -89,7 +89,7 @@ locals {
         {
           Action   = "secretsmanager:GetSecretValue"
           Effect   = "Allow"
-          Resource = one([for s in aws_db_instance.bloom.master_user_secret : s.secret_arn if s.secret_status == "active"])
+          Resource = one([for s in local.bloom_db_instance.master_user_secret : s.secret_arn if s.secret_status == "active"])
         },
       ]
       container_policy = jsonencode({
@@ -120,7 +120,7 @@ locals {
           {
             Action   = "rds-db:connect"
             Effect   = "Allow"
-            Resource = "arn:aws:rds-db:${var.aws_region}:${var.aws_account_number}:dbuser:${aws_db_instance.bloom.id}/bloom_api"
+            Resource = "arn:aws:rds-db:${var.aws_region}:${var.aws_account_number}:dbuser:${local.bloom_db_instance.id}/bloom_api"
           },
           {
             Action   = "ses:SendEmail"
@@ -172,7 +172,7 @@ locals {
         Statement = [{
           Action   = "rds-db:connect"
           Effect   = "Allow"
-          Resource = "arn:aws:rds-db:${var.aws_region}:${var.aws_account_number}:dbuser:${aws_db_instance.bloom.id}/bloom_api"
+          Resource = "arn:aws:rds-db:${var.aws_region}:${var.aws_account_number}:dbuser:${local.bloom_db_instance.id}/bloom_api"
         }]
       })
     }

--- a/infra/tofu_importable_modules/bloom_deployment/ecs_api_service.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_api_service.tf
@@ -2,7 +2,7 @@ locals {
   api_default_env_vars = {
     PORT                = "3100"
     NODE_ENV            = "production"
-    DB_HOST             = aws_db_instance.bloom.address
+    DB_HOST             = local.bloom_db_instance.address
     DB_PORT             = "5432"
     DB_USER             = "bloom_api"
     DB_DATABASE         = "bloom_prisma"
@@ -88,7 +88,7 @@ resource "aws_ecs_task_definition" "bloom_api" {
 }
 resource "aws_ecs_service" "bloom_api" {
   depends_on = [
-    aws_db_instance.bloom,
+    local.bloom_db_instance,
     aws_vpc_endpoint.aws_services["secretsmanager"],
     aws_route_table_association.private_subnet,
     null_resource.bloom_dbinit_run,

--- a/infra/tofu_importable_modules/bloom_deployment/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/main.tf
@@ -138,6 +138,29 @@ locals {
     backup_retention_days = 7
   })
 }
+variable "database_restore_timestamp" {
+  type        = string
+  description = "The timestamp that the RDS restore instance will be restored to. Must be a timestamp in RFC 3339 format (e.g. 2026-04-01T00:00:00Z)"
+  default     = ""
+
+  validation {
+    condition     = var.database_restore_timestamp == "" || can(formatdate("", var.database_restore_timestamp))
+    error_message = "database_restore_timestamp must be a valid RFC 3339 timestamp."
+  }
+  validation {
+    condition     = var.database_restore_timestamp == "" || var.trigger_database_restore
+    error_message = "trigger_database_restore must be set to true if database_restore_timestamp is set."
+  }
+}
+variable "trigger_database_restore" {
+  type        = bool
+  description = "Trigger RDS database recover. Causes a new database instance to be created and restored to the time in database_restore_timestamp."
+  default     = false
+  validation {
+    condition     = !var.trigger_database_restore || var.database_restore_timestamp != ""
+    error_message = "database_restore_timestamp must be set if trigger_database_restore is set to true."
+  }
+}
 
 variable "domain_name" {
   type        = string


### PR DESCRIPTION
This PR addresses #6114

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds support in the AWS infra code for DB recovery.

## How Can This Be Tested/Reviewed?

I didn't have time to test this :(

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
