### PR TITLE
fix: update to seeding to not create dupe reserved community types

### DIFF
--- a/api/prisma/seed-helpers/reserved-community-type-factory.ts
+++ b/api/prisma/seed-helpers/reserved-community-type-factory.ts
@@ -41,13 +41,27 @@ export const reservedCommunityTypeFactoryAll = async (
   jurisdictionId: string,
   prismaClient: PrismaClient,
 ) => {
-  await prismaClient.reservedCommunityTypes.createMany({
-    data: reservedCommunityTypeOptions.map(({ name, description }) => ({
-      name,
-      description,
-      jurisdictionId,
-    })),
-  });
+  for (const { name, description } of reservedCommunityTypeOptions) {
+    const exists = await prismaClient.reservedCommunityTypes.findFirst({
+      select: {
+        id: true,
+      },
+      where: {
+        name,
+        description,
+        jurisdictionId,
+      },
+    });
+    if (!exists?.id) {
+      await prismaClient.reservedCommunityTypes.create({
+        data: {
+          name,
+          description,
+          jurisdictionId,
+        },
+      });
+    }
+  }
 };
 
 export const reservedCommunityTypeFactoryGet = async (

--- a/api/test/integration/reserved-community-type.e2e-spec.ts
+++ b/api/test/integration/reserved-community-type.e2e-spec.ts
@@ -121,7 +121,7 @@ describe('ReservedCommunityType Controller Tests', () => {
       .set('Cookie', cookies)
       .expect(200);
 
-    expect(res.body.length).toEqual(12);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
     expect(res.body.map((body) => body.name)).toContain(
       reservedCommunityTypeA.name,
     );


### PR DESCRIPTION
this changes how we seed reserved community types so that we don't allow for seeding duplicates in case a migration script adds reserved community type data