### PR TITLE
feat: autopopulate reserved community type description

### DIFF
--- a/api/prisma/seed-helpers/reserved-community-type-factory.ts
+++ b/api/prisma/seed-helpers/reserved-community-type-factory.ts
@@ -1,19 +1,25 @@
 import { Prisma, PrismaClient, ReservedCommunityTypes } from '@prisma/client';
 import { randomInt } from 'crypto';
 
-const reservedCommunityTypeOptions = [
-  'specialNeeds',
-  'senior',
-  'senior55',
-  'senior62',
-  'specialNeeds',
-  'developmentalDisability',
-  'tay',
-  'veteran',
-  'schoolEmployee',
-  'farmworkerHousing',
-  'housingVoucher',
-  'referralOnly',
+const reservedCommunityTypeOptions: { name: string; description?: string }[] = [
+  { name: 'specialNeeds' },
+  {
+    name: 'senior',
+  },
+  { name: 'senior55' },
+  {
+    name: 'senior62',
+    description:
+      'This property is reserved for seniors aged 62 and older. Applicants must meet the age requirement to be eligible.',
+  },
+  { name: 'specialNeeds' },
+  { name: 'developmentalDisability' },
+  { name: 'tay' },
+  { name: 'veteran' },
+  { name: 'schoolEmployee' },
+  { name: 'farmworkerHousing' },
+  { name: 'housingVoucher' },
+  { name: 'referralOnly' },
 ];
 
 export const reservedCommunityTypeFactory = (
@@ -36,9 +42,10 @@ export const reservedCommunityTypeFactoryAll = async (
   prismaClient: PrismaClient,
 ) => {
   await prismaClient.reservedCommunityTypes.createMany({
-    data: reservedCommunityTypeOptions.map((value) => ({
-      name: value,
-      jurisdictionId: jurisdictionId,
+    data: reservedCommunityTypeOptions.map(({ name, description }) => ({
+      name,
+      description,
+      jurisdictionId,
     })),
   });
 };
@@ -51,9 +58,8 @@ export const reservedCommunityTypeFactoryGet = async (
   // if name is not given pick one randomly from the above list
   const chosenName =
     name ||
-    reservedCommunityTypeOptions[
-      randomInt(reservedCommunityTypeOptions.length)
-    ];
+    reservedCommunityTypeOptions[randomInt(reservedCommunityTypeOptions.length)]
+      .name;
   const reservedCommunityType =
     await prismaClient.reservedCommunityTypes.findFirst({
       where: {

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -344,6 +344,7 @@ export const stagingSeed = async (
         FeatureFlagEnum.enableSmokingPolicyRadio,
         FeatureFlagEnum.enableSpokenLanguage,
         FeatureFlagEnum.enableUnitAccessibilityTypeTags,
+        FeatureFlagEnum.disableReservedCommunityTypeEdit,
       ],
       visibleNeighborhoodAmenities: [
         NeighborhoodAmenitiesEnum.groceryStores,

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -8,6 +8,7 @@ export enum FeatureFlagEnum {
   disableEthnicityQuestion = 'disableEthnicityQuestion',
   disableJurisdictionalAdmin = 'disableJurisdictionalAdmin',
   disableListingPreferences = 'disableListingPreferences',
+  disableReservedCommunityTypeEdit = 'disableReservedCommunityTypeEdit',
   disableWorkInRegion = 'disableWorkInRegion',
   enableAccessibilityFeatures = 'enableAccessibilityFeatures',
   enableAdaOtherOption = 'enableAdaOtherOption',
@@ -22,14 +23,14 @@ export enum FeatureFlagEnum {
   enableGeocodingRadiusMethod = 'enableGeocodingRadiusMethod',
   enableHomeType = 'enableHomeType',
   enableHousingAdvocate = 'enableHousingAdvocate',
-  enableHousingDeveloperOwner = 'enableHousingDeveloperOwner',
   enableHousingBasics = 'enableHousingBasics',
+  enableHousingDeveloperOwner = 'enableHousingDeveloperOwner',
   enableIsVerified = 'enableIsVerified',
+  enableLeasingAgentAltText = 'enableLeasingAgentAltText',
   enableLimitedHowDidYouHear = 'enableLimitedHowDidYouHear',
   enableListingFavoriting = 'enableListingFavoriting',
   enableListingFileNumber = 'enableListingFileNumber',
   enableListingFiltering = 'enableListingFiltering',
-  enableLeasingAgentAltText = 'enableLeasingAgentAltText',
   enableListingImageAltText = 'enableListingImageAltText',
   enableListingOpportunity = 'enableListingOpportunity',
   enableListingPagination = 'enableListingPagination',
@@ -41,6 +42,7 @@ export enum FeatureFlagEnum {
   enableNeighborhoodAmenitiesDropdown = 'enableNeighborhoodAmenitiesDropdown',
   enableNonRegulatedListings = 'enableNonRegulatedListings',
   enableParkingFee = 'enableParkingFee',
+  enableParkingType = 'enableParkingType',
   enablePartnerDemographics = 'enablePartnerDemographics',
   enablePartnerSettings = 'enablePartnerSettings',
   enablePetPolicyCheckbox = 'enablePetPolicyCheckbox',
@@ -58,16 +60,14 @@ export enum FeatureFlagEnum {
   enableUnitAccessibilityTypeTags = 'enableUnitAccessibilityTypeTags',
   enableUnitGroups = 'enableUnitGroups',
   enableUtilitiesIncluded = 'enableUtilitiesIncluded',
+  enableV2MSQ = 'enableV2MSQ',
   enableVerifyIncome = 'enableVerifyIncome',
   enableWaitlistAdditionalFields = 'enableWaitlistAdditionalFields',
   enableWaitlistLottery = 'enableWaitlistLottery',
   enableWhatToExpectAdditionalField = 'enableWhatToExpectAdditionalField',
-  enableParkingType = 'enableParkingType',
-  enableV2MSQ = 'enableV2MSQ',
   example = 'example', // sample feature flag for testing purposes
   hideCloseListingButton = 'hideCloseListingButton',
   swapCommunityTypeWithPrograms = 'swapCommunityTypeWithPrograms',
-  disableReservedCommunityTypeEdit = 'disableReservedCommunityTypeEdit',
 }
 
 // List of all of existing flags and their descriptions.
@@ -105,6 +105,11 @@ export const featureFlagMap: {
     name: FeatureFlagEnum.disableListingPreferences,
     description:
       'When true listings will no longer support preferences section',
+  },
+  {
+    name: FeatureFlagEnum.disableReservedCommunityTypeEdit,
+    description:
+      'When true, disables editing of reserved community type description in the partners site (shows as plaintext only).',
   },
   {
     name: FeatureFlagEnum.disableWorkInRegion,
@@ -380,10 +385,5 @@ export const featureFlagMap: {
     name: FeatureFlagEnum.swapCommunityTypeWithPrograms,
     description:
       'When true, the programs section on the frontend is displayed as community types.',
-  },
-  {
-    name: FeatureFlagEnum.disableReservedCommunityTypeEdit,
-    description:
-      'When true, disables editing of reserved community type description in the partners site (shows as plaintext only).',
   },
 ];

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -67,6 +67,7 @@ export enum FeatureFlagEnum {
   example = 'example', // sample feature flag for testing purposes
   hideCloseListingButton = 'hideCloseListingButton',
   swapCommunityTypeWithPrograms = 'swapCommunityTypeWithPrograms',
+  disableReservedCommunityTypeEdit = 'disableReservedCommunityTypeEdit',
 }
 
 // List of all of existing flags and their descriptions.
@@ -379,5 +380,10 @@ export const featureFlagMap: {
     name: FeatureFlagEnum.swapCommunityTypeWithPrograms,
     description:
       'When true, the programs section on the frontend is displayed as community types.',
+  },
+  {
+    name: FeatureFlagEnum.disableReservedCommunityTypeEdit,
+    description:
+      'When true, disables editing of reserved community type description in the partners site (shows as plaintext only).',
   },
 ];

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -91,5 +91,6 @@ The following are all of the feature flags currently available in the Bloom plat
 | [enableWhatToExpectAdditionalField](./feature-flags/enableWhatToExpectAdditionalField.md) | When true, the what to expect additional field is displayed in listing creation/edit form on the partner site |
 | [hideCloseListingButton](./feature-flags/hideCloseListingButton.md) | When true, close button is hidden on the listing edit form |
 | [swapCommunityTypeWithPrograms](./feature-flags/swapCommunityTypeWithPrograms.md) | When true, the programs section on the frontend is displayed as community types. |
+| [disableReservedCommunityTypeEdit](./feature-flags/disableReservedCommunityTypeEdit.md) | When true, disables editing of reserved community type description in the partners site (shows as plaintext only). |
 
 <!-- TABLE:END -->

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -33,6 +33,7 @@ The following are all of the feature flags currently available in the Bloom plat
 | [disableEthnicityQuestion](./feature-flags/disableEthnicityQuestion.md) | When true, the ethnicity question is hidden in the application demographics section |
 | [disableJurisdictionalAdmin](./feature-flags/disableJurisdictionalAdmin.md) | When true, jurisdictional admins cannot be created |
 | [disableListingPreferences](./feature-flags/disableListingPreferences.md) | When true listings will no longer support preferences section |
+| [disableReservedCommunityTypeEdit](./feature-flags/disableReservedCommunityTypeEdit.md) | When true, disables editing of reserved community type description in the partners site (shows as plaintext only). |
 | [disableWorkInRegion](./feature-flags/disableWorkInRegion.md) | When true the "Work in Region" question will be removed from the application process |
 | [enableAccessibilityFeatures](./feature-flags/enableAccessibilityFeatures.md) | When true, the 'accessibility features' section is displayed in listing creation/edit and the public listing view |
 | [enableAdaOtherOption](./feature-flags/enableAdaOtherOption.md) | When true, the ADA impairment options will include 'For Other Impairments' |
@@ -91,6 +92,5 @@ The following are all of the feature flags currently available in the Bloom plat
 | [enableWhatToExpectAdditionalField](./feature-flags/enableWhatToExpectAdditionalField.md) | When true, the what to expect additional field is displayed in listing creation/edit form on the partner site |
 | [hideCloseListingButton](./feature-flags/hideCloseListingButton.md) | When true, close button is hidden on the listing edit form |
 | [swapCommunityTypeWithPrograms](./feature-flags/swapCommunityTypeWithPrograms.md) | When true, the programs section on the frontend is displayed as community types. |
-| [disableReservedCommunityTypeEdit](./feature-flags/disableReservedCommunityTypeEdit.md) | When true, disables editing of reserved community type description in the partners site (shows as plaintext only). |
 
 <!-- TABLE:END -->

--- a/docs/feature-flags/disableReservedCommunityTypeEdit.md
+++ b/docs/feature-flags/disableReservedCommunityTypeEdit.md
@@ -1,0 +1,13 @@
+# disableReservedCommunityTypeEdit
+
+## Name
+
+`disableReservedCommunityTypeEdit`
+
+## Description
+
+When true, disables editing of reserved community type description in the partners site (shows as plaintext only).
+
+## Additional Information
+
+This flag only affects the partners site. The public site is unaffected.

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -10570,6 +10570,7 @@ export enum FeatureFlagEnum {
   "example" = "example",
   "hideCloseListingButton" = "hideCloseListingButton",
   "swapCommunityTypeWithPrograms" = "swapCommunityTypeWithPrograms",
+  "disableReservedCommunityTypeEdit" = "disableReservedCommunityTypeEdit",
 }
 
 export enum InputType {

--- a/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
@@ -150,6 +150,113 @@ describe("CommunityType", () => {
     expect(screen.getAllByText("Appears as first page of application")).toHaveLength(2)
   })
 
+  it("should pre-populate description from the listing's existing reservedCommunityDescription", async () => {
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(adminUserWithJurisdictions))
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      }),
+      rest.get("http://localhost/api/adapter/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      })
+    )
+
+    render(
+      <FormProviderWrapper
+        values={{
+          reservedCommunityDescription: "Custom description for this listing",
+          reservedCommunityTypes: { id: "rct1" } as never,
+        }}
+      >
+        <CommunityType
+          listing={{ reservedCommunityTypes: { id: "rct1" } } as never}
+          requiredFields={[]}
+          swapCommunityTypeWithPrograms={false}
+        />
+      </FormProviderWrapper>
+    )
+
+    await screen.findByRole("heading", { level: 2, name: "Community type" })
+    await screen.findByRole("option", { name: "Seniors" })
+
+    expect(screen.getByRole("textbox", { name: "Reserved community description" })).toHaveValue(
+      "Custom description for this listing"
+    )
+  })
+
+  it("should pre-populate description when selecting a community type", async () => {
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(adminUserWithJurisdictions))
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      }),
+      rest.get("http://localhost/api/adapter/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      })
+    )
+
+    render(
+      <FormProviderWrapper>
+        <CommunityType requiredFields={[]} swapCommunityTypeWithPrograms={false} />
+      </FormProviderWrapper>
+    )
+
+    await screen.findByRole("heading", { level: 2, name: "Community type" })
+    await screen.findByRole("option", { name: "Seniors" })
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Reserved community type" }),
+      "Seniors"
+    )
+
+    expect(screen.getByRole("textbox", { name: "Reserved community description" })).toHaveValue(
+      "For folks over the age of 65"
+    )
+  })
+
+  it("should allow the user to edit the pre-populated description", async () => {
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(adminUserWithJurisdictions))
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      }),
+      rest.get("http://localhost/api/adapter/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      })
+    )
+
+    render(
+      <FormProviderWrapper>
+        <CommunityType requiredFields={[]} swapCommunityTypeWithPrograms={false} />
+      </FormProviderWrapper>
+    )
+
+    await screen.findByRole("heading", { level: 2, name: "Community type" })
+    await screen.findByRole("option", { name: "Seniors" })
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Reserved community type" }),
+      "Seniors"
+    )
+
+    const textarea = screen.getByRole("textbox", { name: "Reserved community description" })
+    expect(textarea).toHaveValue("For folks over the age of 65")
+
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "Updated custom description")
+
+    expect(textarea).toHaveValue("Updated custom description")
+  })
+
   it("should not render when swapCommunityTypesWithPrograms is true", () => {
     document.cookie = "access-token-available=True"
     server.use(

--- a/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
@@ -310,10 +310,10 @@ describe("CommunityType", () => {
 
     // Description should be shown as plaintext
     expect(screen.getByText("For folks over the age of 65")).toBeInTheDocument()
-    // Textarea should be hidden
-    expect(
-      screen.queryByRole("textbox", { name: "Reserved community description" })
-    ).not.toBeVisible()
+    // Textarea should be present but visually hidden (has hidden-field class)
+    const textarea = screen.getByRole("textbox", { name: "Reserved community description" })
+    expect(textarea).toBeInTheDocument()
+    expect(textarea.closest(".hidden-field")).not.toBeNull()
   })
 
   it("should update plaintext description when dropdown changes in disabled edit mode", async () => {

--- a/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/sections/CommunityType.test.tsx
@@ -277,4 +277,81 @@ describe("CommunityType", () => {
 
     expect(results.queryAllByRole("heading", { level: 2, name: "Community type" })).toHaveLength(0)
   })
+
+  it("should show plaintext description and hide textarea when disableReservedCommunityTypeEdit is true", async () => {
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(adminUserWithJurisdictions))
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      })
+    )
+
+    render(
+      <FormProviderWrapper>
+        <CommunityType
+          requiredFields={[]}
+          disableReservedCommunityTypeEdit={true}
+          swapCommunityTypeWithPrograms={false}
+        />
+      </FormProviderWrapper>
+    )
+
+    await screen.findByRole("heading", { level: 2, name: "Community type" })
+    await screen.findByRole("option", { name: "Seniors" })
+
+    // Select a community type
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Reserved community type" }),
+      "Seniors"
+    )
+
+    // Description should be shown as plaintext
+    expect(screen.getByText("For folks over the age of 65")).toBeInTheDocument()
+    // Textarea should be hidden
+    expect(
+      screen.queryByRole("textbox", { name: "Reserved community description" })
+    ).not.toBeVisible()
+  })
+
+  it("should update plaintext description when dropdown changes in disabled edit mode", async () => {
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(ctx.json(adminUserWithJurisdictions))
+      }),
+      rest.get("http://localhost:3100/reservedCommunityTypes", (_req, res, ctx) => {
+        return res(ctx.json(reservedCommunityTypes))
+      })
+    )
+
+    render(
+      <FormProviderWrapper>
+        <CommunityType
+          requiredFields={[]}
+          disableReservedCommunityTypeEdit={true}
+          swapCommunityTypeWithPrograms={false}
+        />
+      </FormProviderWrapper>
+    )
+
+    await screen.findByRole("heading", { level: 2, name: "Community type" })
+    await screen.findByRole("option", { name: "Seniors" })
+
+    // Select "Seniors"
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Reserved community type" }),
+      "Seniors"
+    )
+    expect(screen.getByText("For folks over the age of 65")).toBeInTheDocument()
+
+    // Select "Veteran"
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Reserved community type" }),
+      "Veteran"
+    )
+    expect(screen.getByText("For folks who served in the armed forces")).toBeInTheDocument()
+  })
 })

--- a/sites/partners/cypress/e2e/default/03-listing.spec.ts
+++ b/sites/partners/cypress/e2e/default/03-listing.spec.ts
@@ -333,13 +333,15 @@ describe("Listing Management Tests", () => {
 
     // ----------
     // Section - Community type
+
     fillIfDataExists(cy, "reservedCommunityTypes.id", listing.reservedCommunityTypes?.id, "select")
-    fillIfDataExists(
-      cy,
-      "reservedCommunityDescription",
-      listing.reservedCommunityDescription,
-      "type"
-    )
+    if (!getFlagActive(listing, FeatureFlagEnum.disableReservedCommunityTypeEdit)) {
+      if (listing.reservedCommunityDescription) {
+        cy.getByID("reservedCommunityDescription")
+          .clear()
+          .type(listing.reservedCommunityDescription)
+      }
+    }
 
     fillRadio(
       cy,
@@ -961,11 +963,19 @@ describe("Listing Management Tests", () => {
     // ----------
     // Section - Community type
     verifyDetailDataIfExists(cy, "reservedCommunityType", listing.reservedCommunityTypes?.id)
-    verifyDetailDataIfExists(
-      cy,
-      "reservedCommunityDescription",
-      listing.reservedCommunityDescription
-    )
+    if (getFlagActive(listing, FeatureFlagEnum.disableReservedCommunityTypeEdit)) {
+      verifyDetailDataIfExists(
+        cy,
+        "reservedCommunityDescription",
+        listing.reservedCommunityTypeDescription
+      )
+    } else {
+      verifyDetailDataIfExists(
+        cy,
+        "reservedCommunityDescription",
+        listing.reservedCommunityDescription
+      )
+    }
     verifyDetailDataIfExists(
       cy,
       "includeCommunityDisclaimer",
@@ -1479,12 +1489,17 @@ describe("Listing Management Tests", () => {
       )
     }
 
-    verifyDataIfExists(
-      cy,
-      "reservedCommunityDescription",
-      listing.reservedCommunityDescription,
-      "type"
-    )
+    if (getFlagActive(listing, FeatureFlagEnum.disableReservedCommunityTypeEdit)) {
+      // Check plaintext is shown
+      cy.contains(listing.reservedCommunityTypeDescription || "")
+    } else {
+      verifyDataIfExists(
+        cy,
+        "reservedCommunityDescription",
+        listing.reservedCommunityDescription,
+        "type"
+      )
+    }
 
     verifyRadioIfExists(
       cy,

--- a/sites/partners/cypress/fixtures/angelopolisListing.ts
+++ b/sites/partners/cypress/fixtures/angelopolisListing.ts
@@ -110,13 +110,14 @@ export const angelopolisListing: CypressListing = {
       { name: FeatureFlagEnum.enableListingImageAltText, active: true } as FeatureFlag,
       { name: FeatureFlagEnum.enableAccessibilityFeatures, active: true } as FeatureFlag,
       { name: FeatureFlagEnum.enableProperties, active: true } as FeatureFlag,
+      { name: FeatureFlagEnum.disableReservedCommunityTypeEdit, active: true } as FeatureFlag,
     ],
     listingFeaturesConfiguration: listingFeaturesConfiguration,
   } as Jurisdiction,
   jurisdictions: { id: "Angelopolis" },
   region: undefined,
   configurableRegion: "Harbor Area",
-  name: "Basic Test Listing Angelopolis",
+  name: `Basic Test Listing Angelopolis ${Date.now()}`,
   developer: "Basic Test Developer",
   listingsBuildingAddress: {
     street: "548 Market St. #59930",
@@ -128,8 +129,10 @@ export const angelopolisListing: CypressListing = {
   neighborhood: "Basic Test Neighborhood",
   yearBuilt: 2021,
   reservedCommunityTypes: {
-    id: "Seniors",
+    id: "Seniors 62+",
   },
+  reservedCommunityTypeDescription:
+    "This property is reserved for seniors aged 62 and older. Applicants must meet the age requirement to be eligible.",
   creditScreeningFee: "150",
   reviewOrderType: ReviewOrderTypeEnum.firstComeFirstServe,
   disableUnitsAccordion: true,

--- a/sites/partners/cypress/fixtures/bloomingtonListing.ts
+++ b/sites/partners/cypress/fixtures/bloomingtonListing.ts
@@ -61,7 +61,7 @@ export const bloomingtonListing: CypressListing = {
     listingFeaturesConfiguration: listingFeaturesConfiguration,
   } as Jurisdiction,
   jurisdictions: { id: "Bloomington" },
-  name: "Basic Test Listing Bloomington",
+  name: `Basic Test Listing Bloomington ${Date.now()}`,
   developer: "Basic Test Developer",
   listingsBuildingAddress: {
     street: "548 Market St. #59930",

--- a/sites/partners/cypress/fixtures/cypressListingHelpers.ts
+++ b/sites/partners/cypress/fixtures/cypressListingHelpers.ts
@@ -25,6 +25,7 @@ export type CypressListing = Listing & {
   cypressFeatures?: CypressListingFeatures[]
   jurisdiction: Jurisdiction
   units: CypressUnit[]
+  reservedCommunityTypeDescription?: string
 }
 
 export type CypressListingDateTime = {

--- a/sites/partners/src/components/listings/PaperListingForm/ListingForm.module.scss
+++ b/sites/partners/src/components/listings/PaperListingForm/ListingForm.module.scss
@@ -97,3 +97,7 @@
   --grid-gap: 0;
   --grid-gap-lg: 0;
 }
+
+.hidden-field {
+  display: none;
+}

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -628,6 +628,10 @@ const ListingForm = ({
                             setLatLong={setLatitudeLongitude}
                           />
                           <CommunityType
+                            disableReservedCommunityTypeEdit={doJurisdictionsHaveFeatureFlagOn(
+                              FeatureFlagEnum.disableReservedCommunityTypeEdit,
+                              jurisdictionId
+                            )}
                             listing={listing}
                             swapCommunityTypeWithPrograms={swapCommunityTypeWithPrograms}
                             requiredFields={requiredFields}

--- a/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
@@ -42,7 +42,6 @@ const CommunityType = ({
   const [currentCommunityType, setCurrentCommunityType] = useState(
     listing?.reservedCommunityTypes?.id
   )
-  const [currentCommunityDescription] = useState(listing?.reservedCommunityDescription)
 
   // Store the reserved community description in state for immediate updates
   const [description, setDescription] = useState<string>("")
@@ -66,8 +65,7 @@ const CommunityType = ({
 
   useEffect(() => {
     setValue("reservedCommunityTypes.id", currentCommunityType)
-    setValue("reservedCommunityDescription", currentCommunityDescription)
-  }, [options, setValue, currentCommunityType, currentCommunityDescription])
+  }, [options, setValue, currentCommunityType])
 
   useEffect(() => {
     if (![listing?.reservedCommunityTypes?.id, undefined, ""].includes(reservedCommunityType)) {

--- a/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react"
 import { useFormContext } from "react-hook-form"
 import { t, Select, Textarea, FieldGroup, Field } from "@bloom-housing/ui-components"
-import { Grid } from "@bloom-housing/ui-seeds"
+import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import {
   ReservedCommunityType,
   YesNoEnum,
@@ -20,12 +20,14 @@ import SectionWithGrid from "../../../shared/SectionWithGrid"
 import styles from "../ListingForm.module.scss"
 
 type CommunityTypeProps = {
+  disableReservedCommunityTypeEdit?: boolean
   listing?: FormListing
   requiredFields: string[]
   swapCommunityTypeWithPrograms?: boolean
 }
 
 const CommunityType = ({
+  disableReservedCommunityTypeEdit,
   listing,
   requiredFields,
   swapCommunityTypeWithPrograms,
@@ -37,9 +39,9 @@ const CommunityType = ({
   const reservedCommunityType = watch("reservedCommunityTypes.id")
 
   const [options, setOptions] = useState([])
-  const [currentCommunityType, setCurrentCommunityType] = useState(
-    listing?.reservedCommunityTypes?.id
-  )
+
+  // Store the reserved community description in state for immediate updates
+  const [description, setDescription] = useState<string>("")
 
   const { data: reservedCommunityTypes = [], loading } = useReservedCommunityTypeList()
 
@@ -58,19 +60,24 @@ const CommunityType = ({
     }
   }, [options, reservedCommunityTypes, loading])
 
+  // Set reservedCommunityTypes.id from listing only after options are loaded
   useEffect(() => {
-    setValue("reservedCommunityTypes.id", currentCommunityType)
-  }, [options, setValue, currentCommunityType])
-
-  useEffect(() => {
-    if (![listing?.reservedCommunityTypes?.id, undefined, ""].includes(reservedCommunityType)) {
-      setCurrentCommunityType(reservedCommunityType)
-      const matchedType = reservedCommunityTypes.find((type) => type.id === reservedCommunityType)
-      if (matchedType?.description !== undefined) {
-        setValue("reservedCommunityDescription", matchedType.description)
-      }
+    if (listing?.reservedCommunityTypes?.id && !reservedCommunityType && options.length > 0) {
+      setValue("reservedCommunityTypes.id", listing.reservedCommunityTypes.id)
     }
-  }, [reservedCommunityType, listing?.reservedCommunityTypes?.id, reservedCommunityTypes, setValue])
+  }, [listing?.reservedCommunityTypes?.id, reservedCommunityType, setValue, options])
+
+  // Always update description state and form value when reservedCommunityType or types change
+  useEffect(() => {
+    if (reservedCommunityType && reservedCommunityTypes.length > 0) {
+      const matchedType = reservedCommunityTypes.find((type) => type.id === reservedCommunityType)
+      const desc = matchedType?.description ?? ""
+      setValue("reservedCommunityDescription", desc)
+      setDescription(desc)
+    } else {
+      setDescription("")
+    }
+  }, [reservedCommunityType, reservedCommunityTypes, setValue])
 
   useEffect(() => {
     if (
@@ -107,8 +114,8 @@ const CommunityType = ({
                 controlClassName="control"
                 options={options}
                 inputProps={{
-                  onChange: () => {
-                    setCurrentCommunityType(reservedCommunityType)
+                  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
+                    setValue("reservedCommunityTypes.id", e.target.value)
                     fieldHasError(errors?.reservedCommunityTypes) &&
                       clearErrors("reservedCommunityTypes")
                   },
@@ -120,29 +127,46 @@ const CommunityType = ({
             </Grid.Cell>
           )}
         </Grid.Row>
-        <Grid.Row columns={3}>
+        <Grid.Row
+          columns={3}
+          className={!disableReservedCommunityTypeEdit ? styles["hidden-field"] : ""}
+        >
           <Grid.Cell className="seeds-grid-span-2">
-            <Textarea
-              label={getLabel(
-                "reservedCommunityDescription",
-                requiredFields,
-                t("listings.reservedCommunityDescription")
-              )}
-              placeholder={""}
-              name={"reservedCommunityDescription"}
-              id={"reservedCommunityDescription"}
-              fullWidth={true}
-              register={register}
-              note={t("listings.appearsInListing")}
-              errorMessage={fieldMessage(errors?.reservedCommunityDescription)}
-              inputProps={{
-                onChange: () => {
-                  fieldHasError(errors?.reservedCommunityDescription) &&
-                    clearErrors("reservedCommunityDescription")
-                },
-                "aria-required": fieldIsRequired("reservedCommunityDescription", requiredFields),
-              }}
-            />
+            {disableReservedCommunityTypeEdit && (
+              <FieldValue label={t("listings.reservedCommunityDescription")}>
+                {description || t("t.none")}
+              </FieldValue>
+            )}
+          </Grid.Cell>
+        </Grid.Row>
+        <Grid.Row
+          columns={3}
+          className={disableReservedCommunityTypeEdit ? styles["hidden-field"] : ""}
+        >
+          <Grid.Cell className="seeds-grid-span-2">
+            <div>
+              <Textarea
+                label={getLabel(
+                  "reservedCommunityDescription",
+                  requiredFields,
+                  t("listings.reservedCommunityDescription")
+                )}
+                placeholder={""}
+                name={"reservedCommunityDescription"}
+                id={"reservedCommunityDescription"}
+                fullWidth={true}
+                register={register}
+                note={t("listings.appearsInListing")}
+                errorMessage={fieldMessage(errors?.reservedCommunityDescription)}
+                inputProps={{
+                  onChange: () => {
+                    fieldHasError(errors?.reservedCommunityDescription) &&
+                      clearErrors("reservedCommunityDescription")
+                  },
+                  "aria-required": fieldIsRequired("reservedCommunityDescription", requiredFields),
+                }}
+              />
+            </div>
           </Grid.Cell>
         </Grid.Row>
 
@@ -159,20 +183,20 @@ const CommunityType = ({
                   label: t("t.yes"),
                   value: YesNoEnum.yes,
                   id: "includeCommunityDisclaimerYes",
-                  disabled: !currentCommunityType,
+                  disabled: !reservedCommunityType,
                 },
                 {
                   label: t("t.no"),
                   value: YesNoEnum.no,
                   id: "includeCommunityDisclaimerNo",
-                  disabled: !currentCommunityType,
+                  disabled: !reservedCommunityType,
                 },
               ]}
             />
           </Grid.Cell>
         </Grid.Row>
 
-        {watch("includeCommunityDisclaimerQuestion") === YesNoEnum.yes && currentCommunityType && (
+        {watch("includeCommunityDisclaimerQuestion") === YesNoEnum.yes && reservedCommunityType && (
           <>
             <Grid.Row columns={3}>
               <Grid.Cell className="seeds-grid-span-2">

--- a/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
@@ -97,7 +97,8 @@ const CommunityType = ({
   }, [currentCommunityType, loading])
 
   useEffect(() => {
-    if (currentCommunityType && reservedCommunityTypes.length > 0) {
+    const isListingInitialType = currentCommunityType === listing?.reservedCommunityTypes?.id
+    if (currentCommunityType && reservedCommunityTypes.length > 0 && !isListingInitialType) {
       const matchedType = reservedCommunityTypes.find((type) => type.id === currentCommunityType)
       setValue("reservedCommunityDescription", matchedType?.description ?? "")
     }

--- a/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { useFormContext } from "react-hook-form"
 import { t, Select, Textarea, FieldGroup, Field } from "@bloom-housing/ui-components"
 import { FieldValue, Grid } from "@bloom-housing/ui-seeds"
@@ -45,6 +45,7 @@ const CommunityType = ({
 
   // Store the reserved community description in state for immediate updates
   const [description, setDescription] = useState<string>("")
+  const hasInitializedCommunityTypeDescription = useRef(false)
 
   const { data: reservedCommunityTypes = [], loading } = useReservedCommunityTypeList()
 
@@ -87,23 +88,25 @@ const CommunityType = ({
   }, [setValue, listing?.includeCommunityDisclaimer, watch, listing])
 
   useEffect(() => {
-    if (currentCommunityType && reservedCommunityTypes.length > 0) {
-      const matchedType = reservedCommunityTypes.find((type) => type.id === currentCommunityType)
-      setDescription(matchedType?.description ?? "")
-    } else {
-      setDescription("")
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentCommunityType, loading])
+    if (loading) return
 
-  useEffect(() => {
-    const isListingInitialType = currentCommunityType === listing?.reservedCommunityTypes?.id
-    if (currentCommunityType && reservedCommunityTypes.length > 0 && !isListingInitialType) {
-      const matchedType = reservedCommunityTypes.find((type) => type.id === currentCommunityType)
-      setValue("reservedCommunityDescription", matchedType?.description ?? "")
+    const matchedType = currentCommunityType
+      ? reservedCommunityTypes.find((type) => type.id === currentCommunityType)
+      : undefined
+    const nextDescription = matchedType?.description ?? ""
+
+    // Always show the selected community type's description in read-only mode.
+    setDescription(nextDescription)
+
+    // Skip auto-overwriting the listing's existing description on initial form load.
+    if (!hasInitializedCommunityTypeDescription.current) {
+      hasInitializedCommunityTypeDescription.current = true
+      return
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentCommunityType])
+
+    // For subsequent type changes, keep the editable description in sync with selection.
+    setValue("reservedCommunityDescription", nextDescription)
+  }, [currentCommunityType, reservedCommunityTypes, loading, setValue])
 
   return !swapCommunityTypeWithPrograms ? (
     <>

--- a/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
@@ -39,6 +39,10 @@ const CommunityType = ({
   const reservedCommunityType = watch("reservedCommunityTypes.id")
 
   const [options, setOptions] = useState([])
+  const [currentCommunityType, setCurrentCommunityType] = useState(
+    listing?.reservedCommunityTypes?.id
+  )
+  const [currentCommunityDescription] = useState(listing?.reservedCommunityDescription)
 
   // Store the reserved community description in state for immediate updates
   const [description, setDescription] = useState<string>("")
@@ -60,24 +64,16 @@ const CommunityType = ({
     }
   }, [options, reservedCommunityTypes, loading])
 
-  // Set reservedCommunityTypes.id from listing only after options are loaded
   useEffect(() => {
-    if (listing?.reservedCommunityTypes?.id && !reservedCommunityType && options.length > 0) {
-      setValue("reservedCommunityTypes.id", listing.reservedCommunityTypes.id)
-    }
-  }, [listing?.reservedCommunityTypes?.id, reservedCommunityType, setValue, options])
+    setValue("reservedCommunityTypes.id", currentCommunityType)
+    setValue("reservedCommunityDescription", currentCommunityDescription)
+  }, [options, setValue, currentCommunityType, currentCommunityDescription])
 
-  // Always update description state and form value when reservedCommunityType or types change
   useEffect(() => {
-    if (reservedCommunityType && reservedCommunityTypes.length > 0) {
-      const matchedType = reservedCommunityTypes.find((type) => type.id === reservedCommunityType)
-      const desc = matchedType?.description ?? ""
-      setValue("reservedCommunityDescription", desc)
-      setDescription(desc)
-    } else {
-      setDescription("")
+    if (![listing?.reservedCommunityTypes?.id, undefined, ""].includes(reservedCommunityType)) {
+      setCurrentCommunityType(reservedCommunityType)
     }
-  }, [reservedCommunityType, reservedCommunityTypes, setValue])
+  }, [reservedCommunityType, listing?.reservedCommunityTypes?.id])
 
   useEffect(() => {
     if (
@@ -91,6 +87,24 @@ const CommunityType = ({
       )
     }
   }, [setValue, listing?.includeCommunityDisclaimer, watch, listing])
+
+  useEffect(() => {
+    if (currentCommunityType && reservedCommunityTypes.length > 0) {
+      const matchedType = reservedCommunityTypes.find((type) => type.id === currentCommunityType)
+      setDescription(matchedType?.description ?? "")
+    } else {
+      setDescription("")
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentCommunityType, loading])
+
+  useEffect(() => {
+    if (currentCommunityType && reservedCommunityTypes.length > 0) {
+      const matchedType = reservedCommunityTypes.find((type) => type.id === currentCommunityType)
+      setValue("reservedCommunityDescription", matchedType?.description ?? "")
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentCommunityType])
 
   return !swapCommunityTypeWithPrograms ? (
     <>
@@ -114,8 +128,8 @@ const CommunityType = ({
                 controlClassName="control"
                 options={options}
                 inputProps={{
-                  onChange: (e: React.ChangeEvent<HTMLSelectElement>) => {
-                    setValue("reservedCommunityTypes.id", e.target.value)
+                  onChange: () => {
+                    setCurrentCommunityType(reservedCommunityType)
                     fieldHasError(errors?.reservedCommunityTypes) &&
                       clearErrors("reservedCommunityTypes")
                   },
@@ -183,20 +197,20 @@ const CommunityType = ({
                   label: t("t.yes"),
                   value: YesNoEnum.yes,
                   id: "includeCommunityDisclaimerYes",
-                  disabled: !reservedCommunityType,
+                  disabled: !currentCommunityType,
                 },
                 {
                   label: t("t.no"),
                   value: YesNoEnum.no,
                   id: "includeCommunityDisclaimerNo",
-                  disabled: !reservedCommunityType,
+                  disabled: !currentCommunityType,
                 },
               ]}
             />
           </Grid.Cell>
         </Grid.Row>
 
-        {watch("includeCommunityDisclaimerQuestion") === YesNoEnum.yes && reservedCommunityType && (
+        {watch("includeCommunityDisclaimerQuestion") === YesNoEnum.yes && currentCommunityType && (
           <>
             <Grid.Row columns={3}>
               <Grid.Cell className="seeds-grid-span-2">

--- a/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/CommunityType.tsx
@@ -65,8 +65,12 @@ const CommunityType = ({
   useEffect(() => {
     if (![listing?.reservedCommunityTypes?.id, undefined, ""].includes(reservedCommunityType)) {
       setCurrentCommunityType(reservedCommunityType)
+      const matchedType = reservedCommunityTypes.find((type) => type.id === reservedCommunityType)
+      if (matchedType?.description !== undefined) {
+        setValue("reservedCommunityDescription", matchedType.description)
+      }
     }
-  }, [reservedCommunityType, listing?.reservedCommunityTypes?.id])
+  }, [reservedCommunityType, listing?.reservedCommunityTypes?.id, reservedCommunityTypes, setValue])
 
   useEffect(() => {
     if (

--- a/sites/public/__tests__/components/listing/ListingViewSeeds.test.tsx
+++ b/sites/public/__tests__/components/listing/ListingViewSeeds.test.tsx
@@ -583,7 +583,7 @@ describe("<ListingViewSeeds>", () => {
       expect(hmiSectionTitle).toBeInTheDocument()
       expect(
         within(hmiSectionTitle.parentElement).getByText(
-          /For income calculations, household size includes everyone \(all ages\) living in the unit\./
+          /For income calculations, household size includes everyone \(all ages\) living in the unit\./i
         )
       ).toBeInTheDocument()
       expect(


### PR DESCRIPTION
This PR addresses #6171

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

(1) Everywhere, regardless of flag values: if a description is set on a reserved community type, when the dropdown value is changed, the description should auto populate with that value.

(2) New feature flag `disableReservedCommunityTypeEdit`, that when true, will still autopopulate the description, but not allow it to be editable and just show it as a plaintext FieldValue. It will still save the value on the listing.

## How Can This Be Tested/Reviewed?

On a fresh reseed, set a listing's reserved community type to Seniors 62+. The description should fill with the db value. 

In Bloomington: You should be able to edit it to custom text - it will only update on dropdown change.

In Angelopolis: It will not be editable and will just appear as a FieldValue.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
