### PR TITLE
feat: use the V2 MSQ schema for editing applications in Partners

### DIFF
--- a/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationDetails/sections/DetailsMultiselectQuestions.tsx
@@ -88,7 +88,7 @@ const DetailsMultiselectQuestions = ({
                       (question: ApplicationSelection) =>
                         question.multiselectQuestion.id === listingQuestion?.multiselectQuestions.id
                     )
-                    if (!selection) return t("t.none")
+                    if (!selection || selection.selections.length === 0) return t("t.none")
 
                     return selection.selections.map(
                       (selectionOption: ApplicationSelectionOption) => {

--- a/sites/partners/src/components/applications/PaperApplicationForm/MultiselectQuestionsMap.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/MultiselectQuestionsMap.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react"
 import { FieldGroup, t } from "@bloom-housing/ui-components"
 import { Map, LatitudeLongitude } from "@bloom-housing/shared-helpers"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
-import { useFormContext, useWatch } from "react-hook-form"
+import { useFormContext } from "react-hook-form"
 import { GeocodeService as GeocodeServiceType } from "@mapbox/mapbox-sdk/services/geocoding"
 
 interface MapBoxFeature {
@@ -41,19 +41,13 @@ const MultiselectQuestionsMap = ({
   const formMethods = useFormContext()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  const { register, control, getValues, setValue, watch } = formMethods
+  const { register, getValues, setValue, watch } = formMethods
 
-  const buildingAddress: BuildingAddress = useWatch({
-    control,
-    name: `${dataKey}-address`,
-  })
+  const buildingAddress: BuildingAddress = watch(`${dataKey}-address`)
 
   let mapPinPosition = "automatic"
   if (!enableV2MSQ) {
-    mapPinPosition = useWatch({
-      control,
-      name: `${dataKey}-mapPinPosition`,
-    })
+    mapPinPosition = watch(`${dataKey}-mapPinPosition`)
   }
 
   const [latLong, setLatLong] = useState<LatitudeLongitude>({

--- a/sites/partners/src/components/applications/PaperApplicationForm/MultiselectQuestionsMap.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/MultiselectQuestionsMap.tsx
@@ -29,9 +29,14 @@ interface BuildingAddress {
 type MultiselectQuestionsMapProps = {
   geocodingClient: GeocodeServiceType
   dataKey: string
+  enableV2MSQ: boolean
 }
 
-const MultiselectQuestionsMap = ({ geocodingClient, dataKey }: MultiselectQuestionsMapProps) => {
+const MultiselectQuestionsMap = ({
+  geocodingClient,
+  dataKey,
+  enableV2MSQ,
+}: MultiselectQuestionsMapProps) => {
   const [customMapPositionChosen, setCustomMapPositionChosen] = useState(true)
   const formMethods = useFormContext()
 
@@ -42,10 +47,14 @@ const MultiselectQuestionsMap = ({ geocodingClient, dataKey }: MultiselectQuesti
     control,
     name: `${dataKey}-address`,
   })
-  const mapPinPosition = useWatch({
-    control,
-    name: `${dataKey}-mapPinPosition`,
-  })
+
+  let mapPinPosition = "automatic"
+  if (!enableV2MSQ) {
+    mapPinPosition = useWatch({
+      control,
+      name: `${dataKey}-mapPinPosition`,
+    })
+  }
 
   const [latLong, setLatLong] = useState<LatitudeLongitude>({
     latitude: buildingAddress?.latitude ?? null,
@@ -157,38 +166,42 @@ const MultiselectQuestionsMap = ({ geocodingClient, dataKey }: MultiselectQuesti
           </FieldValue>
         </Grid.Cell>
       </Grid.Row>
-      <Grid.Row>
-        <Grid.Cell>
-          <p className="field-label m-4 ml-0">{t("listings.mapPinPosition")}</p>
-        </Grid.Cell>
-      </Grid.Row>
-      <Grid.Row>
-        <Grid.Cell>
-          <FieldGroup
-            name={`${dataKey}-mapPinPosition`}
-            type="radio"
-            fieldGroupClassName={"flex-col"}
-            fieldClassName={"ml-0"}
-            register={register}
-            fields={[
-              {
-                label: t("t.automatic"),
-                value: "automatic",
-                id: `${dataKey}-mapPinPosition-automatic`,
-                note: t("listings.mapPinAutomaticDescription"),
-                defaultChecked: mapPinPosition === "automatic" || mapPinPosition === undefined,
-              },
-              {
-                label: t("t.custom"),
-                value: "custom",
-                id: `${dataKey}-mapPinPosition-custom`,
-                note: t("listings.mapPinCustomDescription"),
-                defaultChecked: mapPinPosition === "custom",
-              },
-            ]}
-          />
-        </Grid.Cell>
-      </Grid.Row>
+      {!enableV2MSQ && (
+        <>
+          <Grid.Row>
+            <Grid.Cell>
+              <p className="field-label m-4 ml-0">{t("listings.mapPinPosition")}</p>
+            </Grid.Cell>
+          </Grid.Row>
+          <Grid.Row>
+            <Grid.Cell>
+              <FieldGroup
+                name={`${dataKey}-mapPinPosition`}
+                type="radio"
+                fieldGroupClassName={"flex-col"}
+                fieldClassName={"ml-0"}
+                register={register}
+                fields={[
+                  {
+                    label: t("t.automatic"),
+                    value: "automatic",
+                    id: `${dataKey}-mapPinPosition-automatic`,
+                    note: t("listings.mapPinAutomaticDescription"),
+                    defaultChecked: mapPinPosition === "automatic" || mapPinPosition === undefined,
+                  },
+                  {
+                    label: t("t.custom"),
+                    value: "custom",
+                    id: `${dataKey}-mapPinPosition-custom`,
+                    note: t("listings.mapPinCustomDescription"),
+                    defaultChecked: mapPinPosition === "custom",
+                  },
+                ]}
+              />
+            </Grid.Cell>
+          </Grid.Row>
+        </>
+      )}
     </>
   )
 }

--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -109,9 +109,14 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
     listingDto?.jurisdictions.id
   )
 
+  const enableV2MSQ = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableV2MSQ,
+    listingDto?.jurisdictions.id
+  )
+
   const units = listingDto?.units
 
-  const defaultValues = editMode ? mapApiToForm(application, listingDto) : {}
+  const defaultValues = editMode ? mapApiToForm(application, listingDto, enableV2MSQ) : {}
 
   const formMethods = useForm<FormTypes>({
     defaultValues,
@@ -364,6 +369,7 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
                           ? t("application.details.communityTypes")
                           : t("application.details.programs")
                       }
+                      enableV2MSQ={enableV2MSQ}
                     />
 
                     <FormHouseholdIncome />
@@ -372,6 +378,7 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
                       questions={preferences}
                       applicationSection={MultiselectQuestionsApplicationSectionEnum.preferences}
                       sectionTitle={t("application.details.preferences")}
+                      enableV2MSQ={enableV2MSQ}
                     />
 
                     <FormDemographics

--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -228,6 +228,7 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
       editMode,
       programs: programs.map((item) => item?.multiselectQuestions),
       preferences: preferences.map((item) => item?.multiselectQuestions),
+      enableV2MSQ,
     })
 
     try {

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -166,6 +166,7 @@ const FormMultiselectQuestions = ({
                   `${option.name || option.text}`
                 )}
                 geocodingClient={geocodingClient}
+                enableV2MSQ={enableV2MSQ}
               />
             </div>
           )}

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -63,6 +63,7 @@ const FormMultiselectQuestions = ({
         ]
       })
     } else {
+      // TODO: We can sunset this after full V2MSQ rollout
       questions?.forEach((listingQuestion) =>
         listingQuestion?.multiselectQuestions?.options?.forEach((option) =>
           keys.push(
@@ -231,6 +232,7 @@ const FormMultiselectQuestions = ({
         <Grid.Row columns={2}>
           {questions?.map((listingQuestion) => {
             const question = listingQuestion?.multiselectQuestions
+            // TODO: We can sunset parts of this after full V2MSQ rollout
             const inputType = enableV2MSQ
               ? question.isExclusive
                 ? "radio"

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormMultiselectQuestions.tsx
@@ -27,6 +27,7 @@ type FormMultiselectQuestionsProps = {
   questions: ListingMultiselectQuestion[]
   applicationSection: MultiselectQuestionsApplicationSectionEnum
   sectionTitle: string
+  enableV2MSQ: boolean
 }
 
 // Set the value as false for a set of option field names
@@ -40,6 +41,7 @@ const FormMultiselectQuestions = ({
   applicationSection,
   questions,
   sectionTitle,
+  enableV2MSQ,
 }: FormMultiselectQuestionsProps) => {
   const formMethods = useFormContext()
 
@@ -52,21 +54,29 @@ const FormMultiselectQuestions = ({
   } = formMethods
 
   const allOptionFieldNames = useMemo(() => {
-    const keys = []
-    questions?.forEach((listingQuestion) =>
-      listingQuestion?.multiselectQuestions?.options?.forEach((option) =>
-        keys.push(
-          fieldName(
-            listingQuestion?.multiselectQuestions.text,
-            applicationSection,
-            cleanMultiselectString(option.text)
+    let keys = []
+    if (enableV2MSQ) {
+      questions?.forEach((listingQuestion) => {
+        keys = [
+          ...keys,
+          ...getAllOptions(listingQuestion?.multiselectQuestions, applicationSection, enableV2MSQ),
+        ]
+      })
+    } else {
+      questions?.forEach((listingQuestion) =>
+        listingQuestion?.multiselectQuestions?.options?.forEach((option) =>
+          keys.push(
+            fieldName(
+              listingQuestion?.multiselectQuestions.text,
+              applicationSection,
+              cleanMultiselectString(option.text)
+            )
           )
         )
       )
-    )
-
+    }
     return keys
-  }, [questions, applicationSection])
+  }, [questions, applicationSection, enableV2MSQ])
 
   const [geocodingClient, setGeocodingClient] = useState<GeocodeServiceType>()
 
@@ -92,15 +102,15 @@ const FormMultiselectQuestions = ({
     question: MultiselectQuestion
   ) => {
     const optionFieldName = fieldName(
-      question.text,
+      question.name || question.text,
       applicationSection,
-      cleanMultiselectString(option.text)
+      cleanMultiselectString(option.name || option.text)
     )
     return (
-      <React.Fragment key={option.text}>
+      <React.Fragment key={option.name || option.text}>
         {field}
 
-        {watchQuestions[optionFieldName] && option?.collectName && (
+        {watchQuestions[optionFieldName] && (option?.shouldCollectName || option?.collectName) && (
           <Field
             id={AddressHolder.Name}
             name={`${optionFieldName}-${AddressHolder.Name}`}
@@ -116,57 +126,67 @@ const FormMultiselectQuestions = ({
             }
           />
         )}
-        {watchQuestions[optionFieldName] && option?.collectRelationship && (
-          <Field
-            id={AddressHolder.Relationship}
-            name={`${optionFieldName}-${AddressHolder.Relationship}`}
-            label={t(`application.preferences.options.${AddressHolder.Relationship}`)}
-            register={register}
-            validation={{ required: true, maxLength: 64 }}
-            error={!!resolveObject(`${optionFieldName}-${AddressHolder.Relationship}`, errors)}
-            errorMessage={
-              resolveObject(`${optionFieldName}-${AddressHolder.Relationship}`, errors)?.type ===
-              "maxLength"
-                ? t("errors.maxLength", { length: 64 })
-                : t("errors.requiredFieldError")
-            }
-          />
-        )}
-        {watchQuestions[optionFieldName] && option.collectAddress && (
-          <div className="pb-4">
-            <FormAddressAlternate
-              subtitle={t("application.preferences.options.qualifyingAddress")}
-              dataKey={fieldName(question.text, applicationSection, `${option.text}-address`)}
+        {watchQuestions[optionFieldName] &&
+          (option?.shouldCollectRelationship || option?.collectRelationship) && (
+            <Field
+              id={AddressHolder.Relationship}
+              name={`${optionFieldName}-${AddressHolder.Relationship}`}
+              label={t(`application.preferences.options.${AddressHolder.Relationship}`)}
               register={register}
-              required={true}
-              errors={errors}
-              stateKeys={stateKeys}
-              data-testid={"app-question-extra-field"}
+              validation={{ required: true, maxLength: 64 }}
+              error={!!resolveObject(`${optionFieldName}-${AddressHolder.Relationship}`, errors)}
+              errorMessage={
+                resolveObject(`${optionFieldName}-${AddressHolder.Relationship}`, errors)?.type ===
+                "maxLength"
+                  ? t("errors.maxLength", { length: 64 })
+                  : t("errors.requiredFieldError")
+              }
             />
-            <MultiselectQuestionsMap
-              dataKey={fieldName(question.text, applicationSection, `${option.text}`)}
-              geocodingClient={geocodingClient}
-            />
-          </div>
-        )}
+          )}
+        {watchQuestions[optionFieldName] &&
+          (option.shouldCollectAddress || option.collectAddress) && (
+            <div className="pb-4">
+              <FormAddressAlternate
+                subtitle={t("application.preferences.options.qualifyingAddress")}
+                dataKey={fieldName(
+                  question.name || question.text,
+                  applicationSection,
+                  `${option.name || option.text}-address`
+                )}
+                register={register}
+                required={true}
+                errors={errors}
+                stateKeys={stateKeys}
+                data-testid={"app-question-extra-field"}
+              />
+              <MultiselectQuestionsMap
+                dataKey={fieldName(
+                  question.name || question.text,
+                  applicationSection,
+                  `${option.name || option.text}`
+                )}
+                geocodingClient={geocodingClient}
+              />
+            </div>
+          )}
       </React.Fragment>
     )
   }
 
   const getCheckboxOption = (option: MultiselectOption, question: MultiselectQuestion) => {
     const optionFieldName = fieldName(
-      question.text,
+      question.name || question.text,
       applicationSection,
-      cleanMultiselectString(option.text)
+      cleanMultiselectString(option.name || option.text)
     )
 
     const checkboxField = (
       <Field
-        id={`${question?.text}-${option.text}`}
+        id={`${question?.name || question?.text}-${option.name || option.text}`}
         name={optionFieldName}
         labelClassName="font-semibold"
         type={"checkbox"}
-        label={option.text}
+        label={option.name || option.text}
         register={register}
       />
     )
@@ -179,23 +199,22 @@ const FormMultiselectQuestions = ({
     setValue: UseFormMethods["setValue"]
   ) => {
     const optionFieldName = fieldName(
-      question.text,
+      question.name || question.text,
       applicationSection,
-      cleanMultiselectString(option.text)
+      cleanMultiselectString(option.name || option.text)
     )
 
     const radioField = (
       <Field
-        id={`${question?.text}-${option.text}`}
+        id={`${question?.name || question?.text}-${option.name || option.text}`}
         name={optionFieldName}
         type={"radio"}
-        label={option.text}
+        label={option.name || option.text}
         register={register}
         inputProps={{
-          value: !!option.text,
+          value: !!(option.name || option.text),
           onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-            // TODO: pass V2MSQ flag state to `getAllOptions`
-            uncheckOptions(getAllOptions(question, applicationSection, false), setValue)
+            uncheckOptions(getAllOptions(question, applicationSection, enableV2MSQ), setValue)
             setValue(optionFieldName, e.target?.value)
           },
         }}
@@ -211,19 +230,24 @@ const FormMultiselectQuestions = ({
         <Grid.Row columns={2}>
           {questions?.map((listingQuestion) => {
             const question = listingQuestion?.multiselectQuestions
-            const inputType = getInputType(question.options as unknown as MultiselectOption[])
+            const inputType = enableV2MSQ
+              ? question.isExclusive
+                ? "radio"
+                : "checkbox"
+              : getInputType(question.options as unknown as MultiselectOption[])
             return (
-              <Grid.Cell key={question.text}>
-                <FieldValue label={question.text}>
+              <Grid.Cell key={question.name || question.text}>
+                <FieldValue label={question.name || question.text}>
                   <fieldset className={"mt-4"}>
                     {inputType === "checkbox" ? (
                       <>
-                        {question?.options
+                        {(enableV2MSQ ? question?.multiselectOptions : question?.options)
                           ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
                           .map((option) => {
                             return getCheckboxOption(option, question)
                           })}
-                        {question?.optOutText &&
+                        {!enableV2MSQ &&
+                          question?.optOutText &&
                           getCheckboxOption(
                             {
                               text: question.optOutText,
@@ -241,12 +265,13 @@ const FormMultiselectQuestions = ({
                       </>
                     ) : (
                       <>
-                        {question?.options
+                        {(enableV2MSQ ? question?.multiselectOptions : question?.options)
                           ?.sort((a, b) => (a.ordinal > b.ordinal ? 1 : -1))
                           .map((option) => {
                             return getRadioOption(option, question, setValue)
                           })}
-                        {question?.optOutText &&
+                        {!enableV2MSQ &&
+                          question?.optOutText &&
                           getRadioOption(
                             {
                               text: question.optOutText,

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -148,6 +148,7 @@ export const mapFormToApi = ({
     }
   })()
 
+  // TODO: We can sunset this after full V2MSQ rollout
   let preferencesData: ApplicationMultiselectQuestion[] = []
   if (!enableV2MSQ) {
     preferencesData = preferences.map((pref: MultiselectQuestion) => {
@@ -159,6 +160,7 @@ export const mapFormToApi = ({
     })
   }
 
+  // TODO: We can sunset this after full V2MSQ rollout
   let programsData: ApplicationMultiselectQuestion[] = []
   if (!enableV2MSQ) {
     programsData = programs.map((program: MultiselectQuestion) => {

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -4,6 +4,8 @@ import {
   adaFeatureKeys,
   mapApiToMultiselectFormV1,
   mapCheckboxesToApiV1,
+  mapApiToMultiselectForm,
+  getSelectionsForApplicationSection,
 } from "@bloom-housing/shared-helpers"
 import { FormTypes, ApplicationTypes, Address } from "../../lib/applications/FormTypes"
 
@@ -280,7 +282,11 @@ export const mapFormToApi = ({
   Format data which comes from the API into correct react-hook-form format.
 */
 
-export const mapApiToForm = (applicationData: Application, listing: Listing) => {
+export const mapApiToForm = (
+  applicationData: Application,
+  listing: Listing,
+  enableV2MSQ: boolean
+) => {
   const submissionDate = applicationData.submissionDate
     ? dayjs(new Date(applicationData.submissionDate))
     : null
@@ -332,18 +338,38 @@ export const mapApiToForm = (applicationData: Application, listing: Listing) => 
   const phoneNumber = applicationData.applicant.phoneNumber
 
   const preferences =
-    mapApiToMultiselectFormV1(
-      Array.isArray(applicationData.preferences) ? applicationData.preferences : [],
-      listing?.listingMultiselectQuestions,
-      MultiselectQuestionsApplicationSectionEnum.preferences
-    ).application.preferences ?? []
+    (enableV2MSQ
+      ? mapApiToMultiselectForm(
+          getSelectionsForApplicationSection(
+            listing?.listingMultiselectQuestions || [],
+            MultiselectQuestionsApplicationSectionEnum.preferences,
+            applicationData.applicationSelections
+          ) || [],
+          listing?.listingMultiselectQuestions || [],
+          MultiselectQuestionsApplicationSectionEnum.preferences
+        ).application.preferences
+      : mapApiToMultiselectFormV1(
+          Array.isArray(applicationData.preferences) ? applicationData.preferences : [],
+          listing?.listingMultiselectQuestions,
+          MultiselectQuestionsApplicationSectionEnum.preferences
+        ).application.preferences) ?? []
 
   const programs =
-    mapApiToMultiselectFormV1(
-      Array.isArray(applicationData.programs) ? applicationData.programs : [],
-      listing?.listingMultiselectQuestions,
-      MultiselectQuestionsApplicationSectionEnum.programs
-    ).application.programs ?? []
+    (enableV2MSQ
+      ? mapApiToMultiselectForm(
+          getSelectionsForApplicationSection(
+            listing?.listingMultiselectQuestions || [],
+            MultiselectQuestionsApplicationSectionEnum.programs,
+            applicationData.applicationSelections
+          ) || [],
+          listing?.listingMultiselectQuestions || [],
+          MultiselectQuestionsApplicationSectionEnum.programs
+        ).application.programs
+      : mapApiToMultiselectFormV1(
+          Array.isArray(applicationData.programs) ? applicationData.programs : [],
+          listing?.listingMultiselectQuestions,
+          MultiselectQuestionsApplicationSectionEnum.programs
+        ).application.programs) ?? []
 
   const application: ApplicationTypes = (() => {
     const {

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -29,6 +29,7 @@ import {
   MultiselectQuestionsApplicationSectionEnum,
   Application,
   ApplicationSelectionUpdate,
+  ApplicationMultiselectQuestion,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 dayjs.extend(customParseFormat)
 
@@ -72,6 +73,7 @@ type mapFormToApiProps = {
   editMode: boolean
   programs: MultiselectQuestion[]
   preferences: MultiselectQuestion[]
+  enableV2MSQ: boolean
 }
 
 /*
@@ -84,6 +86,7 @@ export const mapFormToApi = ({
   editMode,
   programs,
   preferences,
+  enableV2MSQ
 }: mapFormToApiProps) => {
   const language: LanguagesEnum | null = data.application?.language
     ? data.application?.language
@@ -145,29 +148,35 @@ export const mapFormToApi = ({
     }
   })()
 
-  // TODO:
-  const preferencesData = preferences.map((pref: MultiselectQuestion) => {
-    return mapCheckboxesToApiV1(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences)
-  })
+  let preferencesData: ApplicationMultiselectQuestion[] = []
+  if (!enableV2MSQ) {
+    preferencesData = preferences.map((pref: MultiselectQuestion) => {
+      return mapCheckboxesToApiV1(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences)
+    })
+  }
 
-  // TODO:
-  const programsData = programs.map((program: MultiselectQuestion) => {
-    return mapCheckboxesToApiV1(data, program, MultiselectQuestionsApplicationSectionEnum.programs)
-  })
+  let programsData: ApplicationMultiselectQuestion[] = []
+  if (!enableV2MSQ) {
+    programsData = programs.map((program: MultiselectQuestion) => {
+      return mapCheckboxesToApiV1(data, program, MultiselectQuestionsApplicationSectionEnum.programs)
+    })
+  }
 
   let selections: ApplicationSelectionUpdate[] = []
-  programs.forEach((program: MultiselectQuestion) => {
-    selections = [
-      ...selections,
-      mapCheckboxesToApi(data, program, MultiselectQuestionsApplicationSectionEnum.programs),
-    ]
-  })
-  preferences.forEach((pref: MultiselectQuestion) => {
-    selections = [
-      ...selections,
-      mapCheckboxesToApi(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences),
-    ]
-  })
+  if (enableV2MSQ) {
+    programs.forEach((program: MultiselectQuestion) => {
+      selections = [
+        ...selections,
+        mapCheckboxesToApi(data, program, MultiselectQuestionsApplicationSectionEnum.programs),
+      ]
+    })
+    preferences.forEach((pref: MultiselectQuestion) => {
+      selections = [
+        ...selections,
+        mapCheckboxesToApi(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences),
+      ]
+    })
+  }
 
   // additional phone
   const {
@@ -268,9 +277,7 @@ export const mapFormToApi = ({
     householdExpectingChanges,
     householdStudent,
     reasonableAccommodations,
-    // TODO:
     preferences: preferencesData,
-    // TODO:
     programs: programsData,
     applicationSelections: selections,
     income,

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -6,6 +6,7 @@ import {
   mapCheckboxesToApiV1,
   mapApiToMultiselectForm,
   getSelectionsForApplicationSection,
+  mapCheckboxesToApi,
 } from "@bloom-housing/shared-helpers"
 import { FormTypes, ApplicationTypes, Address } from "../../lib/applications/FormTypes"
 
@@ -27,6 +28,7 @@ import {
   Listing,
   MultiselectQuestionsApplicationSectionEnum,
   Application,
+  ApplicationSelectionUpdate,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 dayjs.extend(customParseFormat)
 
@@ -143,12 +145,28 @@ export const mapFormToApi = ({
     }
   })()
 
+  // TODO:
   const preferencesData = preferences.map((pref: MultiselectQuestion) => {
     return mapCheckboxesToApiV1(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences)
   })
 
+  // TODO:
   const programsData = programs.map((program: MultiselectQuestion) => {
     return mapCheckboxesToApiV1(data, program, MultiselectQuestionsApplicationSectionEnum.programs)
+  })
+
+  let selections: ApplicationSelectionUpdate[] = []
+  programs.forEach((program: MultiselectQuestion) => {
+    selections = [
+      ...selections,
+      mapCheckboxesToApi(data, program, MultiselectQuestionsApplicationSectionEnum.programs),
+    ]
+  })
+  preferences.forEach((pref: MultiselectQuestion) => {
+    selections = [
+      ...selections,
+      mapCheckboxesToApi(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences),
+    ]
   })
 
   // additional phone
@@ -250,8 +268,11 @@ export const mapFormToApi = ({
     householdExpectingChanges,
     householdStudent,
     reasonableAccommodations,
+    // TODO:
     preferences: preferencesData,
+    // TODO:
     programs: programsData,
+    applicationSelections: selections,
     income,
     incomePeriod,
     incomeVouchers,

--- a/sites/partners/src/lib/applications/formatApplicationData.ts
+++ b/sites/partners/src/lib/applications/formatApplicationData.ts
@@ -86,7 +86,7 @@ export const mapFormToApi = ({
   editMode,
   programs,
   preferences,
-  enableV2MSQ
+  enableV2MSQ,
 }: mapFormToApiProps) => {
   const language: LanguagesEnum | null = data.application?.language
     ? data.application?.language
@@ -151,14 +151,22 @@ export const mapFormToApi = ({
   let preferencesData: ApplicationMultiselectQuestion[] = []
   if (!enableV2MSQ) {
     preferencesData = preferences.map((pref: MultiselectQuestion) => {
-      return mapCheckboxesToApiV1(data, pref, MultiselectQuestionsApplicationSectionEnum.preferences)
+      return mapCheckboxesToApiV1(
+        data,
+        pref,
+        MultiselectQuestionsApplicationSectionEnum.preferences
+      )
     })
   }
 
   let programsData: ApplicationMultiselectQuestion[] = []
   if (!enableV2MSQ) {
     programsData = programs.map((program: MultiselectQuestion) => {
-      return mapCheckboxesToApiV1(data, program, MultiselectQuestionsApplicationSectionEnum.programs)
+      return mapCheckboxesToApiV1(
+        data,
+        program,
+        MultiselectQuestionsApplicationSectionEnum.programs
+      )
     })
   }
 


### PR DESCRIPTION
This PR addresses #5158 & #6138

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

You can now create & edit applications using the V2MSQ schema.

## How Can This Be Tested/Reviewed?

Ensure that both V1 and V2 work for editing applications. You may need to reseed locally (first `yarn db:setup:staging --msqV2` and then without that flag)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
