### PR TITLE
feat: mfa flow when phone disabled

### DIFF
--- a/sites/partners/__tests__/pages/sign-in.test.tsx
+++ b/sites/partners/__tests__/pages/sign-in.test.tsx
@@ -295,6 +295,60 @@ describe("Partners Sign In Page", () => {
         expect(mockRouter.push).toHaveBeenCalledWith("/")
       })
     })
+
+    it("skips MFA type step when SMS MFA is disabled", async () => {
+      process.env.showSmsMfa = ""
+
+      try {
+        const mockError = {
+          response: {
+            status: 401,
+            data: {
+              name: "mfaCodeIsMissing",
+              message: "MFA code is missing",
+            },
+          },
+        }
+
+        const mockLogin = jest.fn().mockRejectedValue(mockError)
+        const mockRequestMfaCode = jest.fn().mockResolvedValue({ phoneNumberVerified: true })
+
+        const { getByLabelText, getByRole, findByText, queryByText } = render(
+          <AuthContext.Provider
+            value={{
+              initialStateLoaded: true,
+              profile: undefined,
+              login: mockLogin,
+              requestMfaCode: mockRequestMfaCode,
+              doJurisdictionsHaveFeatureFlagOn: mockDoJurisdictionsHaveFeatureFlagOn,
+            }}
+          >
+            <MessageContext.Provider value={TOAST_MESSAGE}>
+              <SignIn />
+            </MessageContext.Provider>
+          </AuthContext.Provider>
+        )
+
+        fireEvent.change(getByLabelText("Email"), { target: { value: "partner@example.com" } })
+        fireEvent.change(getByLabelText("Password"), { target: { value: "password123" } })
+        fireEvent.click(getByRole("button", { name: /sign in/i }))
+
+        await waitFor(() => {
+          expect(mockRequestMfaCode).toHaveBeenCalledWith(
+            "partner@example.com",
+            "password123",
+            MfaType.email
+          )
+        })
+
+        expect(await findByText(/we sent a code to your email/i)).toBeInTheDocument()
+        expect(
+          queryByText(/how would you like us to verify that it's you\?/i)
+        ).not.toBeInTheDocument()
+      } finally {
+        process.env.showSmsMfa = "TRUE"
+      }
+    })
   })
 
   describe("Phone number addition flow tests", () => {

--- a/sites/partners/src/components/users/FormSignInMFAType.tsx
+++ b/sites/partners/src/components/users/FormSignInMFAType.tsx
@@ -30,6 +30,8 @@ const FormSignInMFAType = ({
     window.scrollTo(0, 0)
   }
 
+  const showSmsMfa = String(process.env.showSmsMfa).toLowerCase() === "true"
+
   return (
     <BloomCard
       iconSymbol="userCircle"
@@ -73,7 +75,7 @@ const FormSignInMFAType = ({
           >
             {t("nav.signInMFA.verifyByEmail")}
           </Button>
-          {process.env.showSmsMfa && (
+          {showSmsMfa && (
             <div className={"seeds-m-bs-4"}>
               <Button
                 type="submit"

--- a/sites/partners/src/lib/users/signInHelpers.ts
+++ b/sites/partners/src/lib/users/signInHelpers.ts
@@ -12,11 +12,14 @@ export const onSubmitEmailAndPassword =
     setEmail,
     setPassword,
     setRenderStep,
+    setMfaType,
     determineNetworkError,
     login,
+    requestMfaCode,
     router,
     resetNetworkError,
     setLoading,
+    showSmsMfa,
     reCaptchaEnabled,
     reCaptchaToken,
     setRefreshReCaptcha,
@@ -55,7 +58,20 @@ export const onSubmitEmailAndPassword =
         setEmail(email)
         setPassword(password)
         resetNetworkError()
-        setRenderStep(EnumRenderStep.mfaType)
+
+        if (showSmsMfa) {
+          setRenderStep(EnumRenderStep.mfaType)
+          return
+        }
+
+        try {
+          await requestMfaCode(email, password, MfaType.email)
+          setMfaType(MfaType.email)
+          setRenderStep(EnumRenderStep.enterCode)
+        } catch (requestError) {
+          const { status } = requestError.response || {}
+          determineNetworkError(status, requestError)
+        }
       } else {
         const { status } = error.response || {}
         determineNetworkError(status, error)

--- a/sites/partners/src/pages/sign-in.tsx
+++ b/sites/partners/src/pages/sign-in.tsx
@@ -56,6 +56,7 @@ const SignIn = () => {
   }>()
 
   const reCaptchaEnabled = !!process.env.reCaptchaKey
+  const showSmsMfa = String(process.env.showSmsMfa).toLowerCase() === "true"
 
   const {
     mutate: mutateResendConfirmation,
@@ -156,11 +157,14 @@ const SignIn = () => {
               setEmail,
               setPassword,
               setRenderStep,
+              setMfaType,
               determineNetworkError,
               login,
+              requestMfaCode,
               router,
               resetNetworkError,
               setLoading,
+              showSmsMfa,
               reCaptchaEnabled,
               reCaptchaToken,
               setRefreshReCaptcha,


### PR DESCRIPTION
This PR addresses #6100

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Skip the MFA type (email or phone) step when SMS MFA is disabled.

## How Can This Be Tested/Reviewed?

Locally, set `SHOW_SMS_MFA` in partners to `TRUE`. Create a new partner user, confirm them, then re-login. Ensure the flow is unchanged - the SMS type step still shows and has both email and phone options. Then set it to `FALSE` and, login as the same user, and ensure the type step never appears and the email code is automatically sent.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
