### PR TITLE
feat: make ecs task resources configurable

### DIFF
--- a/infra/tofu_importable_modules/bloom_deployment/ecs_api_service.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_api_service.tf
@@ -28,9 +28,8 @@ resource "aws_ecs_task_definition" "bloom_api" {
   execution_role_arn = aws_iam_role.bloom_ecs["api"].arn
   task_role_arn      = aws_iam_role.bloom_container["api"].arn
 
-  # Keep in sync with docker-compose.yml
-  cpu    = 1024     # 1 vCPU
-  memory = 2 * 1024 # 2 GiB in MiB
+  cpu    = var.bloom_api_resource_limits.vcpu
+  memory = var.bloom_api_resource_limits.memory_mib
 
   container_definitions = jsonencode([
     {

--- a/infra/tofu_importable_modules/bloom_deployment/ecs_site_partners_service.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_site_partners_service.tf
@@ -22,9 +22,8 @@ resource "aws_ecs_task_definition" "bloom_site_partners" {
   execution_role_arn = aws_iam_role.bloom_ecs["site-partners"].arn
   task_role_arn      = aws_iam_role.bloom_container["site-partners"].arn
 
-  # Keep in sync with docker-compose.yml
-  cpu    = 2 * 1024 # 2 vCPU
-  memory = 4 * 1024 # 4 GiB in MiB
+  cpu    = var.bloom_site_partners_resource_limits.vcpu
+  memory = var.bloom_site_partners_resource_limits.memory_mib
 
   container_definitions = jsonencode([
     {

--- a/infra/tofu_importable_modules/bloom_deployment/ecs_site_public_service.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_site_public_service.tf
@@ -29,9 +29,8 @@ resource "aws_ecs_task_definition" "bloom_site_public" {
   execution_role_arn = aws_iam_role.bloom_ecs["site-public"].arn
   task_role_arn      = aws_iam_role.bloom_container["site-public"].arn
 
-  # Keep in sync with docker-compose.yml
-  cpu    = 2 * 1024 # 2 vCPU
-  memory = 6 * 1024 # 6 GiB in MiB
+  cpu    = var.bloom_site_public_resource_limits.vcpu
+  memory = var.bloom_site_public_resource_limits.memory_mib
 
   container_definitions = jsonencode([
     {

--- a/infra/tofu_importable_modules/bloom_deployment/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/main.tf
@@ -195,6 +195,19 @@ variable "bloom_api_task_count" {
 locals {
   bloom_api_task_count = var.bloom_api_task_count != null ? var.bloom_api_task_count : (var.high_availability ? 2 : 1)
 }
+variable "bloom_api_resource_limits" {
+  description = "ECS task resource limits for the API contianer. vcpu is in CPU units where 1024 CPU units = 1 CPU."
+  type = object({
+    vcpu       = number
+    memory_mib = number
+  })
+  # Keep in sync with docker-compose.yml
+  default = {
+    vcpu       = 1 * 1024 # 1 CPU
+    memory_mib = 2 * 1024 # 2 GiB
+  }
+}
+
 variable "bloom_site_partners_image" {
   type        = string
   description = "Container image for the Bloom partners site."
@@ -212,6 +225,18 @@ variable "bloom_site_partners_task_count" {
 locals {
   bloom_site_partners_task_count = var.bloom_site_partners_task_count != null ? var.bloom_site_partners_task_count : (var.high_availability ? 2 : 1)
 }
+variable "bloom_site_partners_resource_limits" {
+  description = "ECS task resource limits for the partners site contianer. vcpu is in CPU units where 1024 CPU units = 1 CPU."
+  type = object({
+    vcpu       = number
+    memory_mib = number
+  })
+  # Keep in sync with docker-compose.yml
+  default = {
+    vcpu       = 2 * 1024 # 2 CPU
+    memory_mib = 4 * 1024 # 4 GiB
+  }
+}
 variable "bloom_site_public_image" {
   type        = string
   description = "Container image for the Bloom public site."
@@ -228,6 +253,18 @@ variable "bloom_site_public_task_count" {
 }
 locals {
   bloom_site_public_task_count = var.bloom_site_public_task_count != null ? var.bloom_site_public_task_count : (var.high_availability ? 2 : 1)
+}
+variable "bloom_site_public_resource_limits" {
+  description = "ECS task resource limits for the public site contianer. vcpu is in CPU units where 1024 CPU units = 1 CPU."
+  type = object({
+    vcpu       = number
+    memory_mib = number
+  })
+  # Keep in sync with docker-compose.yml
+  default = {
+    vcpu       = 2 * 1024 # 2 CPU
+    memory_mib = 6 * 1024 # 6 GiB
+  }
 }
 
 # Create a CloudTrail data store so that audit events are query-able in SQL.


### PR DESCRIPTION
## Description

Changes how ECS task resource limits are defaulted and make them easily configurable from root modules.

## How Can This Be Tested/Reviewed?

I ran tofu apply on the bloom_dev deployment and verified no changes were planned.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
