### PR TITLE
fix: add filter by number of bathrooms

### DIFF
--- a/api/prisma/seed-staging/seed-bloomington.ts
+++ b/api/prisma/seed-staging/seed-bloomington.ts
@@ -63,6 +63,7 @@ export const createBloomingtonJurisdiction = async (
         FeatureFlagEnum.enableCompanyWebsite,
         FeatureFlagEnum.enableCustomListingNotifications,
         FeatureFlagEnum.enableFaq,
+        FeatureFlagEnum.enableFilterByBathroom,
         FeatureFlagEnum.enableGenderQuestion,
         FeatureFlagEnum.enableGeocodingPreferences,
         FeatureFlagEnum.enableGeocodingRadiusMethod,

--- a/api/prisma/seed-staging/seed-bridge-bay.ts
+++ b/api/prisma/seed-staging/seed-bridge-bay.ts
@@ -2401,6 +2401,7 @@ export const realisticAddressesForOtherStatuses = [
 const featureFlags = [
   FeatureFlagEnum.disableEthnicityQuestion,
   FeatureFlagEnum.disableWorkInRegion,
+  FeatureFlagEnum.enableFilterByBathroom,
   FeatureFlagEnum.enableGeocodingPreferences,
   FeatureFlagEnum.enableGeocodingRadiusMethod,
   FeatureFlagEnum.enableGenderQuestion,

--- a/api/src/dtos/listings/listings-filter-params.dto.ts
+++ b/api/src/dtos/listings/listings-filter-params.dto.ts
@@ -52,11 +52,12 @@ export class ListingFilterParams extends BaseFilter {
 
   @Expose()
   @ApiPropertyOptional({
-    example: '2',
+    isArray: true,
+    example: [1],
+    default: [1],
   })
-  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
-  @Type(() => Number)
-  [ListingFilterKeys.bathrooms]?: number;
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default], each: true })
+  [ListingFilterKeys.bathrooms]?: number[];
 
   @Expose()
   @ApiPropertyOptional({

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -20,6 +20,7 @@ export enum FeatureFlagEnum {
   enableConfigurableRegions = 'enableConfigurableRegions',
   enableCreditScreeningFee = 'enableCreditScreeningFee',
   enableFaq = 'enableFaq',
+  enableFilterByBathroom = 'enableFilterByBathroom',
   enableFullTimeStudentQuestion = 'enableFullTimeStudentQuestion',
   enableGenderQuestion = 'enableGenderQuestion',
   enableGeocodingPreferences = 'enableGeocodingPreferences',
@@ -167,6 +168,11 @@ export const featureFlagMap: {
     name: FeatureFlagEnum.enableFaq,
     description:
       'When true, a link to the FAQ page is displayed on the get assistance page',
+  },
+  {
+    name: FeatureFlagEnum.enableFilterByBathroom,
+    description:
+      'When true, the filter drawer on the public site includes the option to filter listings by number of bathrooms',
   },
   {
     name: FeatureFlagEnum.enableFullTimeStudentQuestion,

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -45,6 +45,7 @@ The following are all of the feature flags currently available in the Bloom plat
 | [enableCreditScreeningFee](./feature-flags/enableCreditScreeningFee.md) | When true, credit screening fee is enabled for listings |
 | [enableCustomListingNotifications](./feature-flags/enableCustomListingNotifications.md) | When true, users have access to custom notification settings |
 | [enableFaq](./feature-flags/enableFaq.md) | When true, a link to the FAQ page is displayed on the get assistance page |
+| [enableFilterByBathroom](./feature-flags/enableFilterByBathroom.md) | When true, the filter drawer on the public site includes the option to filter listings by number of bathrooms |
 | [enableFullTimeStudentQuestion](./feature-flags/enableFullTimeStudentQuestion.md) | When true, the full time student question is displayed in the application form |
 | [enableGenderQuestion](./feature-flags/enableGenderQuestion.md) | When true, the gender identity question is displayed in the public and partner application demographics section |
 | [enableGeocodingPreferences](./feature-flags/enableGeocodingPreferences.md) | When true, preferences can be created with geocoding functionality and when an application is created/updated on a listing that is geocoding then the application gets geocoded |

--- a/docs/feature-flags/enableFilterByBathroom.md
+++ b/docs/feature-flags/enableFilterByBathroom.md
@@ -1,0 +1,13 @@
+# enableFilterByBathroom
+
+## Name
+
+`enableFilterByBathroom`
+
+## Description
+
+When true, the filter drawer on the public site includes the option to filter listings by number of bathrooms
+
+## Additional Information
+
+## Images

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -10653,6 +10653,7 @@ export enum FeatureFlagEnum {
   "enableConfigurableRegions" = "enableConfigurableRegions",
   "enableCreditScreeningFee" = "enableCreditScreeningFee",
   "enableFaq" = "enableFaq",
+  "enableFilterByBathroom" = "enableFilterByBathroom",
   "enableFullTimeStudentQuestion" = "enableFullTimeStudentQuestion",
   "enableGenderQuestion" = "enableGenderQuestion",
   "enableGeocodingPreferences" = "enableGeocodingPreferences",

--- a/sites/public/__tests__/components/browse/FilterDrawer.test.tsx
+++ b/sites/public/__tests__/components/browse/FilterDrawer.test.tsx
@@ -577,6 +577,74 @@ describe("FilterDrawer", () => {
     expect(screen.queryByRole("checkbox", { name: "Apartment" })).not.toBeInTheDocument()
   })
 
+  it("should not show bathrooms section when enableFilterByBathroom flag is off", () => {
+    render(
+      <FilterDrawer
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onClear={() => {}}
+        filterState={{}}
+        multiselectData={mockMultiselect}
+        activeFeatureFlags={[]}
+        listingFeaturesConfiguration={defaultListingFeaturesConfiguration}
+      />
+    )
+
+    expect(screen.queryByRole("group", { name: "Bathrooms" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("checkbox", { name: "1" })).not.toBeInTheDocument()
+  })
+
+  it("should show bathrooms section with unchecked checkboxes when flag is on and no filter state", () => {
+    render(
+      <FilterDrawer
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onClear={() => {}}
+        filterState={{}}
+        multiselectData={mockMultiselect}
+        activeFeatureFlags={[FeatureFlagEnum.enableFilterByBathroom]}
+        listingFeaturesConfiguration={defaultListingFeaturesConfiguration}
+      />
+    )
+
+    expect(screen.getByRole("group", { name: "Bathrooms" })).toBeInTheDocument()
+    expect(screen.getByRole("checkbox", { name: "1" })).not.toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "2" })).not.toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "3" })).not.toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "4" })).not.toBeChecked()
+  })
+
+  it("should show bathrooms checkboxes as checked when filterState has selections", () => {
+    const filterState: FilterData = {
+      [ListingFilterKeys.bathrooms]: {
+        "1": true,
+        "2": false,
+        "3": true,
+        "4": false,
+      },
+    }
+
+    render(
+      <FilterDrawer
+        isOpen={true}
+        onClose={() => {}}
+        onSubmit={() => {}}
+        onClear={() => {}}
+        filterState={filterState}
+        multiselectData={mockMultiselect}
+        activeFeatureFlags={[FeatureFlagEnum.enableFilterByBathroom]}
+        listingFeaturesConfiguration={defaultListingFeaturesConfiguration}
+      />
+    )
+
+    expect(screen.getByRole("checkbox", { name: "1" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "2" })).not.toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "3" })).toBeChecked()
+    expect(screen.getByRole("checkbox", { name: "4" })).not.toBeChecked()
+  })
+
   it("should not show parking types section when parkingType flag is off", () => {
     render(
       <FilterDrawer

--- a/sites/public/__tests__/components/browse/FilterDrawerHelpers.test.tsx
+++ b/sites/public/__tests__/components/browse/FilterDrawerHelpers.test.tsx
@@ -337,6 +337,19 @@ describe("filter drawer helpers", () => {
       const backendFilters = encodeFilterDataToBackendFilters(filterData)
       expect(backendFilters).toStrictEqual([{ $comparison: "LIKE", name: "Listing Name" }])
     })
+    it("should return correct BE filters for bathrooms count", () => {
+      const filterData: FilterData = {
+        [ListingFilterKeys.bathrooms]: {
+          "1": false,
+          "2": true,
+          "3": true,
+          "4": false,
+        },
+      }
+
+      const backendFilters = encodeFilterDataToBackendFilters(filterData)
+      expect(backendFilters).toStrictEqual([{ $comparison: "IN", bathrooms: [2, 3] }])
+    })
     it("should return correct BE filters for all comparison types combined", () => {
       const filterData: FilterData = {
         [ListingFilterKeys.isVerified]: true,

--- a/sites/public/src/components/browse/FilterDrawer.tsx
+++ b/sites/public/src/components/browse/FilterDrawer.tsx
@@ -1,4 +1,4 @@
-import { Form, t } from "@bloom-housing/ui-components"
+import { Field, Form, t } from "@bloom-housing/ui-components"
 import { Button, Drawer } from "@bloom-housing/ui-seeds"
 import { useForm } from "react-hook-form"
 import {
@@ -83,6 +83,10 @@ const FilterDrawer = (props: FilterDrawerProps) => {
 
   const enableSection8 = props.activeFeatureFlags?.some(
     (entry) => entry === FeatureFlagEnum.enableSection8Question
+  )
+
+  const enableFilterByBathroom = props.activeFeatureFlags?.some(
+    (entry) => entry === FeatureFlagEnum.enableFilterByBathroom
   )
 
   // When unit groups are off, closed waitlist has no backend signal, so hide it
@@ -171,6 +175,21 @@ const FilterDrawer = (props: FilterDrawerProps) => {
               )}
               register={register}
             />
+            {enableFilterByBathroom && (
+              <CheckboxGroup
+                groupLabel={t("t.bathrooms")}
+                fields={["1", "2", "3", "4"].map((bathroomCount) => {
+                  return {
+                    key: `${ListingFilterKeys.bathrooms}.${bathroomCount}`,
+                    label: bathroomCount,
+                    defaultChecked: isTrue(
+                      props.filterState?.[ListingFilterKeys.bathrooms]?.[bathroomCount]
+                    ),
+                  }
+                })}
+                register={register}
+              />
+            )}
             <RentSection
               register={register}
               getValues={getValues}

--- a/sites/public/src/components/browse/FilterDrawer.tsx
+++ b/sites/public/src/components/browse/FilterDrawer.tsx
@@ -178,10 +178,11 @@ const FilterDrawer = (props: FilterDrawerProps) => {
             {enableFilterByBathroom && (
               <CheckboxGroup
                 groupLabel={t("t.bathrooms")}
-                fields={["1", "2", "3", "4"].map((bathroomCount) => {
+                fields={["0", "1", "2", "3", "4", "5"].map((bathroomCount) => {
                   return {
                     key: `${ListingFilterKeys.bathrooms}.${bathroomCount}`,
-                    label: bathroomCount,
+                    label:
+                      bathroomCount === "0" ? t("listings.unit.sharedBathroom") : bathroomCount,
                     defaultChecked: isTrue(
                       props.filterState?.[ListingFilterKeys.bathrooms]?.[bathroomCount]
                     ),

--- a/sites/public/src/components/browse/FilterDrawerHelpers.tsx
+++ b/sites/public/src/components/browse/FilterDrawerHelpers.tsx
@@ -38,6 +38,7 @@ export interface FilterData {
   monthlyRent?: { [K in "maxRent" | "minRent"]?: string }
   regions?: { [K in RegionEnum]: BooleanOrBooleanString }
   configurableRegions?: string
+  bathrooms?: { [K in "1" | "2" | "3" | "4"]?: BooleanOrBooleanString }
   section8Acceptance?: BooleanOrBooleanString
   reservedCommunityTypes?: { [K in ReservedCommunityTypes]?: BooleanOrBooleanString }
   multiselectQuestions?: Record<string, BooleanOrBooleanString>
@@ -83,6 +84,7 @@ export interface AccessibilitySectionProps {
 
 const arrayFilters: ListingFilterKeys[] = [
   ListingFilterKeys.bedroomTypes,
+  ListingFilterKeys.bathrooms,
   ListingFilterKeys.counties,
   ListingFilterKeys.homeTypes,
   ListingFilterKeys.listingFeatures,
@@ -406,6 +408,8 @@ export const encodeFilterDataToBackendFilters = (data: FilterData): ListingFilte
         if (field[1]) {
           if (filterType === ListingFilterKeys.bedroomTypes) {
             selectedFields.push(unitTypeMapping[field[0]]?.value)
+          } else if (filterType === ListingFilterKeys.bathrooms) {
+            selectedFields.push(parseInt(field[0]))
           } else {
             selectedFields.push(field[0])
           }
@@ -444,6 +448,12 @@ export const encodeFilterDataToBackendFilters = (data: FilterData): ListingFilte
         filter[ListingFilterKeys.monthlyRent] = userSelections["maxRent"]?.replace(",", "")
         filters.push(filter)
       }
+      // } else if (filterType === ListingFilterKeys.bathrooms && userSelections) {
+      //   const filter = {
+      //     $comparison: EnumListingFilterParamsComparison["="],
+      //   }
+      //   filter[ListingFilterKeys.bathrooms] = userSelections
+      //   filters.push(filter)
     } else if (filterType === ListingFilterKeys.name) {
       const filter = {
         $comparison: EnumListingFilterParamsComparison["LIKE"],
@@ -534,6 +544,8 @@ export const decodeQueryToFilterData = (parsedQuery: ParsedUrlQuery): FilterData
       //custom separator to avoid conflicts with higher values with commas
       const rentArr = userSelections.split("-")
       filterData[filterType] = { minRent: rentArr[0] ?? "", maxRent: rentArr[1] ?? "" }
+    } else if (filterType === ListingFilterKeys.bathrooms && typeof userSelections === "string") {
+      filterData[filterType] = userSelections
     } else if (filterType === ListingFilterKeys.name) {
       filterData[filterType] = userSelections
     }
@@ -566,6 +578,8 @@ export const removeUnselectedFilterData = (data: FilterData): FilterData => {
       (filterType === ListingFilterKeys.monthlyRent && userSelections["minRent"]) ||
       userSelections["maxRent"]
     ) {
+      cleanedFilterData[filterType] = userSelections
+    } else if (filterType === ListingFilterKeys.bathrooms && userSelections) {
       cleanedFilterData[filterType] = userSelections
     } else if (filterType === ListingFilterKeys.name && userSelections) {
       cleanedFilterData[filterType] = userSelections

--- a/sites/public/src/components/browse/FilterDrawerHelpers.tsx
+++ b/sites/public/src/components/browse/FilterDrawerHelpers.tsx
@@ -448,12 +448,6 @@ export const encodeFilterDataToBackendFilters = (data: FilterData): ListingFilte
         filter[ListingFilterKeys.monthlyRent] = userSelections["maxRent"]?.replace(",", "")
         filters.push(filter)
       }
-      // } else if (filterType === ListingFilterKeys.bathrooms && userSelections) {
-      //   const filter = {
-      //     $comparison: EnumListingFilterParamsComparison["="],
-      //   }
-      //   filter[ListingFilterKeys.bathrooms] = userSelections
-      //   filters.push(filter)
     } else if (filterType === ListingFilterKeys.name) {
       const filter = {
         $comparison: EnumListingFilterParamsComparison["LIKE"],


### PR DESCRIPTION
This PR addresses #6241

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds the "Bathrooms" filter to the public search form

<img width="429" height="175" alt="image" src="https://github.com/user-attachments/assets/84cc065a-de9e-4a76-b5d2-877979e9c3c8" />

I chose to have it be checkboxes rather than Doorway's radio button because that fits better with the patterns we have in core. Also, it is behind a feature flag

Open question:
* Is up to 4 bedrooms enough for options? If so, should the 4 bedroom option be changed to 4+ and have it be anything greater than or equal to 4?

## How Can This Be Tested/Reviewed?

After seeding the staging data on the public site using Bloomington you should see the "Bathrooms" filter and it should properly filter the listings when selections are chosen.

The filter should not appear for any other jurisdictions

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
