### PR TITLE
fix: allow setting seed jurisdiction name override, default seed

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -98,5 +98,7 @@ CONTACT_EMAIL='email@example.com'
 DB_NO_SSL="TRUE"
 # when TRUE we will use the winston logger instead of the default nestjs logger
 USE_WINSTON="FALSE"
-# optional: override the Angelopolis jurisdiction name used in staging seed
-# DBSEED_ANGELOPOLIS_JURISDICTION_NAME=
+# optional: seed only a specific jurisdiction (Bloomington, Lakeview, Angelopolis, NadaHill)
+# DBSEED_JURISDICTION=
+# optional: override the display name of the seeded jurisdiction (underscores replaced with spaces)
+# DBSEED_JURISDICTION_NAME=

--- a/api/.env.template
+++ b/api/.env.template
@@ -98,3 +98,5 @@ CONTACT_EMAIL='email@example.com'
 DB_NO_SSL="TRUE"
 # when TRUE we will use the winston logger instead of the default nestjs logger
 USE_WINSTON="FALSE"
+# optional: override the Angelopolis jurisdiction name used in staging seed
+# DBSEED_ANGELOPOLIS_JURISDICTION_NAME=

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -19,15 +19,16 @@ export const stagingSeed = async (
     publicSiteBaseURL,
     msqV2,
     asRegion = false,
-    angelopolisJurisdictionName,
+    jurisdiction,
   }: {
     jurisdictionName: string;
     publicSiteBaseURL: string;
     msqV2: boolean;
     asRegion: boolean;
-    angelopolisJurisdictionName?: string;
+    jurisdiction?: string;
   },
 ) => {
+  const resolvedJurisdictionName = jurisdictionName?.replace(/_/g, ' ');
   // Seed feature flags
   await createAllFeatureFlags(prismaClient);
 
@@ -56,9 +57,47 @@ export const stagingSeed = async (
       ...bridgeBayJurisdictions.map((jurisdiction) => jurisdiction.id),
     );
     mainJurisdiction = bridgeBayJurisdictions[0];
+  } else if (jurisdiction) {
+    switch (jurisdiction) {
+      case 'Bloomington':
+        mainJurisdiction = await createBloomingtonJurisdiction(prismaClient, {
+          jurisdictionName: resolvedJurisdictionName ?? 'Bloomington',
+          publicSiteBaseURL,
+          unitTypes,
+          partnerUser,
+          msqV2,
+        });
+        break;
+      case 'Lakeview':
+        mainJurisdiction = await createLakeviewJurisdiction(prismaClient, {
+          jurisdictionName: resolvedJurisdictionName,
+          publicSiteBaseURL,
+          unitTypes,
+          msqV2,
+        });
+        break;
+      case 'Angelopolis':
+        mainJurisdiction = await createAngelopolisJurisdiction(prismaClient, {
+          jurisdictionName: resolvedJurisdictionName,
+          publicSiteBaseURL,
+          unitTypes,
+          partnerUser,
+          msqV2,
+        });
+        break;
+      case 'NadaHill':
+        mainJurisdiction = await createNadaHillJurisdiction(prismaClient, {
+          jurisdictionName: resolvedJurisdictionName,
+          publicSiteBaseURL,
+        });
+        break;
+      default:
+        throw new Error(`Unknown jurisdiction: ${jurisdiction}`);
+    }
+    allJurisdictions.push(mainJurisdiction.id);
   } else {
     mainJurisdiction = await createBloomingtonJurisdiction(prismaClient, {
-      jurisdictionName,
+      jurisdictionName: resolvedJurisdictionName ?? jurisdictionName,
       publicSiteBaseURL,
       unitTypes,
       partnerUser,
@@ -79,7 +118,6 @@ export const stagingSeed = async (
         unitTypes,
         partnerUser,
         msqV2,
-        jurisdictionName: angelopolisJurisdictionName,
       },
     );
     const nadaHill = await createNadaHillJurisdiction(prismaClient, {

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -19,11 +19,13 @@ export const stagingSeed = async (
     publicSiteBaseURL,
     msqV2,
     asRegion = false,
+    angelopolisJurisdictionName,
   }: {
     jurisdictionName: string;
     publicSiteBaseURL: string;
     msqV2: boolean;
     asRegion: boolean;
+    angelopolisJurisdictionName?: string;
   },
 ) => {
   // Seed feature flags
@@ -72,7 +74,13 @@ export const stagingSeed = async (
     );
     const angelopolisJurisdiction = await createAngelopolisJurisdiction(
       prismaClient,
-      { publicSiteBaseURL, unitTypes, partnerUser, msqV2 },
+      {
+        publicSiteBaseURL,
+        unitTypes,
+        partnerUser,
+        msqV2,
+        jurisdictionName: angelopolisJurisdictionName,
+      },
     );
     const nadaHill = await createNadaHillJurisdiction(prismaClient, {
       publicSiteBaseURL,

--- a/api/prisma/seed-staging.ts
+++ b/api/prisma/seed-staging.ts
@@ -28,7 +28,6 @@ export const stagingSeed = async (
     jurisdiction?: string;
   },
 ) => {
-  const resolvedJurisdictionName = jurisdictionName?.replace(/_/g, ' ');
   // Seed feature flags
   await createAllFeatureFlags(prismaClient);
 
@@ -61,7 +60,7 @@ export const stagingSeed = async (
     switch (jurisdiction) {
       case 'Bloomington':
         mainJurisdiction = await createBloomingtonJurisdiction(prismaClient, {
-          jurisdictionName: resolvedJurisdictionName ?? 'Bloomington',
+          jurisdictionName: jurisdictionName ?? 'Bloomington',
           publicSiteBaseURL,
           unitTypes,
           partnerUser,
@@ -70,7 +69,7 @@ export const stagingSeed = async (
         break;
       case 'Lakeview':
         mainJurisdiction = await createLakeviewJurisdiction(prismaClient, {
-          jurisdictionName: resolvedJurisdictionName,
+          jurisdictionName: jurisdictionName,
           publicSiteBaseURL,
           unitTypes,
           msqV2,
@@ -78,7 +77,7 @@ export const stagingSeed = async (
         break;
       case 'Angelopolis':
         mainJurisdiction = await createAngelopolisJurisdiction(prismaClient, {
-          jurisdictionName: resolvedJurisdictionName,
+          jurisdictionName: jurisdictionName,
           publicSiteBaseURL,
           unitTypes,
           partnerUser,
@@ -87,7 +86,7 @@ export const stagingSeed = async (
         break;
       case 'NadaHill':
         mainJurisdiction = await createNadaHillJurisdiction(prismaClient, {
-          jurisdictionName: resolvedJurisdictionName,
+          jurisdictionName: jurisdictionName,
           publicSiteBaseURL,
         });
         break;
@@ -97,7 +96,7 @@ export const stagingSeed = async (
     allJurisdictions.push(mainJurisdiction.id);
   } else {
     mainJurisdiction = await createBloomingtonJurisdiction(prismaClient, {
-      jurisdictionName: resolvedJurisdictionName ?? jurisdictionName,
+      jurisdictionName: jurisdictionName,
       publicSiteBaseURL,
       unitTypes,
       partnerUser,

--- a/api/prisma/seed-staging/seed-angelopolis.ts
+++ b/api/prisma/seed-staging/seed-angelopolis.ts
@@ -76,17 +76,19 @@ export const createAngelopolisJurisdiction = async (
     unitTypes,
     partnerUser,
     msqV2,
+    jurisdictionName = 'Angelopolis',
   }: {
     publicSiteBaseURL: string;
     unitTypes: { id: string }[];
     partnerUser: { id: string };
     msqV2: boolean;
+    jurisdictionName?: string;
   },
 ) => {
   const optionalV2MSQ = msqV2 ? [FeatureFlagEnum.enableV2MSQ] : [];
 
   const jurisdiction = await prismaClient.jurisdictions.create({
-    data: jurisdictionFactory('Angelopolis', {
+    data: jurisdictionFactory(jurisdictionName, {
       publicSiteBaseURL,
       listingApprovalPermissions: [UserRoleEnum.admin],
       featureFlags: [
@@ -255,7 +257,7 @@ export const createAngelopolisJurisdiction = async (
     }),
   });
 
-  await agencyFactory(jurisdiction.id, prismaClient, 5, 'Angelopolis');
+  await agencyFactory(jurisdiction.id, prismaClient, 5, jurisdictionName);
 
   const agency = await prismaClient.agency.findFirst({
     where: {

--- a/api/prisma/seed-staging/seed-lakeview.ts
+++ b/api/prisma/seed-staging/seed-lakeview.ts
@@ -24,15 +24,17 @@ export const createLakeviewJurisdiction = async (
     publicSiteBaseURL,
     unitTypes,
     msqV2,
+    jurisdictionName = 'Lakeview',
   }: {
     publicSiteBaseURL: string;
     unitTypes: { id: string }[];
     msqV2: boolean;
+    jurisdictionName?: string;
   },
 ) => {
   const optionalV2MSQ = msqV2 ? [FeatureFlagEnum.enableV2MSQ] : [];
   const jurisdiction = await prismaClient.jurisdictions.create({
-    data: jurisdictionFactory('Lakeview', {
+    data: jurisdictionFactory(jurisdictionName, {
       publicSiteBaseURL,
       featureFlags: [
         ...optionalV2MSQ,

--- a/api/prisma/seed-staging/seed-nada-hill.ts
+++ b/api/prisma/seed-staging/seed-nada-hill.ts
@@ -5,12 +5,14 @@ export const createNadaHillJurisdiction = async (
   prismaClient: PrismaClient,
   {
     publicSiteBaseURL,
+    jurisdictionName = 'Nada Hill',
   }: {
     publicSiteBaseURL: string;
+    jurisdictionName?: string;
   },
 ) => {
   return await prismaClient.jurisdictions.create({
-    data: jurisdictionFactory('Nada Hill', {
+    data: jurisdictionFactory(jurisdictionName, {
       publicSiteBaseURL,
       featureFlags: [],
       requiredListingFields: ['name'],

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -20,7 +20,8 @@ async function main() {
     values: { environment, jurisdictionName, msqV2, asRegion },
   } = parseArgs({ options });
   const publicSiteBaseURL = env.DBSEED_PUBLIC_SITE_BASE_URL;
-  const angelopolisJurisdictionName = env.DBSEED_ANGELOPOLIS_JURISDICTION_NAME;
+  const seedJurisdiction = env.DBSEED_JURISDICTION;
+  const seedJurisdictionName = env.DBSEED_JURISDICTION_NAME ?? jurisdictionName;
 
   switch (environment) {
     case 'production':
@@ -37,11 +38,11 @@ async function main() {
       // Staging setup should have realistic looking data with a preset list of listings
       // along with all of the required tables (ami, users, etc)
       stagingSeed(prisma, {
-        jurisdictionName: jurisdictionName as string,
+        jurisdictionName: seedJurisdictionName as string,
         publicSiteBaseURL: publicSiteBaseURL,
         msqV2: msqV2 as boolean,
         asRegion: asRegion as boolean,
-        angelopolisJurisdictionName,
+        jurisdiction: seedJurisdiction,
       });
       break;
     case 'development':

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -20,6 +20,7 @@ async function main() {
     values: { environment, jurisdictionName, msqV2, asRegion },
   } = parseArgs({ options });
   const publicSiteBaseURL = env.DBSEED_PUBLIC_SITE_BASE_URL;
+  const angelopolisJurisdictionName = env.DBSEED_ANGELOPOLIS_JURISDICTION_NAME;
 
   switch (environment) {
     case 'production':
@@ -40,6 +41,7 @@ async function main() {
         publicSiteBaseURL: publicSiteBaseURL,
         msqV2: msqV2 as boolean,
         asRegion: asRegion as boolean,
+        angelopolisJurisdictionName,
       });
       break;
     case 'development':


### PR DESCRIPTION
## Description

Allows for Angelopolis seed name to be overridden, such that LA can set the new environment variables when testing locally and can just run the staging seed and have one jurisdiction with a custom name be added.

Adds two new backend env vars - `DBSEED_JURISDICTION` and `DBSEED_JURISDICTION_NAME`. When the jurisdiction is set, only that jurisdiction is seeded. When the name is set, that seeded jurisdiction uses that as the name (moving underscores to spaces so it is script friendly).

## How Can This Be Tested/Reviewed?

LA would set:
DBSEED_JURISDICTION=Angelopolis 
DBSEED_JURISDICTION_NAME=Los_Angeles

Without these, ensure all 4 jurisdictions are seeded.
With these two values, ensure only the Angelopolis-like jurisdiction is seeded and named `Los Angeles`.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
