### PR TITLE
fix: update queries for given and family name tests

### DIFF
--- a/sites/public/__tests__/components/account/EditAdvocateAccount.test.tsx
+++ b/sites/public/__tests__/components/account/EditAdvocateAccount.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { useRouter } from "next/router"
 import userEvent from "@testing-library/user-event"
 import { AuthContext } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
 import { user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { Agency, User, UserService } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { EditAdvocateAccount } from "../../../src/components/account/EditAdvocateAccount"
@@ -106,7 +107,9 @@ describe("EditAdvocateAccount", () => {
     renderEditAdvocateAccount()
 
     await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "First or given name" })).toBeInTheDocument()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+      ).toBeInTheDocument()
     })
 
     await userEvent.selectOptions(screen.getByRole("combobox", { name: "Agency" }), "agency-2")
@@ -197,7 +200,9 @@ describe("EditAdvocateAccount", () => {
     renderEditAdvocateAccount()
 
     await waitFor(() => {
-      expect(screen.getByRole("textbox", { name: "First or given name" })).toBeInTheDocument()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+      ).toBeInTheDocument()
     })
 
     await userEvent.click(screen.getByRole("button", { name: "Update Agency" }))

--- a/sites/public/__tests__/components/account/EditPublicAccount.test.tsx
+++ b/sites/public/__tests__/components/account/EditPublicAccount.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import userEvent from "@testing-library/user-event"
 import { useRouter } from "next/router"
 import { user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { t } from "@bloom-housing/ui-components"
 import { AuthContext } from "@bloom-housing/shared-helpers"
 import { User, UserService } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import Edit from "../../../src/pages/account/edit"
@@ -98,8 +99,12 @@ describe("EditPublicAccount", () => {
         expect(screen.getByDisplayValue("First")).toBeInTheDocument()
       })
 
-      const firstNameField = screen.getByLabelText("First or given name", { selector: "input" })
-      const lastNameField = screen.getByLabelText("Last or family name", { selector: "input" })
+      const firstNameField = screen.getByLabelText(t("application.name.firstOrGivenName"), {
+        selector: "input",
+      })
+      const lastNameField = screen.getByLabelText(t("application.name.lastOrFamilyName"), {
+        selector: "input",
+      })
       const updateButton = document.getElementById("account-submit-name")
 
       await userEvent.clear(firstNameField)

--- a/sites/public/__tests__/components/listing/ListingViewSeeds.test.tsx
+++ b/sites/public/__tests__/components/listing/ListingViewSeeds.test.tsx
@@ -583,7 +583,7 @@ describe("<ListingViewSeeds>", () => {
       expect(hmiSectionTitle).toBeInTheDocument()
       expect(
         within(hmiSectionTitle.parentElement).getByText(
-          "For income calculations, household size includes everyone (all ages) living in the unit."
+          /For income calculations, household size includes everyone \(all ages\) living in the unit\./
         )
       ).toBeInTheDocument()
       expect(

--- a/sites/public/__tests__/pages/applications/contact/alternate-contact-name.test.tsx
+++ b/sites/public/__tests__/pages/applications/contact/alternate-contact-name.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { setupServer } from "msw/lib/node"
 import { fireEvent } from "@testing-library/react"
+import { t } from "@bloom-housing/ui-components"
 import { mockNextRouter, render } from "../../../testUtils"
 import ApplicationAlternateContactName from "../../../../src/pages/applications/contact/alternate-contact-name"
 import {
@@ -87,8 +88,8 @@ describe("applications pages", () => {
       expect(
         await findByText("There are errors you'll need to resolve before moving on.")
       ).toBeInTheDocument()
-      expect(getByText("Please enter a given name")).toBeInTheDocument()
-      expect(getByText("Please enter a family name")).toBeInTheDocument()
+      expect(getByText(t("errors.givenNameError"))).toBeInTheDocument()
+      expect(getByText(t("errors.familyNameError"))).toBeInTheDocument()
     })
 
     it("should disable fields and autofill alternate contact name for advocates", async () => {

--- a/sites/public/__tests__/pages/applications/contact/name.test.tsx
+++ b/sites/public/__tests__/pages/applications/contact/name.test.tsx
@@ -1,6 +1,9 @@
 import React from "react"
 import { setupServer } from "msw/lib/node"
 import { fireEvent } from "@testing-library/react"
+import { AuthContext, blankApplication } from "@bloom-housing/shared-helpers"
+import { listing, user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { t } from "@bloom-housing/ui-components"
 import { mockNextRouter, render } from "../../../testUtils"
 import ApplicationName from "../../../../src/pages/applications/contact/name"
 import {
@@ -8,8 +11,6 @@ import {
   retrieveApplicationConfig,
 } from "../../../../src/lib/applications/AppSubmissionContext"
 import ApplicationConductor from "../../../../src/lib/applications/ApplicationConductor"
-import { AuthContext, blankApplication } from "@bloom-housing/shared-helpers"
-import { listing, user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 
 window.scrollTo = jest.fn()
 
@@ -86,8 +87,8 @@ describe("applications pages", () => {
       expect(
         await findByText("There are errors you'll need to resolve before moving on.")
       ).toBeInTheDocument()
-      expect(getByText("Please enter a given name")).toBeInTheDocument()
-      expect(getByText("Please enter a family name")).toBeInTheDocument()
+      expect(getByText(t("errors.givenNameError"))).toBeInTheDocument()
+      expect(getByText(t("errors.familyNameError"))).toBeInTheDocument()
       expect(
         getByText("Please enter a valid date of birth, must be 18 or older")
       ).toBeInTheDocument()

--- a/sites/public/__tests__/pages/applications/household/member.test.tsx
+++ b/sites/public/__tests__/pages/applications/household/member.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { setupServer } from "msw/lib/node"
 import { fireEvent } from "@testing-library/react"
+import { t } from "@bloom-housing/ui-components"
 import { mockNextRouter, render } from "../../../testUtils"
 import ApplicationMember from "../../../../src/pages/applications/household/member"
 
@@ -45,8 +46,8 @@ describe("applications pages", () => {
       expect(
         await findByText("There are errors you'll need to resolve before moving on.")
       ).toBeInTheDocument()
-      expect(getByText("Please enter a given name")).toBeInTheDocument()
-      expect(getByText("Please enter a family name")).toBeInTheDocument()
+      expect(getByText(t("errors.givenNameError"))).toBeInTheDocument()
+      expect(getByText(t("errors.familyNameError"))).toBeInTheDocument()
       expect(getByText("Please enter a valid date of birth")).toBeInTheDocument()
       expect(getAllByText("Please select one of the options above.")).toHaveLength(3)
     })

--- a/sites/public/__tests__/pages/complete-advocate-account.test.tsx
+++ b/sites/public/__tests__/pages/complete-advocate-account.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import userEvent from "@testing-library/user-event"
 import { AuthContext } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
 import {
   Agency,
   AuthService,
@@ -95,8 +96,12 @@ describe("CompleteAdvocateAccount page", () => {
       expect(
         screen.getByText("Please fill out the required fields to complete your account setup.")
       ).toBeInTheDocument()
-      expect(screen.getByRole("textbox", { name: "First or given name" })).toBeInTheDocument()
-      expect(screen.getByRole("textbox", { name: "Last or family name" })).toBeInTheDocument()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") })
+      ).toBeInTheDocument()
       expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument()
     })
 
@@ -106,9 +111,13 @@ describe("CompleteAdvocateAccount page", () => {
       renderPage()
 
       await waitFor(() => {
-        expect(screen.getByRole("textbox", { name: "First or given name" })).toHaveValue("Jane")
+        expect(
+          screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+        ).toHaveValue("Jane")
       })
-      expect(screen.getByRole("textbox", { name: "Last or family name" })).toHaveValue("Doe")
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") })
+      ).toHaveValue("Doe")
     })
 
     it("shows the expired/resend state when the token is invalid", async () => {
@@ -250,8 +259,12 @@ describe("CompleteAdvocateAccount page", () => {
       })
 
       // Name section (pre-filled from existing user)
-      expect(screen.getByRole("textbox", { name: "First or given name" })).toHaveValue("Jane")
-      expect(screen.getByRole("textbox", { name: "Last or family name" })).toHaveValue("Doe")
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+      ).toHaveValue("Jane")
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") })
+      ).toHaveValue("Doe")
 
       // Address section
       expect(screen.getByRole("textbox", { name: "Street address" })).toBeInTheDocument()

--- a/sites/public/__tests__/pages/create-account.test.tsx
+++ b/sites/public/__tests__/pages/create-account.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, mockNextRouter, render, waitFor, screen } from "../testUtils"
 import { user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
+import { t } from "@bloom-housing/ui-components"
 import React from "react"
 import CreateAccount from "../../src/pages/create-account"
 import userEvent from "@testing-library/user-event"
@@ -35,9 +36,13 @@ describe("Create Account Page", () => {
     expect(screen.getByRole("heading", { name: /create account/i, level: 1 })).toBeInTheDocument()
 
     expect(screen.getByText("Your name", { selector: "legend" })).toBeInTheDocument()
-    verifyInitialInput(screen.getByRole("textbox", { name: /first or given name/i }))
+    verifyInitialInput(
+      screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+    )
     verifyInitialInput(screen.getByRole("textbox", { name: /middle name \(optional\)/i }))
-    verifyInitialInput(screen.getByRole("textbox", { name: /last or family name/i }))
+    verifyInitialInput(
+      screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") })
+    )
 
     expect(screen.getByText("Your date of birth", { selector: "legend" })).toBeInTheDocument()
     verifyInitialInput(screen.getByRole("textbox", { name: /month/i }))
@@ -101,10 +106,14 @@ describe("Create Account Page", () => {
       expect(createAccountButton).toBeInTheDocument()
       await userEvent.click(createAccountButton)
 
-      expect(screen.getByRole("textbox", { name: /first or given name/i })).toBeInvalid()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+      ).toBeInvalid()
       expect(screen.getByText("Please enter a first name")).toBeInTheDocument()
 
-      expect(screen.getByRole("textbox", { name: /last or family name/i })).toBeInvalid()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") })
+      ).toBeInvalid()
       expect(screen.getByText("Please enter a last name")).toBeInTheDocument()
 
       expect(screen.getByRole("textbox", { name: /month/i })).toBeInvalid()
@@ -128,9 +137,13 @@ describe("Create Account Page", () => {
       render(<CreateAccount />)
 
       const createAccountButton = screen.getByRole("button", { name: /create account/i })
-      const firstNameField = screen.getByRole("textbox", { name: /first or given name/i })
+      const firstNameField = screen.getByRole("textbox", {
+        name: t("application.name.firstOrGivenName"),
+      })
       const middleNameField = screen.getByRole("textbox", { name: /middle name \(optional\)/i })
-      const lastNameField = screen.getByRole("textbox", { name: /last or family name/i })
+      const lastNameField = screen.getByRole("textbox", {
+        name: t("application.name.lastOrFamilyName"),
+      })
       expect(firstNameField).toBeInTheDocument()
       expect(middleNameField).toBeInTheDocument()
       expect(lastNameField).toBeInTheDocument()
@@ -385,9 +398,15 @@ describe("Create Account Page", () => {
 
       expect(screen.getByRole("heading", { name: /create account/i, level: 1 })).toBeInTheDocument()
 
-      await userEvent.type(screen.getByRole("textbox", { name: /first or given name/i }), "John")
+      await userEvent.type(
+        screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") }),
+        "John"
+      )
       await userEvent.type(screen.getByRole("textbox", { name: /middle name/i }), "Admin")
-      await userEvent.type(screen.getByRole("textbox", { name: /last or family name/i }), "Doe")
+      await userEvent.type(
+        screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") }),
+        "Doe"
+      )
       await userEvent.type(screen.getByRole("textbox", { name: /month/i }), "2")
       await userEvent.type(screen.getByRole("textbox", { name: /day/i }), "4")
       await userEvent.type(screen.getByRole("textbox", { name: /year/i }), "2000")
@@ -423,9 +442,15 @@ describe("Create Account Page", () => {
 
     expect(screen.getByRole("heading", { name: /create account/i, level: 1 })).toBeInTheDocument()
 
-    await userEvent.type(screen.getByRole("textbox", { name: /first or given name/i }), "John")
+    await userEvent.type(
+      screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") }),
+      "John"
+    )
     await userEvent.type(screen.getByRole("textbox", { name: /middle name/i }), "Admin")
-    await userEvent.type(screen.getByRole("textbox", { name: /last or family name/i }), "Doe")
+    await userEvent.type(
+      screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") }),
+      "Doe"
+    )
     await userEvent.type(screen.getByRole("textbox", { name: /month/i }), "2")
     await userEvent.type(screen.getByRole("textbox", { name: /day/i }), "4")
     await userEvent.type(screen.getByRole("textbox", { name: /year/i }), "2000")

--- a/sites/public/__tests__/pages/create-advocate-account.test.tsx
+++ b/sites/public/__tests__/pages/create-advocate-account.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { setupServer } from "msw/lib/node"
 import userEvent from "@testing-library/user-event"
+import { t } from "@bloom-housing/ui-components"
 import { Agency } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { fireEvent, mockNextRouter, render, screen, waitFor } from "../testUtils"
 import CreateAdvocateAccount from "../../src/pages/create-advocate-account"
@@ -49,8 +50,12 @@ const fillAdvocateForm = async (
   email = "john.doe@example.com",
   agency = "agency-1"
 ) => {
-  const firstNameField = screen.getByRole("textbox", { name: "First or given name" })
-  const lastNameField = screen.getByRole("textbox", { name: "Last or family name" })
+  const firstNameField = screen.getByRole("textbox", {
+    name: t("application.name.firstOrGivenName"),
+  })
+  const lastNameField = screen.getByRole("textbox", {
+    name: t("application.name.lastOrFamilyName"),
+  })
   const emailField = screen.getByRole("textbox", { name: "Email" })
   const agencySelect = screen.getByRole("combobox", { name: "Agency" })
   const submitButton = screen.getByRole("button", { name: "Request an account" })
@@ -73,9 +78,13 @@ describe("Create advocate page", () => {
     expect(screen.getByText("Housing advocate")).toBeInTheDocument()
 
     expect(screen.getByText("Your name", { selector: "legend" })).toBeInTheDocument()
-    expect(screen.getByRole("textbox", { name: "First or given name" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+    ).toBeInTheDocument()
     expect(screen.getByRole("textbox", { name: "Middle name (optional)" })).toBeInTheDocument()
-    expect(screen.getByRole("textbox", { name: "Last or family name" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") })
+    ).toBeInTheDocument()
 
     expect(screen.getByText("Your organization")).toBeInTheDocument()
     expect(screen.getByRole("combobox", { name: "Agency" })).toBeInTheDocument()
@@ -117,10 +126,14 @@ describe("Create advocate page", () => {
       const submitButton = screen.getByRole("button", { name: "Request an account" })
       await userEvent.click(submitButton)
 
-      expect(screen.getByRole("textbox", { name: "First or given name" })).toBeInvalid()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.firstOrGivenName") })
+      ).toBeInvalid()
       expect(screen.getByText("Please enter a first name")).toBeInTheDocument()
 
-      expect(screen.getByRole("textbox", { name: "Last or family name" })).toBeInvalid()
+      expect(
+        screen.getByRole("textbox", { name: t("application.name.lastOrFamilyName") })
+      ).toBeInvalid()
       expect(screen.getByText("Please enter a last name")).toBeInTheDocument()
 
       expect(screen.getByRole("textbox", { name: "Email" })).toBeInvalid()
@@ -134,9 +147,13 @@ describe("Create advocate page", () => {
       renderCreateAdvocateAccountPage()
 
       const submitButton = screen.getByRole("button", { name: "Request an account" })
-      const firstNameField = screen.getByRole("textbox", { name: "First or given name" })
+      const firstNameField = screen.getByRole("textbox", {
+        name: t("application.name.firstOrGivenName"),
+      })
       const middleNameField = screen.getByRole("textbox", { name: "Middle name (optional)" })
-      const lastNameField = screen.getByRole("textbox", { name: "Last or family name" })
+      const lastNameField = screen.getByRole("textbox", {
+        name: t("application.name.lastOrFamilyName"),
+      })
 
       await userEvent.type(firstNameField, Array(65).fill("a").join(""))
       await userEvent.type(middleNameField, Array(65).fill("a").join(""))


### PR DESCRIPTION
This PR addresses #6131

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Updates the queries for given and family name so that the [LA PR](https://github.com/bloom-housing/bloom-la/pull/58) that overrides these strings can pass the tests.

## How Can This Be Tested/Reviewed?

Ensure the tests pass!

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
