### PR TITLE
fix: open waitlist, hide closed when no unit groups

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -543,23 +543,21 @@ export class ListingService implements OnModuleInit {
                   key: ListingFilterKeys.availabilities,
                   caseSensitive: true,
                 });
-                return [
-                  {
-                    AND: builtFilter
-                      .map((filt) => ({
-                        unitGroups: {
-                          some: {
-                            [FilterAvailabilityEnum.openWaitlist]: filt,
-                          },
+                return {
+                  AND: builtFilter
+                    .map((filt) => ({
+                      unitGroups: {
+                        some: {
+                          [FilterAvailabilityEnum.openWaitlist]: filt,
                         },
-                      }))
-                      .concat(
-                        notUnderConstruction.map((filt) => ({
-                          marketingType: filt,
-                        })),
-                      ),
-                  },
-                ];
+                      },
+                    }))
+                    .concat(
+                      notUnderConstruction.map((filt) => ({
+                        marketingType: filt,
+                      })),
+                    ),
+                };
               } else if (availability === FilterAvailabilityEnum.comingSoon) {
                 const builtFilter = buildFilter({
                   $comparison: Compare['='],
@@ -597,6 +595,7 @@ export class ListingService implements OnModuleInit {
                   },
                   {
                     AND: [
+                      { unitGroups: { none: {} } },
                       {
                         reviewOrderType: {
                           in: [
@@ -727,6 +726,7 @@ export class ListingService implements OnModuleInit {
               },
               {
                 AND: [
+                  { unitGroups: { none: {} } },
                   {
                     reviewOrderType: {
                       in: [

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -543,8 +543,6 @@ export class ListingService implements OnModuleInit {
                   key: ListingFilterKeys.availabilities,
                   caseSensitive: true,
                 });
-                // Two OR branches: unit-groups listings use unitGroups.openWaitlist,
-                // listings without unit groups require reviewOrderType + isWaitlistOpen:false
                 return [
                   {
                     AND: builtFilter
@@ -560,22 +558,6 @@ export class ListingService implements OnModuleInit {
                           marketingType: filt,
                         })),
                       ),
-                  },
-                  {
-                    AND: [
-                      {
-                        reviewOrderType: {
-                          in: [
-                            ReviewOrderTypeEnum.waitlist,
-                            ReviewOrderTypeEnum.waitlistLottery,
-                          ],
-                        },
-                      },
-                      { isWaitlistOpen: { equals: false } },
-                      ...notUnderConstruction.map((filt) => ({
-                        marketingType: filt,
-                      })),
-                    ],
                   },
                 ];
               } else if (availability === FilterAvailabilityEnum.comingSoon) {
@@ -698,22 +680,6 @@ export class ListingService implements OnModuleInit {
                       marketingType: filt,
                     })),
                   ),
-              },
-              {
-                AND: [
-                  {
-                    reviewOrderType: {
-                      in: [
-                        ReviewOrderTypeEnum.waitlist,
-                        ReviewOrderTypeEnum.waitlistLottery,
-                      ],
-                    },
-                  },
-                  { isWaitlistOpen: { equals: false } },
-                  ...notUnderConstruction.map((filt) => ({
-                    marketingType: filt,
-                  })),
-                ],
               },
             ],
           });

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -543,21 +543,41 @@ export class ListingService implements OnModuleInit {
                   key: ListingFilterKeys.availabilities,
                   caseSensitive: true,
                 });
-                return {
-                  AND: builtFilter
-                    .map((filt) => ({
-                      unitGroups: {
-                        some: {
-                          [FilterAvailabilityEnum.openWaitlist]: filt,
+                // Two OR branches: unit-groups listings use unitGroups.openWaitlist,
+                // listings without unit groups require reviewOrderType + isWaitlistOpen:false
+                return [
+                  {
+                    AND: builtFilter
+                      .map((filt) => ({
+                        unitGroups: {
+                          some: {
+                            [FilterAvailabilityEnum.openWaitlist]: filt,
+                          },
+                        },
+                      }))
+                      .concat(
+                        notUnderConstruction.map((filt) => ({
+                          marketingType: filt,
+                        })),
+                      ),
+                  },
+                  {
+                    AND: [
+                      {
+                        reviewOrderType: {
+                          in: [
+                            ReviewOrderTypeEnum.waitlist,
+                            ReviewOrderTypeEnum.waitlistLottery,
+                          ],
                         },
                       },
-                    }))
-                    .concat(
-                      notUnderConstruction.map((filt) => ({
+                      { isWaitlistOpen: { equals: false } },
+                      ...notUnderConstruction.map((filt) => ({
                         marketingType: filt,
                       })),
-                    ),
-                };
+                    ],
+                  },
+                ];
               } else if (availability === FilterAvailabilityEnum.comingSoon) {
                 const builtFilter = buildFilter({
                   $comparison: Compare['='],
@@ -577,21 +597,38 @@ export class ListingService implements OnModuleInit {
                   key: ListingFilterKeys.availabilities,
                   caseSensitive: true,
                 });
-                return {
-                  AND: builtFilter
-                    .map((filt) => ({
-                      unitGroups: {
-                        some: {
-                          [FilterAvailabilityEnum.openWaitlist]: filt,
+                return [
+                  {
+                    AND: builtFilter
+                      .map((filt) => ({
+                        unitGroups: {
+                          some: {
+                            [FilterAvailabilityEnum.openWaitlist]: filt,
+                          },
+                        },
+                      }))
+                      .concat(
+                        notUnderConstruction.map((filt) => ({
+                          marketingType: filt,
+                        })),
+                      ),
+                  },
+                  {
+                    AND: [
+                      {
+                        reviewOrderType: {
+                          in: [
+                            ReviewOrderTypeEnum.waitlist,
+                            ReviewOrderTypeEnum.waitlistLottery,
+                          ],
                         },
                       },
-                    }))
-                    .concat(
-                      notUnderConstruction.map((filt) => ({
+                      ...notUnderConstruction.map((filt) => ({
                         marketingType: filt,
                       })),
-                    ),
-                };
+                    ],
+                  },
+                ];
               } else if (availability === FilterAvailabilityEnum.waitlistOpen) {
                 const builtFilter = buildFilter({
                   $comparison: Compare.IN,
@@ -662,6 +699,22 @@ export class ListingService implements OnModuleInit {
                     })),
                   ),
               },
+              {
+                AND: [
+                  {
+                    reviewOrderType: {
+                      in: [
+                        ReviewOrderTypeEnum.waitlist,
+                        ReviewOrderTypeEnum.waitlistLottery,
+                      ],
+                    },
+                  },
+                  { isWaitlistOpen: { equals: false } },
+                  ...notUnderConstruction.map((filt) => ({
+                    marketingType: filt,
+                  })),
+                ],
+              },
             ],
           });
         } else if (
@@ -705,6 +758,21 @@ export class ListingService implements OnModuleInit {
                       marketingType: filt,
                     })),
                   ),
+              },
+              {
+                AND: [
+                  {
+                    reviewOrderType: {
+                      in: [
+                        ReviewOrderTypeEnum.waitlist,
+                        ReviewOrderTypeEnum.waitlistLottery,
+                      ],
+                    },
+                  },
+                  ...notUnderConstruction.map((filt) => ({
+                    marketingType: filt,
+                  })),
+                ],
               },
             ],
           });

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -634,9 +634,12 @@ describe('Listing Controller Tests', () => {
     let listing4WithUnitGroups;
     let listing5WithUnitGroups;
     let listing6WithUnitGroups;
+    let listingWithIsWaitlistOpenTrue;
+    let listingWithIsWaitlistOpenFalse;
     let jurisdictionB;
     let jurisdictionC;
     let jurisdictionDWithUnitGroups;
+    let jurisdictionEWithoutUnitGroups;
     let multiselectQuestionPreference1;
     let multiselectQuestionPreference2;
     let multiselectQuestionPreference3;
@@ -803,6 +806,33 @@ describe('Listing Controller Tests', () => {
       listing6WithUnitGroups = await prisma.listings.create({
         data: listing6Input,
       });
+
+      jurisdictionEWithoutUnitGroups = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(`filterableList E ${randomName()}`),
+      });
+      const listing7Input = await listingFactory(
+        jurisdictionEWithoutUnitGroups.id,
+        prisma,
+        {
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+        },
+      );
+      listingWithIsWaitlistOpenTrue = await prisma.listings.create({
+        data: listing7Input,
+      });
+      const listing8Input = await listingFactory(
+        jurisdictionEWithoutUnitGroups.id,
+        prisma,
+        {
+          reviewOrderType: ReviewOrderTypeEnum.waitlist,
+          listing: {
+            isWaitlistOpen: false,
+          } as Prisma.ListingsCreateInput,
+        },
+      );
+      listingWithIsWaitlistOpenFalse = await prisma.listings.create({
+        data: listing8Input,
+      });
     });
 
     it('should get listings from list endpoint when no params are sent', async () => {
@@ -938,6 +968,59 @@ describe('Listing Controller Tests', () => {
 
       expect(res.body.items[0].id).toEqual(listing4WithUnitGroups.id);
     });
+
+    it('should return a listing based on filter availabilities - openWaitlist - isWaitlistOpen', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['IN'],
+            availabilities: [FilterAvailabilityEnum.openWaitlist],
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionEWithoutUnitGroups.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toEqual(1);
+      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenTrue.id);
+    });
+
+    it('should return a listing based on filter availabilities - closedWaitlist - isWaitlistOpen', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['IN'],
+            availabilities: [FilterAvailabilityEnum.closedWaitlist],
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionEWithoutUnitGroups.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toEqual(1);
+      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenFalse.id);
+    });
+
     it('should return a listing based on filter availabilities - waitlistOpen', async () => {
       const query: ListingsQueryBody = {
         page: 1,
@@ -1098,6 +1181,58 @@ describe('Listing Controller Tests', () => {
       expect(res.body.items.length).toEqual(1);
 
       expect(res.body.items[0].id).toEqual(listing4WithUnitGroups.id);
+    });
+
+    it('should return a listing based on filter availability - openWaitlist - isWaitlistOpen', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['='],
+            availability: FilterAvailabilityEnum.openWaitlist,
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionEWithoutUnitGroups.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toEqual(1);
+      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenTrue.id);
+    });
+
+    it('should return a listing based on filter availability - closedWaitlist - isWaitlistOpen', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['='],
+            availability: FilterAvailabilityEnum.closedWaitlist,
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionEWithoutUnitGroups.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toEqual(1);
+      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenFalse.id);
     });
     it('should return a listing based on filter availability - waitlistOpen', async () => {
       const query: ListingsQueryBody = {

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -634,8 +634,7 @@ describe('Listing Controller Tests', () => {
     let listing4WithUnitGroups;
     let listing5WithUnitGroups;
     let listing6WithUnitGroups;
-    let listingWithIsWaitlistOpenTrue;
-    let listingWithIsWaitlistOpenFalse;
+    let listingWithWaitlistReviewOrder;
     let jurisdictionB;
     let jurisdictionC;
     let jurisdictionDWithUnitGroups;
@@ -817,21 +816,8 @@ describe('Listing Controller Tests', () => {
           reviewOrderType: ReviewOrderTypeEnum.waitlist,
         },
       );
-      listingWithIsWaitlistOpenTrue = await prisma.listings.create({
+      listingWithWaitlistReviewOrder = await prisma.listings.create({
         data: listing7Input,
-      });
-      const listing8Input = await listingFactory(
-        jurisdictionEWithoutUnitGroups.id,
-        prisma,
-        {
-          reviewOrderType: ReviewOrderTypeEnum.waitlist,
-          listing: {
-            isWaitlistOpen: false,
-          } as Prisma.ListingsCreateInput,
-        },
-      );
-      listingWithIsWaitlistOpenFalse = await prisma.listings.create({
-        data: listing8Input,
       });
     });
 
@@ -969,7 +955,7 @@ describe('Listing Controller Tests', () => {
       expect(res.body.items[0].id).toEqual(listing4WithUnitGroups.id);
     });
 
-    it('should return a listing based on filter availabilities - openWaitlist - isWaitlistOpen', async () => {
+    it('should return a listing based on filter availabilities - openWaitlist - no unit groups', async () => {
       const query: ListingsQueryBody = {
         page: 1,
         view: ListingViews.base,
@@ -992,33 +978,7 @@ describe('Listing Controller Tests', () => {
         .expect(201);
 
       expect(res.body.items.length).toEqual(1);
-      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenTrue.id);
-    });
-
-    it('should return a listing based on filter availabilities - closedWaitlist - isWaitlistOpen', async () => {
-      const query: ListingsQueryBody = {
-        page: 1,
-        view: ListingViews.base,
-        filter: [
-          {
-            $comparison: Compare['IN'],
-            availabilities: [FilterAvailabilityEnum.closedWaitlist],
-          },
-          {
-            $comparison: Compare['='],
-            jurisdiction: jurisdictionEWithoutUnitGroups.id,
-          },
-        ],
-      };
-
-      const res = await request(app.getHttpServer())
-        .post(`/listings/list`)
-        .send(query)
-        .set({ passkey: process.env.API_PASS_KEY || '' })
-        .expect(201);
-
-      expect(res.body.items.length).toEqual(1);
-      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenFalse.id);
+      expect(res.body.items[0].id).toEqual(listingWithWaitlistReviewOrder.id);
     });
 
     it('should return a listing based on filter availabilities - waitlistOpen', async () => {
@@ -1183,7 +1143,7 @@ describe('Listing Controller Tests', () => {
       expect(res.body.items[0].id).toEqual(listing4WithUnitGroups.id);
     });
 
-    it('should return a listing based on filter availability - openWaitlist - isWaitlistOpen', async () => {
+    it('should return a listing based on filter availability - openWaitlist - no unit groups', async () => {
       const query: ListingsQueryBody = {
         page: 1,
         view: ListingViews.base,
@@ -1206,34 +1166,9 @@ describe('Listing Controller Tests', () => {
         .expect(201);
 
       expect(res.body.items.length).toEqual(1);
-      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenTrue.id);
+      expect(res.body.items[0].id).toEqual(listingWithWaitlistReviewOrder.id);
     });
 
-    it('should return a listing based on filter availability - closedWaitlist - isWaitlistOpen', async () => {
-      const query: ListingsQueryBody = {
-        page: 1,
-        view: ListingViews.base,
-        filter: [
-          {
-            $comparison: Compare['='],
-            availability: FilterAvailabilityEnum.closedWaitlist,
-          },
-          {
-            $comparison: Compare['='],
-            jurisdiction: jurisdictionEWithoutUnitGroups.id,
-          },
-        ],
-      };
-
-      const res = await request(app.getHttpServer())
-        .post(`/listings/list`)
-        .send(query)
-        .set({ passkey: process.env.API_PASS_KEY || '' })
-        .expect(201);
-
-      expect(res.body.items.length).toEqual(1);
-      expect(res.body.items[0].id).toEqual(listingWithIsWaitlistOpenFalse.id);
-    });
     it('should return a listing based on filter availability - waitlistOpen', async () => {
       const query: ListingsQueryBody = {
         page: 1,

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -1551,6 +1551,7 @@ describe('Testing listing service', () => {
               },
               {
                 AND: [
+                  { unitGroups: { none: {} } },
                   {
                     reviewOrderType: {
                       in: [
@@ -1664,6 +1665,7 @@ describe('Testing listing service', () => {
               },
               {
                 AND: [
+                  { unitGroups: { none: {} } },
                   {
                     reviewOrderType: {
                       in: [
@@ -1785,6 +1787,7 @@ describe('Testing listing service', () => {
               },
               {
                 AND: [
+                  { unitGroups: { none: {} } },
                   {
                     reviewOrderType: {
                       in: [

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -1492,6 +1492,24 @@ describe('Testing listing service', () => {
                   },
                 ],
               },
+              {
+                AND: [
+                  {
+                    reviewOrderType: {
+                      in: [
+                        ReviewOrderTypeEnum.waitlist,
+                        ReviewOrderTypeEnum.waitlistLottery,
+                      ],
+                    },
+                  },
+                  { isWaitlistOpen: { equals: false } },
+                  {
+                    marketingType: {
+                      not: { equals: MarketingTypeEnum.comingSoon },
+                    },
+                  },
+                ],
+              },
             ],
           },
         ],
@@ -1540,6 +1558,23 @@ describe('Testing listing service', () => {
                   {
                     unitGroups: {
                       some: { openWaitlist: { equals: true } },
+                    },
+                  },
+                  {
+                    marketingType: {
+                      not: { equals: MarketingTypeEnum.comingSoon },
+                    },
+                  },
+                ],
+              },
+              {
+                AND: [
+                  {
+                    reviewOrderType: {
+                      in: [
+                        ReviewOrderTypeEnum.waitlist,
+                        ReviewOrderTypeEnum.waitlistLottery,
+                      ],
                     },
                   },
                   {
@@ -1646,6 +1681,23 @@ describe('Testing listing service', () => {
                 ],
               },
               {
+                AND: [
+                  {
+                    reviewOrderType: {
+                      in: [
+                        ReviewOrderTypeEnum.waitlist,
+                        ReviewOrderTypeEnum.waitlistLottery,
+                      ],
+                    },
+                  },
+                  {
+                    marketingType: {
+                      not: { equals: MarketingTypeEnum.comingSoon },
+                    },
+                  },
+                ],
+              },
+              {
                 unitsAvailable: {
                   gte: 1,
                 },
@@ -1685,6 +1737,24 @@ describe('Testing listing service', () => {
                       some: { openWaitlist: { equals: false } },
                     },
                   },
+                  {
+                    marketingType: {
+                      not: { equals: MarketingTypeEnum.comingSoon },
+                    },
+                  },
+                ],
+              },
+              {
+                AND: [
+                  {
+                    reviewOrderType: {
+                      in: [
+                        ReviewOrderTypeEnum.waitlist,
+                        ReviewOrderTypeEnum.waitlistLottery,
+                      ],
+                    },
+                  },
+                  { isWaitlistOpen: { equals: false } },
                   {
                     marketingType: {
                       not: { equals: MarketingTypeEnum.comingSoon },
@@ -1740,6 +1810,23 @@ describe('Testing listing service', () => {
                   {
                     unitGroups: {
                       some: { openWaitlist: { equals: true } },
+                    },
+                  },
+                  {
+                    marketingType: {
+                      not: { equals: MarketingTypeEnum.comingSoon },
+                    },
+                  },
+                ],
+              },
+              {
+                AND: [
+                  {
+                    reviewOrderType: {
+                      in: [
+                        ReviewOrderTypeEnum.waitlist,
+                        ReviewOrderTypeEnum.waitlistLottery,
+                      ],
                     },
                   },
                   {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -1492,24 +1492,6 @@ describe('Testing listing service', () => {
                   },
                 ],
               },
-              {
-                AND: [
-                  {
-                    reviewOrderType: {
-                      in: [
-                        ReviewOrderTypeEnum.waitlist,
-                        ReviewOrderTypeEnum.waitlistLottery,
-                      ],
-                    },
-                  },
-                  { isWaitlistOpen: { equals: false } },
-                  {
-                    marketingType: {
-                      not: { equals: MarketingTypeEnum.comingSoon },
-                    },
-                  },
-                ],
-              },
             ],
           },
         ],
@@ -1737,24 +1719,6 @@ describe('Testing listing service', () => {
                       some: { openWaitlist: { equals: false } },
                     },
                   },
-                  {
-                    marketingType: {
-                      not: { equals: MarketingTypeEnum.comingSoon },
-                    },
-                  },
-                ],
-              },
-              {
-                AND: [
-                  {
-                    reviewOrderType: {
-                      in: [
-                        ReviewOrderTypeEnum.waitlist,
-                        ReviewOrderTypeEnum.waitlistLottery,
-                      ],
-                    },
-                  },
-                  { isWaitlistOpen: { equals: false } },
                   {
                     marketingType: {
                       not: { equals: MarketingTypeEnum.comingSoon },

--- a/sites/public/__tests__/components/browse/FilterDrawer.test.tsx
+++ b/sites/public/__tests__/components/browse/FilterDrawer.test.tsx
@@ -95,8 +95,7 @@ describe("FilterDrawer", () => {
     expect(screen.getByRole("checkbox", { name: "Units available" })).not.toBeChecked()
     expect(screen.getByLabelText("Open waitlist")).toBeInTheDocument()
     expect(screen.getByRole("checkbox", { name: "Open waitlist" })).not.toBeChecked()
-    expect(screen.getByLabelText("Closed waitlist")).toBeInTheDocument()
-    expect(screen.getByRole("checkbox", { name: "Closed waitlist" })).not.toBeChecked()
+    expect(screen.queryByLabelText("Closed waitlist")).not.toBeInTheDocument()
     expect(screen.getByLabelText("Coming soon")).toBeInTheDocument()
     expect(screen.getByRole("checkbox", { name: "Coming soon" })).not.toBeChecked()
 
@@ -280,8 +279,7 @@ describe("FilterDrawer", () => {
     expect(screen.getByRole("checkbox", { name: "Units available" })).not.toBeChecked()
     expect(screen.getByLabelText("Open waitlist")).toBeInTheDocument()
     expect(screen.getByRole("checkbox", { name: "Open waitlist" })).not.toBeChecked()
-    expect(screen.getByLabelText("Closed waitlist")).toBeInTheDocument()
-    expect(screen.getByRole("checkbox", { name: "Closed waitlist" })).not.toBeChecked()
+    expect(screen.queryByLabelText("Closed waitlist")).not.toBeInTheDocument()
     expect(screen.getByLabelText("Coming soon")).toBeInTheDocument()
     expect(screen.getByRole("checkbox", { name: "Coming soon" })).not.toBeChecked()
 
@@ -447,6 +445,46 @@ describe("FilterDrawer", () => {
     expect(screen.getByRole("checkbox", { name: "4 bedroom" })).not.toBeChecked()
     expect(screen.queryByLabelText("SRO")).not.toBeInTheDocument()
     expect(screen.queryByLabelText("5 bedroom")).not.toBeInTheDocument()
+  })
+
+  it("should not show closed waitlist when unit groups flag is off", () => {
+    render(
+      <FilterDrawer
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onClear={() => {}}
+        filterState={{}}
+        multiselectData={[]}
+        activeFeatureFlags={[]}
+        listingFeaturesConfiguration={defaultListingFeaturesConfiguration}
+      />
+    )
+
+    expect(screen.getByRole("group", { name: "Availability" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Units available")).toBeInTheDocument()
+    expect(screen.getByLabelText("Open waitlist")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Closed waitlist")).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Coming soon")).toBeInTheDocument()
+  })
+
+  it("should show closed waitlist when unit groups flag is on", () => {
+    render(
+      <FilterDrawer
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onClear={() => {}}
+        filterState={{}}
+        multiselectData={[]}
+        activeFeatureFlags={[FeatureFlagEnum.enableUnitGroups]}
+        listingFeaturesConfiguration={defaultListingFeaturesConfiguration}
+      />
+    )
+
+    expect(screen.getByRole("group", { name: "Availability" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Closed waitlist")).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "Closed waitlist" })).not.toBeChecked()
   })
 
   it("should not show regions if toggles are off", () => {

--- a/sites/public/src/components/browse/FilterDrawer.tsx
+++ b/sites/public/src/components/browse/FilterDrawer.tsx
@@ -2,6 +2,7 @@ import { Form, t } from "@bloom-housing/ui-components"
 import { Button, Drawer } from "@bloom-housing/ui-seeds"
 import { useForm } from "react-hook-form"
 import {
+  FilterAvailabilityEnum,
   RegionEnum,
   HomeTypeEnum,
   ListingFilterKeys,
@@ -84,8 +85,15 @@ const FilterDrawer = (props: FilterDrawerProps) => {
     (entry) => entry === FeatureFlagEnum.enableSection8Question
   )
 
-  const availabilityLabels = getAvailabilityValues(enableUnitGroups).map((key) =>
+  // When unit groups are off, closed waitlist has no backend signal, so hide it
+  const availabilityDisplayValues = getAvailabilityValues(enableUnitGroups).filter(
+    (key) => enableUnitGroups || key !== FilterAvailabilityEnum.closedWaitlist
+  )
+  const availabilityLabels = availabilityDisplayValues.map((key) =>
     t(`listings.availability.${key}`)
+  )
+  const availabilityKeys = getAvailabilityValues(false).filter(
+    (key) => enableUnitGroups || key !== FilterAvailabilityEnum.closedWaitlist
   )
 
   return (
@@ -119,7 +127,7 @@ const FilterDrawer = (props: FilterDrawerProps) => {
               fields={buildDefaultFilterFields(
                 ListingFilterKeys.availabilities,
                 availabilityLabels,
-                getAvailabilityValues(false),
+                availabilityKeys,
                 props.filterState
               )}
               register={register}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,10 +1006,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloom-housing/ui-components@14.0.1":
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-14.0.1.tgz#6e069b7f4396a0cd8b24223f3f527154d1b36813"
-  integrity sha512-sB6j9y7GrwiJ70M3YKBkk7TAI0XeRmLZICYpIFe+iO+HxVo4K7hzn+EAJZri6YRGtEA/jqR16Wne27+1DDMYCg==
+"@bloom-housing/ui-components@14.0.2":
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/@bloom-housing/ui-components/-/ui-components-14.0.2.tgz#89df6a2672faf33621e2755adaf4162f3ce70e60"
+  integrity sha512-RhNtz8lyh8f5LwUpiPFYClowgZBPNDh+K3GU5ZDoSIF0TGfec63BpB3GjwvyUSCeJCdsRoSX0q+RRtcfnj6BWQ==
   dependencies:
     "@dnd-kit/react" "^0.3.2"
     "@fortawesome/fontawesome-svg-core" "^6.1.1"


### PR DESCRIPTION
This PR addresses #6264

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

1. The open waitlist filter was not appropriately filtering on the listing status when unit groups is off
2. The closed waitlist filter should be hidden when unit groups are off

## How Can This Be Tested/Reviewed?

1. Ensure when unit groups are off, that the closed waitlist checkbox in the Availability section does not appear in the filter drawer
2. Ensure any listings with the gray "Open waitlist" status banner appear when filtering by open waitlist

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
