### PR TITLE
fix: partner paper application correct languages

### DIFF
--- a/sites/partners/__tests__/components/applications/PaperApplicationForm/sections/FormApplicationData.test.tsx
+++ b/sites/partners/__tests__/components/applications/PaperApplicationForm/sections/FormApplicationData.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import React from "react"
 import userEvent from "@testing-library/user-event"
 import {
@@ -14,6 +14,12 @@ const defaultFormApplicationDataProps = {
   enableApplicationStatus: false,
   enableReceivedAtAndByFields: false,
   appType: ApplicationSubmissionTypeEnum.paper,
+  availableJurisdictionLanguages: [
+    LanguagesEnum.en,
+    LanguagesEnum.es,
+    LanguagesEnum.vi,
+    LanguagesEnum.zh,
+  ],
 }
 
 describe("<FormApplicationData>", () => {
@@ -76,6 +82,7 @@ describe("<FormApplicationData>", () => {
     )
 
     const languageSelect = screen.getByLabelText(/language submitted in/i)
+    expect(within(languageSelect).getAllByRole("option")).toHaveLength(5)
     await userEvent.selectOptions(languageSelect, LanguagesEnum.en)
 
     expect((languageSelect as HTMLSelectElement).value).toBe(LanguagesEnum.en)

--- a/sites/partners/__tests__/pages/application/edit.test.tsx
+++ b/sites/partners/__tests__/pages/application/edit.test.tsx
@@ -7,6 +7,7 @@ import userEvent from "@testing-library/user-event"
 import {
   ApplicationStatusEnum,
   FeatureFlagEnum,
+  LanguagesEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { application, listing, user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 
@@ -33,6 +34,7 @@ describe("application edit page", () => {
         value={{
           profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
           doJurisdictionsHaveFeatureFlagOn: () => false,
+          getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
         }}
       >
         <EditApplication />
@@ -60,6 +62,7 @@ describe("application edit page", () => {
             profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
             doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
               featureFlag === FeatureFlagEnum.enableApplicationStatus,
+            getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
           }}
         >
           <EditApplication />
@@ -106,6 +109,7 @@ describe("application edit page", () => {
             profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
             doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
               featureFlag === FeatureFlagEnum.enableApplicationStatus,
+            getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
           }}
         >
           <EditApplication />
@@ -151,6 +155,7 @@ describe("application edit page", () => {
             profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
             doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
               featureFlag === FeatureFlagEnum.enableApplicationStatus,
+            getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
           }}
         >
           <EditApplication />
@@ -199,6 +204,7 @@ describe("application edit page", () => {
             profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
             doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
               featureFlag === FeatureFlagEnum.enableApplicationStatus,
+            getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
           }}
         >
           <EditApplication />

--- a/sites/partners/__tests__/pages/listings/[id]/applications/add.test.tsx
+++ b/sites/partners/__tests__/pages/listings/[id]/applications/add.test.tsx
@@ -6,7 +6,10 @@ import { rest } from "msw"
 import { application, listing, user } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import userEvent from "@testing-library/user-event"
 import { AuthContext } from "@bloom-housing/shared-helpers"
-import { ApplicationsService } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  ApplicationsService,
+  LanguagesEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 
 const server = setupServer()
 
@@ -43,6 +46,7 @@ describe("listing applications add page", () => {
           profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
           doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
             mockJurisdictionsHaveFeatureFlagOn(featureFlag),
+          getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
         }}
       >
         <NewApplication />
@@ -105,6 +109,7 @@ describe("listing applications add page", () => {
           profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
           doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
             mockJurisdictionsHaveFeatureFlagOn(featureFlag),
+          getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
         }}
       >
         <NewApplication />
@@ -135,6 +140,7 @@ describe("listing applications add page", () => {
           profile: { ...user, listings: [{ id: listing.id }], jurisdictions: [] },
           doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
             mockJurisdictionsHaveFeatureFlagOn(featureFlag),
+          getJurisdictionLanguages: () => [LanguagesEnum.en, LanguagesEnum.es, LanguagesEnum.vi],
         }}
       >
         <NewApplication />

--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -43,7 +43,8 @@ type AlertErrorType = "api" | "form"
 const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormProps) => {
   const { listingDto } = useSingleListingData(listingId)
   const { data: jurisdictionData } = useJurisdiction(listingDto?.jurisdictions?.id)
-  const { doJurisdictionsHaveFeatureFlagOn, applicationsService } = useContext(AuthContext)
+  const { doJurisdictionsHaveFeatureFlagOn, applicationsService, getJurisdictionLanguages } =
+    useContext(AuthContext)
 
   const preferences = listingSectionQuestions(
     listingDto,
@@ -150,6 +151,10 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
     data: FormTypes
     redirect: "details" | "new"
   } | null>(null)
+
+  const availableJurisdictionLanguages = listingDto?.jurisdictions?.id
+    ? getJurisdictionLanguages(listingDto?.jurisdictions?.id)
+    : []
 
   useEffect(() => {
     if (application?.householdMember) {
@@ -342,6 +347,7 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
                         enableApplicationStatus && editMode && application?.markedAsDuplicate
                       }
                       reviewOrderType={listingDto?.reviewOrderType}
+                      availableJurisdictionLanguages={availableJurisdictionLanguages}
                     />
 
                     <FormPrimaryApplicant

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormApplicationData.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormApplicationData.tsx
@@ -23,6 +23,7 @@ type FormApplicationDataProps = {
   appType: ApplicationSubmissionTypeEnum
   disableApplicationStatusControls?: boolean
   reviewOrderType?: ReviewOrderTypeEnum
+  availableJurisdictionLanguages?: LanguagesEnum[]
 }
 
 const FormApplicationData = ({
@@ -31,6 +32,7 @@ const FormApplicationData = ({
   appType,
   disableApplicationStatusControls = false,
   reviewOrderType,
+  availableJurisdictionLanguages = [],
 }: FormApplicationDataProps) => {
   const formMethods = useFormContext()
 
@@ -103,7 +105,13 @@ const FormApplicationData = ({
             label={t("application.add.languageSubmittedIn")}
             register={register}
             controlClassName="control"
-            options={["", ...Object.values(LanguagesEnum)]}
+            options={[
+              "",
+              ...availableJurisdictionLanguages.map((item) => ({
+                label: t(`languages.${item}`),
+                value: item,
+              })),
+            ]}
             keyPrefix="languages"
           />
         </Grid.Cell>


### PR DESCRIPTION
This PR addresses #6244

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The language selector for paper applications was displaying all possible language options instead of the languages configured for that jurisdiction. This change switches it to grab the languages from the jurisdictions 

## How Can This Be Tested/Reviewed?

* Seed the data
* In the partner go to add an application for a listing
* For Angelopolis you should see 8 language options
* For Lakeview you should only see 4 options

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
