### PR TITLE
fix: add last login at to update password flow

### DIFF
--- a/api/prisma/seed-helpers/user-factory.ts
+++ b/api/prisma/seed-helpers/user-factory.ts
@@ -17,6 +17,7 @@ export const userFactory = async (optionalParams?: {
   password?: string;
   phoneNumber?: string;
   phoneNumberVerified?: boolean;
+  passwordUpdatedAt?: Date;
   roles?: Prisma.UserRolesUncheckedCreateWithoutUserAccountsInput;
   singleUseCode?: string;
   lastLoginAt?: Date;
@@ -41,6 +42,7 @@ export const userFactory = async (optionalParams?: {
   passwordHash: optionalParams?.password
     ? await passwordToHash(optionalParams?.password)
     : await passwordToHash('Abcdef12345!'),
+  passwordUpdatedAt: optionalParams?.passwordUpdatedAt || new Date(),
   phoneNumber:
     optionalParams?.phoneNumber ||
     (optionalParams?.isAdvocate ? '(415) 555-1212' : undefined),

--- a/api/src/passports/mfa.strategy.ts
+++ b/api/src/passports/mfa.strategy.ts
@@ -210,6 +210,7 @@ export class MfaStrategy extends PassportStrategy(Strategy, 'mfa') {
         phoneNumberVerified,
         failedLoginAttemptsCount,
         lastLoginAt: new Date(),
+        wasWarnedOfDeletion: false,
       },
       where: {
         id: userId,

--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -349,6 +349,7 @@ export class AuthService {
         confirmedAt: user.confirmedAt || new Date(),
         confirmationToken: null,
         lastLoginAt: new Date(),
+        wasWarnedOfDeletion: false,
       },
       where: {
         id: user.id,

--- a/api/src/services/auth.service.ts
+++ b/api/src/services/auth.service.ts
@@ -348,6 +348,7 @@ export class AuthService {
         resetToken: null,
         confirmedAt: user.confirmedAt || new Date(),
         confirmationToken: null,
+        lastLoginAt: new Date(),
       },
       where: {
         id: user.id,

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -1666,7 +1666,11 @@ export class UserService {
       .toDate();
     const usersToBeDeleted = await this.prisma.userAccounts.findMany({
       select: { id: true, wasWarnedOfDeletion: true },
-      where: { lastLoginAt: { lt: deleteBeforeDate }, userRoles: null },
+      where: {
+        lastLoginAt: { lt: deleteBeforeDate },
+        passwordUpdatedAt: { lt: deleteBeforeDate },
+        userRoles: null,
+      },
     });
 
     for (const user of usersToBeDeleted) {
@@ -1694,6 +1698,7 @@ export class UserService {
       await this.cronJobService.markCronJobAsStarted(
         USER_DELETION_WARN_CRON_JOB_NAME,
       );
+      const LIMIT = 1_000; // set a limit to avoid sending too many emails at once
       // warning the user 30 days before the user account will be deleted
       const warnDateNumber =
         Number(this.configService.get('USERS_DAYS_TILL_EXPIRY')) - 30;
@@ -1706,9 +1711,11 @@ export class UserService {
         },
         where: {
           lastLoginAt: { lte: warnDate },
+          passwordUpdatedAt: { lte: warnDate },
           userRoles: null,
           wasWarnedOfDeletion: false,
         },
+        take: LIMIT,
       });
       this.logger.warn(`warning ${users.length} users of account deletion`);
       for (const user of users) {

--- a/api/test/integration/user.e2e-spec.ts
+++ b/api/test/integration/user.e2e-spec.ts
@@ -1231,12 +1231,14 @@ describe('User Controller Tests', () => {
       const publicUserInactiveNotWarned = await prisma.userAccounts.create({
         data: await userFactory({
           lastLoginAt: dayjs(new Date()).subtract(1100, 'days').toDate(),
+          passwordUpdatedAt: dayjs(new Date()).subtract(1100, 'days').toDate(),
           wasWarnedOfDeletion: false,
         }),
       });
       const publicUserInactiveWarned = await prisma.userAccounts.create({
         data: await userFactory({
           lastLoginAt: dayjs(new Date()).subtract(1100, 'days').toDate(),
+          passwordUpdatedAt: dayjs(new Date()).subtract(1300, 'days').toDate(),
           wasWarnedOfDeletion: true,
         }),
       });
@@ -1302,6 +1304,10 @@ describe('User Controller Tests', () => {
           firstName: 'A',
           confirmedAt: new Date(),
           lastLoginAt: dayjs(new Date()).subtract(4, 'years').toDate(),
+          passwordUpdatedAt: dayjs(new Date())
+            .subtract(4, 'years')
+            .subtract(25, 'days')
+            .toDate(),
         }),
       });
       // User that has logged in recently
@@ -1310,6 +1316,7 @@ describe('User Controller Tests', () => {
           firstName: 'B',
           confirmedAt: new Date(),
           lastLoginAt: dayjs(new Date()).subtract(4, 'days').toDate(),
+          passwordUpdatedAt: dayjs(new Date()).subtract(4, 'days').toDate(),
         }),
       });
       // Partner user
@@ -1336,6 +1343,10 @@ describe('User Controller Tests', () => {
           firstName: 'E',
           confirmedAt: new Date(),
           lastLoginAt: dayjs(new Date()).subtract(4, 'years').toDate(),
+          passwordUpdatedAt: dayjs(new Date())
+            .subtract(3, 'years')
+            .subtract(2, 'days')
+            .toDate(),
           language: LanguagesEnum.es,
         }),
       });

--- a/api/test/unit/passports/mfa.strategy.spec.ts
+++ b/api/test/unit/passports/mfa.strategy.spec.ts
@@ -259,6 +259,7 @@ describe('Testing mfa strategy', () => {
         singleUseCodeUpdatedAt: null,
         phoneNumberVerified: null,
         lastLoginAt: expect.anything(),
+        wasWarnedOfDeletion: false,
         failedLoginAttemptsCount: 0,
       },
       where: {
@@ -476,6 +477,7 @@ describe('Testing mfa strategy', () => {
         phoneNumberVerified: false,
         lastLoginAt: expect.anything(),
         failedLoginAttemptsCount: 1,
+        wasWarnedOfDeletion: false,
       },
       where: {
         id,
@@ -534,6 +536,7 @@ describe('Testing mfa strategy', () => {
         phoneNumberVerified: false,
         lastLoginAt: expect.anything(),
         failedLoginAttemptsCount: 1,
+        wasWarnedOfDeletion: false,
       },
       where: {
         id,
@@ -604,6 +607,7 @@ describe('Testing mfa strategy', () => {
         phoneNumberVerified: true,
         lastLoginAt: expect.anything(),
         failedLoginAttemptsCount: 0,
+        wasWarnedOfDeletion: false,
       },
       where: {
         id,
@@ -659,6 +663,7 @@ describe('Testing mfa strategy', () => {
         phoneNumberVerified: false,
         lastLoginAt: expect.anything(),
         failedLoginAttemptsCount: 0,
+        wasWarnedOfDeletion: false,
       },
       where: {
         id,

--- a/api/test/unit/services/auth.service.spec.ts
+++ b/api/test/unit/services/auth.service.spec.ts
@@ -36,6 +36,7 @@ import {
   passwordToHash,
 } from '../../../src/utilities/password-helpers';
 import { SnapshotCreateService } from '../../../src/services/snapshot-create.service';
+import { last } from 'lodash';
 
 jest.mock('@google-cloud/recaptcha-enterprise');
 const mockedRecaptcha =
@@ -994,6 +995,7 @@ describe('Testing auth service', () => {
         resetToken: null,
         confirmedAt: expect.anything(),
         confirmationToken: null,
+        lastLoginAt: expect.anything(),
       },
       where: {
         id,

--- a/api/test/unit/services/auth.service.spec.ts
+++ b/api/test/unit/services/auth.service.spec.ts
@@ -996,6 +996,7 @@ describe('Testing auth service', () => {
         confirmedAt: expect.anything(),
         confirmationToken: null,
         lastLoginAt: expect.anything(),
+        wasWarnedOfDeletion: false,
       },
       where: {
         id,

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -3972,6 +3972,7 @@ describe('Testing user service', () => {
       );
     });
     it('should delete users for all inactive user', async () => {
+      jest.useFakeTimers().setSystemTime(new Date('2025-11-22T12:25:00.000Z'));
       // This test goes through all possible options
       //  has or has not been warned of deletion
       //  has or doesn't have applications
@@ -4003,6 +4004,21 @@ describe('Testing user service', () => {
       process.env.USERS_DAYS_TILL_EXPIRY = '1095';
       const response = await service.deleteAfterInactivity();
       expect(response).toEqual({ success: true });
+      expect(prisma.userAccounts.findMany).toBeCalledWith({
+        select: {
+          id: true,
+          wasWarnedOfDeletion: true,
+        },
+        where: {
+          lastLoginAt: {
+            lt: new Date('2022-11-23T12:25:00.000Z'),
+          },
+          passwordUpdatedAt: {
+            lt: new Date('2022-11-23T12:25:00.000Z'),
+          },
+          userRoles: null,
+        },
+      });
       expect(prisma.userAccounts.delete).toBeCalledWith({
         where: { id: 'userId1' },
       });
@@ -4064,9 +4080,11 @@ describe('Testing user service', () => {
         },
         where: {
           lastLoginAt: { lte: new Date('2022-12-23T12:25:00.000Z') },
+          passwordUpdatedAt: { lte: new Date('2022-12-23T12:25:00.000Z') },
           userRoles: null,
           wasWarnedOfDeletion: false,
         },
+        take: 1000,
       });
       expect(prisma.userAccounts.update).toBeCalledWith({
         data: {
@@ -4123,9 +4141,11 @@ describe('Testing user service', () => {
         },
         where: {
           lastLoginAt: { lte: new Date('2022-12-23T12:25:00.000Z') },
+          passwordUpdatedAt: { lte: new Date('2022-12-23T12:25:00.000Z') },
           userRoles: null,
           wasWarnedOfDeletion: false,
         },
+        take: 1000,
       });
       expect(emailService.warnOfAccountRemoval).toBeCalledTimes(2);
       expect(prisma.userAccounts.update).toBeCalledTimes(1);


### PR DESCRIPTION
This PR addresses https://github.com/bloom-housing/bloom/issues/5218 and https://github.com/bloom-housing/bloom/issues/5219

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description
NOTE: this has already been merged into Doorway

During last minute testing it was identified that there are users in the system that the last_login_at field is not up to date. This happens when the last time a user logged in was via the forgot password flow. In that flow we were not updating the last_login_at field.

This causes issues because that is the field we are using to determine if a user should be both deleted as well as warned of deletion. The fix is to both update that flow to start setting that field as well as updating both of those cron jobs to look at the password_updated_at field

Also, after doing checks on how many people will get deleted in the first run I realized it would be close to 13K users. So I added a LIMIT to the number. The first time it is run in production I will run it 13 times to get everyone

## How Can This Be Tested/Reviewed?

Go through the whole warn user and delete user flows:

1. Create several public users
2. Change their last_login_at to be well in the past
3. Change their password_updated_at to be well in the past
4. Run both cron jobs and they should successfully warn and delete those users

Go through the forgot password flow and make sure the last_login_at field is updated

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
