### PR TITLE
fix: lottery results preference name bugs

### DIFF
--- a/sites/public/src/pages/account/application/[id]/lottery-results.tsx
+++ b/sites/public/src/pages/account/application/[id]/lottery-results.tsx
@@ -222,7 +222,9 @@ const LotteryResults = () => {
                       return result
                         ? preferenceRank(
                             result.ordinal,
-                            question.multiselectQuestions.text,
+                            question.multiselectQuestions.name
+                              ? question.multiselectQuestions.name
+                              : question.multiselectQuestions.text,
                             totals?.find(
                               (total) =>
                                 total.multiselectQuestionId === question.multiselectQuestions.id

--- a/sites/public/styles/lottery-results.module.scss
+++ b/sites/public/styles/lottery-results.module.scss
@@ -31,6 +31,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    word-break: break-word;
   }
 
   .rank-number {
@@ -45,6 +46,7 @@
     height: var(--seeds-s10);
     letter-spacing: -0.05em;
     margin-inline-end: var(--seeds-s6);
+    min-width: fit-content;
   }
 
   .rank-number-content {


### PR DESCRIPTION
This PR addresses [#(6268)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/6268)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Issue 1: When an applicant goes to view their lottery results, if a preference that they had selected has a name that is significantly long (either high character count or character width), the number rank wraps and shows incorrectly.
Issue 2: With V2 MSQ turned on, when an applicant goes to view their lottery results, the preferences they selected are missing their names.

Fix ensures name is always present, wraps text when needed and result number has min-width to show correctly

## How Can This Be Tested/Reviewed?

Run `yarn setup --msqV2`
Create two new preferences, one with a long continuous string of M's between 25-30 characters and one with spaces
Add preferences to a lottery listing and publish
Apply to the listing signed into an account and claim both preferences
Close the listing, run the lottery and release the lottery
View lottery results, confirm names are present, wrapping correctly and rank number is show properly

## Author Checklist:

- [x] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
