### PR TITLE
listing: skip amiChart findMany when no units carry an AMI chart

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -2963,13 +2963,18 @@ export class ListingService implements OnModuleInit {
   addUnitsSummarized = async (listing: Listing) => {
     if (Array.isArray(listing.units) && listing.units.length > 0) {
       const unitsWithCharts = listing.units.filter((unit) => unit.amiChart?.id);
-      const amiChartsRaw = await this.prisma.amiChart.findMany({
-        where: {
-          id: {
-            in: unitsWithCharts.map((unit) => unit.amiChart?.id),
-          },
-        },
-      });
+      // Skip the findMany when none of the units carry an amiChart (e.g.
+      // when called from a view that doesn't select amiChart). Otherwise
+      // we'd run an `in: []` query that downstream views weren't expecting.
+      const amiChartsRaw = unitsWithCharts.length
+        ? await this.prisma.amiChart.findMany({
+            where: {
+              id: {
+                in: unitsWithCharts.map((unit) => unit.amiChart?.id),
+              },
+            },
+          })
+        : [];
       const amiCharts = mapTo(AmiChart, amiChartsRaw);
       listing.unitsSummarized = summarizeUnits(listing, amiCharts);
     }


### PR DESCRIPTION
Per the diagnosis @ludtkemorgan put in #5684: when `addUnitsSummarized` runs against a listing pulled with a view that doesn't `select` `amiChart`, every `unit.amiChart?.id` is undefined, `unitsWithCharts` ends up empty, and we still issue `prisma.amiChart.findMany({ where: { id: { in: [] } } })`. That's enough to trip up downstream callers expecting the base path not to hit the AMI chart table, which is what's breaking `account/application/[id]` (the listing title doesn't load).

Short-circuit `findMany` when `unitsWithCharts` is empty.

Closes #5684. Happy to also tackle the alternate framing (selecting `amiChart` in `ListingView`) in a follow-up if you'd rather fix it that way; the issue's listed both options.