### PR TITLE
fix: upping 256 max units array size

### DIFF
--- a/api/src/dtos/listings/listing-create.dto.ts
+++ b/api/src/dtos/listings/listing-create.dto.ts
@@ -42,7 +42,7 @@ export class ListingCreate extends OmitType(ListingUpdate, [
   })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => UnitCreate)
-  @ArrayMaxSize(256, { groups: [ValidationsGroupsEnum.default] })
+  @ArrayMaxSize(500, { groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional({ type: UnitCreate, isArray: true })
   units?: UnitCreate[];
 

--- a/api/src/dtos/listings/listing-create.dto.ts
+++ b/api/src/dtos/listings/listing-create.dto.ts
@@ -1,7 +1,7 @@
 import { AddressCreate } from '../addresses/address-create.dto';
 import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import { ApplicationMethodCreate } from '../application-methods/application-method-create.dto';
-import { ArrayMaxSize, Validate, ValidateNested } from 'class-validator';
+import { Validate, ValidateNested } from 'class-validator';
 import { Expose, Type } from 'class-transformer';
 import { ListingEventCreate } from './listing-event-create.dto';
 import { ListingFeaturesCreate } from './listing-feature-create.dto';
@@ -42,7 +42,6 @@ export class ListingCreate extends OmitType(ListingUpdate, [
   })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => UnitCreate)
-  @ArrayMaxSize(500, { groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional({ type: UnitCreate, isArray: true })
   units?: UnitCreate[];
 

--- a/api/src/dtos/listings/listing-update.dto.ts
+++ b/api/src/dtos/listings/listing-update.dto.ts
@@ -2,7 +2,7 @@ import { AddressUpdate } from '../addresses/address-update.dto';
 import { ApiProperty } from '@nestjs/swagger';
 import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
 import { ApplicationMethodUpdate } from '../application-methods/application-method-update.dto';
-import { ArrayMaxSize, Validate, ValidateNested } from 'class-validator';
+import { Validate, ValidateNested } from 'class-validator';
 import { AssetCreate } from '../assets/asset-create.dto';
 import { Expose, Type } from 'class-transformer';
 import { IdDTO } from '../shared/id.dto';
@@ -84,7 +84,6 @@ export class ListingUpdate extends OmitType(Listing, [
   })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => UnitUpdate)
-  @ArrayMaxSize(500, { groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional({ type: UnitUpdate, isArray: true })
   units?: UnitUpdate[];
 

--- a/api/src/dtos/listings/listing-update.dto.ts
+++ b/api/src/dtos/listings/listing-update.dto.ts
@@ -84,7 +84,7 @@ export class ListingUpdate extends OmitType(Listing, [
   })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => UnitUpdate)
-  @ArrayMaxSize(256, { groups: [ValidationsGroupsEnum.default] })
+  @ArrayMaxSize(500, { groups: [ValidationsGroupsEnum.default] })
   @ApiPropertyOptional({ type: UnitUpdate, isArray: true })
   units?: UnitUpdate[];
 

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -996,7 +996,7 @@ class Listing extends AbstractDTO {
   })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => Unit)
-  @ArrayMaxSize(256, { groups: [ValidationsGroupsEnum.default] })
+  @ArrayMaxSize(500, { groups: [ValidationsGroupsEnum.default] })
   @ApiProperty({ type: Unit, isArray: true })
   units: Unit[];
 

--- a/api/src/dtos/listings/listing.dto.ts
+++ b/api/src/dtos/listings/listing.dto.ts
@@ -1,6 +1,5 @@
 import { Expose, Transform, TransformFnParams, Type } from 'class-transformer';
 import {
-  ArrayMaxSize,
   IsArray,
   IsBoolean,
   IsDate,
@@ -996,7 +995,6 @@ class Listing extends AbstractDTO {
   })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
   @Type(() => Unit)
-  @ArrayMaxSize(500, { groups: [ValidationsGroupsEnum.default] })
   @ApiProperty({ type: Unit, isArray: true })
   units: Unit[];
 


### PR DESCRIPTION
This ups the max number of allowed units on a listing to 500

the easiest way to test this is to change the seed script to create a listing with >256 units and <500 units and verify that editing that seeded listing saves correctly 