### PR TITLE
fix: allow jadmins to create agency

### DIFF
--- a/api/src/controllers/agency.controller.ts
+++ b/api/src/controllers/agency.controller.ts
@@ -8,10 +8,12 @@ import {
   Post,
   Put,
   Query,
+  Request,
   UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import {
   ApiExtraModels,
   ApiOkResponse,
@@ -23,9 +25,12 @@ import { AgencyUpdate } from '../dtos/agency/agency-update.dto';
 import Agency from '../dtos/agency/agency.dto';
 import { IdDTO } from '../dtos/shared/id.dto';
 import { ApiKeyGuard } from '../guards/api-key.guard';
+import { JwtAuthGuard } from '../guards/jwt.guard';
 import { OptionalAuthGuard } from '../../src/guards/optional.guard';
 import { PermissionGuard } from '../guards/permission.guard';
 import { AgencyService } from '../services/agency.service';
+import { mapTo } from '../utilities/mapTo';
+import { User } from '../dtos/users/user.dto';
 import { defaultValidationPipeOptions } from '../utilities/default-validation-pipe-options';
 import { SuccessDTO } from '../dtos/shared/success.dto';
 import { PaginatedAgencyDto } from '../dtos/agency/paginated-agency.dto';
@@ -81,9 +86,12 @@ export class AgencyController {
   })
   @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
   @ApiOkResponse({ type: Agency })
-  @UseGuards(PermissionGuard)
-  public async createAgency(@Body() agencyDto: AgencyCreate): Promise<Agency> {
-    return await this.agencyService.create(agencyDto);
+  @UseGuards(JwtAuthGuard)
+  public async createAgency(
+    @Body() agencyDto: AgencyCreate,
+    @Request() req: ExpressRequest,
+  ): Promise<Agency> {
+    return await this.agencyService.create(agencyDto, mapTo(User, req['user']));
   }
 
   @Put()
@@ -93,9 +101,12 @@ export class AgencyController {
   })
   @UsePipes(new ValidationPipe(defaultValidationPipeOptions))
   @ApiOkResponse({ type: Agency })
-  @UseGuards(PermissionGuard)
-  public async update(@Body() agencyDto: AgencyUpdate): Promise<Agency> {
-    return await this.agencyService.update(agencyDto);
+  @UseGuards(JwtAuthGuard)
+  public async update(
+    @Body() agencyDto: AgencyUpdate,
+    @Request() req: ExpressRequest,
+  ): Promise<Agency> {
+    return await this.agencyService.update(agencyDto, mapTo(User, req['user']));
   }
 
   @Delete()
@@ -103,9 +114,12 @@ export class AgencyController {
     summary: 'Deletes an agency entry from the database by its ID',
     operationId: 'delete',
   })
-  @UseGuards(PermissionGuard)
+  @UseGuards(JwtAuthGuard)
   @ApiOkResponse({ type: SuccessDTO })
-  public async delete(@Body() idDto: IdDTO): Promise<SuccessDTO> {
-    return await this.agencyService.deleteOne(idDto);
+  public async delete(
+    @Body() idDto: IdDTO,
+    @Request() req: ExpressRequest,
+  ): Promise<SuccessDTO> {
+    return await this.agencyService.deleteOne(idDto, mapTo(User, req['user']));
   }
 }

--- a/api/src/services/agency.service.ts
+++ b/api/src/services/agency.service.ts
@@ -21,10 +21,16 @@ import { IdDTO } from '../dtos/shared/id.dto';
 import { buildOrderBy } from '../utilities/build-order-by';
 import { OrderByEnum } from '../enums/shared/order-by-enum';
 import { buildFilter } from '../utilities/build-filter';
+import { PermissionService } from './permission.service';
+import { permissionActions } from '../enums/permissions/permission-actions-enum';
+import { User } from '../dtos/users/user.dto';
 
 @Injectable()
 export class AgencyService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private permissionService: PermissionService,
+  ) {}
 
   /**
    * Returns a paginated list of agencies matching the provided query parameters.
@@ -126,12 +132,19 @@ export class AgencyService {
    * @throws {BadRequestException} If a jurisdiction ID to link to is not provided.
    * @throws {NotFoundException} If a jurisdiction to link to is not found for the given ID.
    */
-  async create(agencyDto: AgencyCreate) {
+  async create(agencyDto: AgencyCreate, requestingUser: User) {
     if (!agencyDto.jurisdictions || !agencyDto.jurisdictions.id) {
       throw new BadRequestException('A valid jurisdiction must be provided');
     }
 
     await this.findOrThrowJurisdiction(agencyDto.jurisdictions.id);
+
+    await this.permissionService.canOrThrow(
+      requestingUser,
+      'agency',
+      permissionActions.create,
+      { jurisdictionId: agencyDto.jurisdictions.id },
+    );
 
     const rawAgency = await this.prisma.agency.create({
       data: {
@@ -158,7 +171,7 @@ export class AgencyService {
    * @throws {BadRequestException} If a jurisdiction ID to link to is not provided.
    * @throws {NotFoundException} If a jurisdiction to link to is not found for the given ID.
    */
-  async update(agencyDto: AgencyUpdate) {
+  async update(agencyDto: AgencyUpdate, requestingUser: User) {
     if (!agencyDto.jurisdictions || !agencyDto.jurisdictions.id) {
       throw new BadRequestException('A valid jurisdiction must be provided');
     }
@@ -166,6 +179,13 @@ export class AgencyService {
     await this.findOrThrowJurisdiction(agencyDto.jurisdictions.id);
 
     await this.findOrThrowAgency(agencyDto.id);
+
+    await this.permissionService.canOrThrow(
+      requestingUser,
+      'agency',
+      permissionActions.update,
+      { jurisdictionId: agencyDto.jurisdictions.id },
+    );
 
     const rawAgency = await this.prisma.agency.update({
       data: {
@@ -194,12 +214,19 @@ export class AgencyService {
    * @returns A `SuccessDTO` indicating that the delete operation completed successfully.
    * @throws {BadRequestException} If no agency ID is provided or the agency is associated with users.
    */
-  async deleteOne(idDto: IdDTO) {
+  async deleteOne(idDto: IdDTO, requestingUser: User) {
     if (!idDto || !idDto.id) {
       throw new BadRequestException('A agency ID must be provided');
     }
 
-    await this.findOrThrowAgency(idDto.id);
+    const existingAgency = await this.findOrThrowAgency(idDto.id);
+
+    await this.permissionService.canOrThrow(
+      requestingUser,
+      'agency',
+      permissionActions.delete,
+      { jurisdictionId: existingAgency.jurisdictions?.id },
+    );
 
     const associatedUsersCount = await this.prisma.userAccounts.count({
       where: {

--- a/api/src/services/permission.service.ts
+++ b/api/src/services/permission.service.ts
@@ -114,6 +114,12 @@ export class PermissionService {
           );
           await enforcer.addPermissionForUser(
             user.id,
+            'agency',
+            `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
+            `(${permissionActions.read}|${permissionActions.create}|${permissionActions.update}|${permissionActions.delete})`,
+          );
+          await enforcer.addPermissionForUser(
+            user.id,
             'user',
             `r.obj.jurisdictionId == '${adminInJurisdiction.id}'`,
             `(${permissionActions.read}|${permissionActions.invitePartner}|${permissionActions.inviteJurisdictionalAdmin}|${permissionActions.update}|${permissionActions.delete})`,

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -1613,7 +1613,7 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         .expect(200);
     });
 
-    it('should error as forbidden for create endpoint', async () => {
+    it('should succeed for create endpoint', async () => {
       const agencyData = {
         name: 'New Test Agency',
         jurisdictions: {
@@ -1626,10 +1626,10 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         .send(agencyData)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(201);
     });
 
-    it('should error as forbidden for update endpoint', async () => {
+    it('should succeed for update endpoint', async () => {
       if (!agencyId) {
         throw new Error('Agency ID not set up for test');
       }
@@ -1647,10 +1647,10 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         .send(agencyUpdateData)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
 
-    it('should error as forbidden for delete endpoint', async () => {
+    it('should succeed for delete endpoint', async () => {
       const agencyData = {
         name: 'Agency to Delete',
         jurisdictions: {
@@ -1677,7 +1677,7 @@ describe('Testing Permissioning of endpoints as Jurisdictional Admin in the corr
         } as IdDTO)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(200);
     });
   });
 });

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -1476,7 +1476,7 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .send(agencyData)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(401);
     });
 
     it('should error as unauthorized for update endpoint', async () => {
@@ -1497,7 +1497,7 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         .send(agencyUpdateData)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(401);
     });
 
     it('should error as unauthorized for delete endpoint', async () => {
@@ -1527,7 +1527,7 @@ describe('Testing Permissioning of endpoints as logged out user', () => {
         } as IdDTO)
         .set({ passkey: process.env.API_PASS_KEY || '' })
         .set('Cookie', cookies)
-        .expect(403);
+        .expect(401);
     });
   });
 });

--- a/sites/partners/__tests__/pages/settings/agencies.test.tsx
+++ b/sites/partners/__tests__/pages/settings/agencies.test.tsx
@@ -248,14 +248,34 @@ describe("<SettingsAgencies>", () => {
         return res(ctx.json(user))
       })
     )
+    const enableHousingAdvocateFlag = {
+      name: FeatureFlagEnum.enableHousingAdvocate,
+      active: true,
+      id: "ff-enable-housing-advocate",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      description: "",
+      jurisdictions: [],
+    }
+
     render(
       <AuthContext.Provider
         value={{
           profile: {
             ...user,
             jurisdictions: [
-              { ...jurisdiction, id: "jurisdiction1", name: "Jurisdiction 1" },
-              { ...jurisdiction, id: "jurisdiction2", name: "Jurisdiction 2" },
+              {
+                ...jurisdiction,
+                id: "jurisdiction1",
+                name: "Jurisdiction 1",
+                featureFlags: [...jurisdiction.featureFlags, enableHousingAdvocateFlag],
+              },
+              {
+                ...jurisdiction,
+                id: "jurisdiction2",
+                name: "Jurisdiction 2",
+                featureFlags: [...jurisdiction.featureFlags, enableHousingAdvocateFlag],
+              },
             ],
             listings: [],
           },

--- a/sites/partners/__tests__/pages/settings/properties.test.tsx
+++ b/sites/partners/__tests__/pages/settings/properties.test.tsx
@@ -267,14 +267,34 @@ describe("<SettingsProperties>", () => {
         return res(ctx.json(user))
       })
     )
+    const enablePropertiesFlag = {
+      name: FeatureFlagEnum.enableProperties,
+      active: true,
+      id: "ff-enable-properties",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      description: "",
+      jurisdictions: [],
+    }
+
     render(
       <AuthContext.Provider
         value={{
           profile: {
             ...user,
             jurisdictions: [
-              { id: "jurisdiction1", name: "Jurisdiction 1" } as Jurisdiction,
-              { id: "jurisdiction2", name: "Jurisdiction 2" } as Jurisdiction,
+              {
+                ...jurisdiction,
+                id: "jurisdiction1",
+                name: "Jurisdiction 1",
+                featureFlags: [...jurisdiction.featureFlags, enablePropertiesFlag],
+              },
+              {
+                ...jurisdiction,
+                id: "jurisdiction2",
+                name: "Jurisdiction 2",
+                featureFlags: [...jurisdiction.featureFlags, enablePropertiesFlag],
+              },
             ],
             listings: [],
           },

--- a/sites/partners/src/components/settings/AgencyDrawer.tsx
+++ b/sites/partners/src/components/settings/AgencyDrawer.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useContext } from "react"
 import { useForm } from "react-hook-form"
 import { AuthContext } from "@bloom-housing/shared-helpers"
-import { Agency, AgencyCreate } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  Agency,
+  AgencyCreate,
+  FeatureFlagEnum,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { Button, Card, Drawer, FieldValue, Grid } from "@bloom-housing/ui-seeds"
 import { Field, Select, SelectOption, t } from "@bloom-housing/ui-components"
 import { addAsterisk, defaultFieldProps, fieldHasError } from "../../lib/helpers"
@@ -33,11 +37,17 @@ export const AgencyDrawer = ({
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { register, errors, clearErrors, trigger, getValues } = useForm<AgencyFormTypes>()
 
+  const eligibleJurisdictions = profile.jurisdictions.filter((j) =>
+    j.featureFlags?.some(
+      (flag) => flag.name === FeatureFlagEnum.enableHousingAdvocate && flag.active
+    )
+  )
+
   const jurisdictionOptions: SelectOption[] =
-    profile.jurisdictions.length !== 0
+    eligibleJurisdictions.length !== 0
       ? [
           { label: "", value: "" },
-          ...profile.jurisdictions.map((jurisdiction) => ({
+          ...eligibleJurisdictions.map((jurisdiction) => ({
             label: jurisdiction.name,
             value: jurisdiction.id,
           })),

--- a/sites/partners/src/components/settings/PropertyDrawer.tsx
+++ b/sites/partners/src/components/settings/PropertyDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+  FeatureFlagEnum,
   Listing,
   Property,
   PropertyCreate,
@@ -45,11 +46,15 @@ export const PropertyDrawer = ({
     (listing) => listing.property?.id === editedProperty?.id
   )
 
+  const eligibleJurisdictions = profile.jurisdictions.filter((j) =>
+    j.featureFlags?.some((flag) => flag.name === FeatureFlagEnum.enableProperties && flag.active)
+  )
+
   const jurisdictionOptions: SelectOption[] =
-    profile.jurisdictions.length !== 0
+    eligibleJurisdictions.length !== 0
       ? [
           { label: "", value: "" },
-          ...profile.jurisdictions.map((jurisdiction) => ({
+          ...eligibleJurisdictions.map((jurisdiction) => ({
             label: jurisdiction.name,
             value: jurisdiction.id,
           })),


### PR DESCRIPTION
## Description

1. Jurisdictional admins should be able to create agencies
2. The jurisdiction dropdown for properties and agencies should only show jurisdictions that have the appropriate flag enabled

## How Can This Be Tested/Reviewed?

Log-in as a jurisdictional admin, ensure you can create an agency, and that the only dropdown item in core after the seed in Angelopolis.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
