### PR TITLE
fix: missing description n/a

### DIFF
--- a/sites/partners/src/components/settings/MultiselectQuestions/MultiselectQuestionViewDrawer.tsx
+++ b/sites/partners/src/components/settings/MultiselectQuestions/MultiselectQuestionViewDrawer.tsx
@@ -100,7 +100,9 @@ const MultiselectQuestionViewDrawer = ({
                         data={questionData.multiselectOptions.map((item) => ({
                           order: { content: item.ordinal },
                           name: { content: item.name },
-                          description: { content: item.description ?? t("t.n/a") },
+                          description: {
+                            content: item.description ? item.description : t("t.n/a"),
+                          },
                           view: {
                             content: (
                               <Button
@@ -197,7 +199,7 @@ const MultiselectQuestionViewDrawer = ({
                 <Grid.Row>
                   <FieldValue label={t("t.title")}>{optionData?.name}</FieldValue>
                   <FieldValue label={t("t.descriptionTitle")}>
-                    {optionData?.description ?? t("t.n/a")}
+                    {optionData?.description ? optionData.description : t("t.n/a")}
                   </FieldValue>
                 </Grid.Row>
                 {optionData?.links?.length > 0 && (


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Newly created MSQs in v2 have an empty string in the description. Need to account for this when displaying `n/a`

## How Can This Be Tested/Reviewed?

Run `yarn setup --msqV2`
Run application
Login to partner site
Under Settings-Preferences, create a new preference with no descriptions filled out. Make visible to partners.
Add to an active listing
Return to preferences table and view, description fields should show `n/a`

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
