### PR TITLE
fix: update monthly income to display decimals

### DIFF
--- a/api/src/utilities/unit-utilities.ts
+++ b/api/src/utilities/unit-utilities.ts
@@ -35,6 +35,13 @@ export const usd = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 0,
 });
 
+const usdTwoDecimal = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
 export const minMax = (baseValue: MinMax, newValue: number): MinMax => {
   return {
     min: Math.min(baseValue.min, newValue),
@@ -57,7 +64,9 @@ export const minMaxCurrency = (
 };
 
 export const yearlyCurrencyStringToMonthly = (currency: string) => {
-  return usd.format(parseFloat(currency.replace(/[^0-9.-]+/g, '')) / 12);
+  return usdTwoDecimal.format(
+    parseFloat(currency.replace(/[^0-9.-]+/g, '')) / 12,
+  );
 };
 
 export const getAmiChartItemUniqueKey = (amiChartItem: AmiChartItem) => {

--- a/api/test/unit/utilities/unit-utilities.spec.ts
+++ b/api/test/unit/utilities/unit-utilities.spec.ts
@@ -105,22 +105,22 @@ describe('Unit Transformations', () => {
         },
         rows: [
           {
-            maxIncomeMonth: 'listings.monthlyIncome*income:$2,583',
+            maxIncomeMonth: 'listings.monthlyIncome*income:$2,583.33',
             maxIncomeYear: 'listings.annualIncome*income:$31,000',
             sizeColumn: 2,
           },
           {
-            maxIncomeMonth: 'listings.monthlyIncome*income:$2,667',
+            maxIncomeMonth: 'listings.monthlyIncome*income:$2,666.67',
             maxIncomeYear: 'listings.annualIncome*income:$32,000',
             sizeColumn: 3,
           },
           {
-            maxIncomeMonth: 'listings.monthlyIncome*income:$2,750',
+            maxIncomeMonth: 'listings.monthlyIncome*income:$2,750.00',
             maxIncomeYear: 'listings.annualIncome*income:$33,000',
             sizeColumn: 4,
           },
           {
-            maxIncomeMonth: 'listings.monthlyIncome*income:$2,833',
+            maxIncomeMonth: 'listings.monthlyIncome*income:$2,833.33',
             maxIncomeYear: 'listings.annualIncome*income:$34,000',
             sizeColumn: 5,
           },
@@ -142,7 +142,7 @@ describe('Unit Transformations', () => {
         },
         rows: [
           {
-            maxIncomeMonth: 'listings.monthlyIncome*income:$3,083',
+            maxIncomeMonth: 'listings.monthlyIncome*income:$3,083.33',
             maxIncomeYear: 'listings.annualIncome*income:$37,000',
             sizeColumn: 8,
           },
@@ -248,7 +248,7 @@ describe('Unit Transformations', () => {
         },
         rows: [
           {
-            maxIncomeMonth: 'listings.monthlyIncome*income:$2,583',
+            maxIncomeMonth: 'listings.monthlyIncome*income:$2,583.33',
             maxIncomeYear: 'listings.annualIncome*income:$31,000',
             sizeColumn: 'listings.unitTypes.oneBdrm',
           },


### PR DESCRIPTION
This PR addresses [#1501](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/1501)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Display 2 decimal for monthly income

## How Can This Be Tested/Reviewed?

On partners Set unit to have maximum input that is not divided by 12, so like 37000, save it and then check on public listing page if it will display monthly value with double digits.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
