### PR TITLE
feat: notifications redirect

### DIFF
--- a/sites/public/src/components/home/HomeResources.tsx
+++ b/sites/public/src/components/home/HomeResources.tsx
@@ -20,10 +20,15 @@ export const HomeResources = (props: HomeResourcesProps) => {
 
   const enableResources = isFeatureFlagOn(props.jurisdiction, FeatureFlagEnum.enableResources)
 
+  const enableCustomListingNotifications = isFeatureFlagOn(
+    props.jurisdiction,
+    FeatureFlagEnum.enableCustomListingNotifications
+  )
+
   return (
     <Grid spacing="lg">
       <Grid.Row columns={enableAdditionalResources ? 3 : 2}>
-        {props.jurisdiction && props.jurisdiction.notificationsSignUpUrl && (
+        {enableCustomListingNotifications && (
           <Grid.Cell>
             <BloomCard
               iconSymbol={"envelope"}
@@ -36,7 +41,7 @@ export const HomeResources = (props: HomeResourcesProps) => {
               <Card.Section>
                 <Button
                   key={"sign-up"}
-                  href={props.jurisdiction.notificationsSignUpUrl}
+                  href={"/account/notifications"}
                   variant="primary-outlined"
                   size={"sm"}
                 >

--- a/sites/public/src/components/home/HomeResources.tsx
+++ b/sites/public/src/components/home/HomeResources.tsx
@@ -25,10 +25,14 @@ export const HomeResources = (props: HomeResourcesProps) => {
     FeatureFlagEnum.enableCustomListingNotifications
   )
 
+  const showNotificationsCard =
+    enableCustomListingNotifications ||
+    (props.jurisdiction && props.jurisdiction.notificationsSignUpUrl)
+
   return (
     <Grid spacing="lg">
       <Grid.Row columns={enableAdditionalResources ? 3 : 2}>
-        {enableCustomListingNotifications && (
+        {showNotificationsCard && (
           <Grid.Cell>
             <BloomCard
               iconSymbol={"envelope"}
@@ -41,7 +45,11 @@ export const HomeResources = (props: HomeResourcesProps) => {
               <Card.Section>
                 <Button
                   key={"sign-up"}
-                  href={"/account/notifications"}
+                  href={
+                    enableCustomListingNotifications
+                      ? "/account/notifications"
+                      : props.jurisdiction.notificationsSignUpUrl
+                  }
                   variant="primary-outlined"
                   size={"sm"}
                 >

--- a/sites/public/src/pages/account/notifications.tsx
+++ b/sites/public/src/pages/account/notifications.tsx
@@ -34,7 +34,10 @@ const Notifications = (props: NotificationProps) => {
   }
 
   return (
-    <RequireLogin signInPath="/sign-in" signInMessage={t("t.loginIsRequired")}>
+    <RequireLogin
+      signInPath="/sign-in?redirectUrl=/account/notifications"
+      signInMessage={t("t.loginIsRequired")}
+    >
       <ApplicationTimeout />
       <Layout
         pageTitle={t("account.accountSettings")}


### PR DESCRIPTION
This PR addresses #5912 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Updates public home page notification resource card to navigate to user settings notification preferences page
* Updates the notification page component, requiring a login guard to add a proper sign in page redirect url param. 

## How Can This Be Tested/Reviewed?

1. Make sure the `enableCustomListingNotifications` feature flag has been enabled for the currently configured public page
2. Go to the public home page and scroll to `Resources` section
3. Click the `Sign up today` button
4. The application should redirect you to the sign-in page with the `?redirectUrl=/account/notifications` URL param
5. Sign in to the public account 
6. Application should redirect you back to the accounts notification preferences page

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
