### PR TITLE
fix: update maxAge cookie to 3 hours

### DIFF
--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -38,7 +38,7 @@ export const AUTH_COOKIE_OPTIONS: CookieOptions = {
   httpOnly: true,
   secure,
   sameSite,
-  maxAge: TOKEN_COOKIE_MAXAGE / 24, // access token should last 1 hr
+  maxAge: TOKEN_COOKIE_MAXAGE / 8, // access token should last 3 hours
 };
 export const REFRESH_COOKIE_OPTIONS: CookieOptions = {
   ...AUTH_COOKIE_OPTIONS,

--- a/api/test/unit/services/auth.service.spec.ts
+++ b/api/test/unit/services/auth.service.spec.ts
@@ -122,7 +122,7 @@ describe('Testing auth service', () => {
       iat?: number;
     };
     expect(decoded.sub).toBe(id);
-    expect(decoded.expiresIn).toBe(86400000 / 24);
+    expect(decoded.expiresIn).toBe(86400000 / 8);
     expect(decoded).toHaveProperty('iat');
     expect(typeof decoded.iat).toBe('number');
   });


### PR DESCRIPTION
This PR addresses #6330 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

There was an update to Doorway a while back to increase the maxAge of an auth cookie to be 3 hours instead of 1 hour. This change needs to be in core and it can be utilized by all jurisdictions

## How Can This Be Tested/Reviewed?

Login should still work for both public and partners. The cookies set should be valid for 3 hours

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
