### PR TITLE
fix: show export button for unpublished results for support admins

### DIFF
--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -158,7 +158,10 @@ const Lottery = (props: { listing: Listing | undefined }) => {
       </CardSection>
     )
 
-    if (profile?.userRoles?.isAdmin) {
+    if (
+      profile?.userRoles?.isAdmin ||
+      (profile?.userRoles?.isSupportAdmin && !!listing.lotteryLastRunAt)
+    ) {
       if (listing.lotteryLastRunAt) {
         return exportCard
       } else {


### PR DESCRIPTION
This PR addresses [#1516](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/metrotranscom/doorway/1516)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

That change doesn't really match request from the ticket, as that export view was not visible for both waitlist and available units, so i am not really sure if that was the correct change (maybe just one listing got published results and other not, and it confused the person creating the request).
Couldn't find any other place where it could have been a problem.

## How Can This Be Tested/Reviewed?

Run lottery in partners app, but not publish it (both for waitlist and available units).
Log in to support admin account.
You should be able to see and export results on `http://localhost:3001/listings/[listingID]/lottery`

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
