### PR TITLE
feat: no demographics fixes

### DIFF
--- a/api/src/types/CsvExportInterface.ts
+++ b/api/src/types/CsvExportInterface.ts
@@ -8,7 +8,7 @@ import { User } from '../dtos/users/user.dto';
 export type CsvHeader = {
   path: string;
   label: string;
-  format?: (val: unknown, fullObject?: unknown) => unknown;
+  format?: (val: any, fullObject?: any) => any;
 };
 
 export interface LotteryHeader {

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -409,6 +409,9 @@ export const getExportHeaders = (
         path: 'preferredUnitTypes',
         label: 'Requested Unit Types',
         format: (val: UnitType[]): string => {
+          if (!val?.map) {
+            return '';
+          }
           return val.map((unit) => unitTypeToReadable(unit.name)).join(',');
         },
       },
@@ -486,8 +489,14 @@ export const getExportHeaders = (
       {
         path: 'demographics.race',
         label: 'Race',
-        format: (val: string[]): string =>
-          val.map((race) => convertDemographicRaceToReadable(race)).join(','),
+        format: (val: string[]): string => {
+          if (!val?.map) {
+            return '';
+          }
+          return val
+            .map((race) => convertDemographicRaceToReadable(race))
+            .join(',');
+        },
       },
       {
         path: 'demographics.howDidYouHear',

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -409,7 +409,7 @@ export const getExportHeaders = (
         path: 'preferredUnitTypes',
         label: 'Requested Unit Types',
         format: (val: UnitType[]): string => {
-          if (!val?.map) {
+          if (!val) {
             return '';
           }
           return val.map((unit) => unitTypeToReadable(unit.name)).join(',');
@@ -490,7 +490,7 @@ export const getExportHeaders = (
         path: 'demographics.race',
         label: 'Race',
         format: (val: string[]): string => {
-          if (!val?.map) {
+          if (!val) {
             return '';
           }
           return val


### PR DESCRIPTION
## Description
Currently if an application export is requested but one or more applications does not have demographics data the export will error

This change means that the export will generate and treat those missing demographics fields as null

## How Can This Be Tested/Reviewed?
the easiest way to test this is to delete demographics data tied to applications on a listing then request an applications export 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
