### PR TITLE
fix: sexual orientation question

### DIFF
--- a/api/prisma/seed-staging/seed-bloomington.ts
+++ b/api/prisma/seed-staging/seed-bloomington.ts
@@ -82,6 +82,7 @@ export const createBloomingtonJurisdiction = async (
         FeatureFlagEnum.enableReceivedAtAndByFields,
         FeatureFlagEnum.enableResources,
         FeatureFlagEnum.enableSection8Question,
+        FeatureFlagEnum.enableSexualOrientationQuestion,
         FeatureFlagEnum.enableSingleUseCode,
         FeatureFlagEnum.enableSupportAdmin,
         FeatureFlagEnum.enableUtilitiesIncluded,

--- a/api/prisma/seed-staging/seed-bridge-bay.ts
+++ b/api/prisma/seed-staging/seed-bridge-bay.ts
@@ -2414,6 +2414,7 @@ const featureFlags = [
   FeatureFlagEnum.enablePartnerDemographics,
   FeatureFlagEnum.enablePartnerSettings,
   FeatureFlagEnum.enableReceivedAtAndByFields,
+  FeatureFlagEnum.enableSexualOrientationQuestion,
   FeatureFlagEnum.enableSupportAdmin,
 ];
 

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -23,6 +23,7 @@ export enum FeatureFlagEnum {
   enableFilterByBathroom = 'enableFilterByBathroom',
   enableFullTimeStudentQuestion = 'enableFullTimeStudentQuestion',
   enableGenderQuestion = 'enableGenderQuestion',
+  enableSexualOrientationQuestion = 'enableSexualOrientationQuestion',
   enableGeocodingPreferences = 'enableGeocodingPreferences',
   enableGeocodingRadiusMethod = 'enableGeocodingRadiusMethod',
   enableHomeType = 'enableHomeType',
@@ -184,6 +185,11 @@ export const featureFlagMap: {
     name: FeatureFlagEnum.enableGenderQuestion,
     description:
       'When true, the gender identity question is displayed in the public and partner application demographics section',
+  },
+  {
+    name: FeatureFlagEnum.enableSexualOrientationQuestion,
+    description:
+      'When true, the sexual orientation question is displayed in the public and partner application demographics section',
   },
   {
     name: FeatureFlagEnum.enableGeocodingPreferences,

--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -23,7 +23,6 @@ export enum FeatureFlagEnum {
   enableFilterByBathroom = 'enableFilterByBathroom',
   enableFullTimeStudentQuestion = 'enableFullTimeStudentQuestion',
   enableGenderQuestion = 'enableGenderQuestion',
-  enableSexualOrientationQuestion = 'enableSexualOrientationQuestion',
   enableGeocodingPreferences = 'enableGeocodingPreferences',
   enableGeocodingRadiusMethod = 'enableGeocodingRadiusMethod',
   enableHomeType = 'enableHomeType',
@@ -59,6 +58,7 @@ export enum FeatureFlagEnum {
   enableRegions = 'enableRegions',
   enableResources = 'enableResources',
   enableSection8Question = 'enableSection8Question',
+  enableSexualOrientationQuestion = 'enableSexualOrientationQuestion',
   enableSingleUseCode = 'enableSingleUseCode',
   enableSmokingPolicyRadio = 'enableSmokingPolicyRadio',
   enableSpokenLanguage = 'enableSpokenLanguage',
@@ -185,11 +185,6 @@ export const featureFlagMap: {
     name: FeatureFlagEnum.enableGenderQuestion,
     description:
       'When true, the gender identity question is displayed in the public and partner application demographics section',
-  },
-  {
-    name: FeatureFlagEnum.enableSexualOrientationQuestion,
-    description:
-      'When true, the sexual orientation question is displayed in the public and partner application demographics section',
   },
   {
     name: FeatureFlagEnum.enableGeocodingPreferences,
@@ -349,6 +344,11 @@ export const featureFlagMap: {
   {
     name: FeatureFlagEnum.enableSection8Question,
     description: 'When true, the Section 8 listing data will be visible',
+  },
+  {
+    name: FeatureFlagEnum.enableSexualOrientationQuestion,
+    description:
+      'When true, the sexual orientation question is displayed in the public and partner application demographics section',
   },
   {
     name: FeatureFlagEnum.enableSingleUseCode,

--- a/api/src/services/application-exporter.service.ts
+++ b/api/src/services/application-exporter.service.ts
@@ -229,6 +229,10 @@ export class ApplicationExporterService {
       jurisdiction as Jurisdiction,
       FeatureFlagEnum.enableGenderQuestion,
     );
+    const enableSexualOrientationQuestion = doJurisdictionHaveFeatureFlagSet(
+      jurisdiction as Jurisdiction,
+      FeatureFlagEnum.enableSexualOrientationQuestion,
+    );
     const enableV2MSQ = doJurisdictionHaveFeatureFlagSet(
       jurisdiction as Jurisdiction,
       FeatureFlagEnum.enableV2MSQ,
@@ -265,6 +269,7 @@ export class ApplicationExporterService {
         enableReasonableAccommodations,
         enableSpokenLanguage,
         enableGenderQuestion,
+        enableSexualOrientationQuestion,
         enableV2MSQ,
         enableReceivedAtAndByFields,
         includeDemographics: queryParams.includeDemographics,
@@ -517,6 +522,10 @@ export class ApplicationExporterService {
       jurisdiction as Jurisdiction,
       FeatureFlagEnum.enableGenderQuestion,
     );
+    const enableSexualOrientationQuestion = doJurisdictionHaveFeatureFlagSet(
+      jurisdiction as Jurisdiction,
+      FeatureFlagEnum.enableSexualOrientationQuestion,
+    );
     const enableV2MSQ = doJurisdictionHaveFeatureFlagSet(
       jurisdiction as Jurisdiction,
       FeatureFlagEnum.enableV2MSQ,
@@ -552,6 +561,7 @@ export class ApplicationExporterService {
         enableFullTimeStudentQuestion,
         enableReasonableAccommodations,
         enableGenderQuestion,
+        enableSexualOrientationQuestion,
         enableV2MSQ,
         enableReceivedAtAndByFields,
         forLottery,

--- a/api/src/utilities/application-export-helpers.ts
+++ b/api/src/utilities/application-export-helpers.ts
@@ -36,6 +36,7 @@ export const getExportHeaders = (
     enableReasonableAccommodations?: boolean;
     enableSpokenLanguage?: boolean;
     enableGenderQuestion?: boolean;
+    enableSexualOrientationQuestion?: boolean;
     enableV2MSQ?: boolean;
     enableReceivedAtAndByFields?: boolean;
     forLottery?: boolean;
@@ -52,6 +53,7 @@ export const getExportHeaders = (
     enableReasonableAccommodations,
     enableSpokenLanguage,
     enableGenderQuestion,
+    enableSexualOrientationQuestion,
     enableV2MSQ,
     enableReceivedAtAndByFields,
     forLottery,
@@ -493,6 +495,14 @@ export const getExportHeaders = (
         label: 'Gender',
         format: (val: string | undefined): string =>
           convertDemographicGenderToReadable(val),
+      });
+    }
+    if (enableSexualOrientationQuestion) {
+      headers.push({
+        path: 'demographics.sexualOrientation',
+        label: 'Sexual Orientation',
+        format: (val: string | undefined): string =>
+          convertDemographicSexualOrientationToReadable(val),
       });
     }
     headers.push(
@@ -951,6 +961,27 @@ export const convertDemographicGenderToReadable = (type: string): string => {
     female: 'Female',
     differentTerm: 'I use a different term',
     dontKnow: "I don't know or don't understand the question",
+    preferNoResponse: 'Prefer not to respond',
+  };
+  return typeMap[type] ?? type;
+};
+
+/**
+ *
+ * @param type takes in the demographic string
+ * @returns outputs the readable version of the string
+ */
+export const convertDemographicSexualOrientationToReadable = (
+  type: string,
+): string => {
+  const typeMap = {
+    asexual: 'Asexual',
+    bisexual: 'Bisexual',
+    gayLesbianSameGenderLoving: 'Gay / Lesbian / Same-Gender Loving',
+    questioningUnsure: 'Questioning / Unsure',
+    straightHeterosexual: 'Straight / Heterosexual',
+    differentTerm: 'I use a different term',
+    dontKnow: 'I don’t understand the question',
     preferNoResponse: 'Prefer not to respond',
   };
   return typeMap[type] ?? type;

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -83,6 +83,7 @@ The following are all of the feature flags currently available in the Bloom plat
 | [enableRegions](./feature-flags/enableRegions.md) | When true, the region can be defined for the building address |
 | [enableResources](./feature-flags/enableResources.md) | When true, the public site displays links to resources on various pages |
 | [enableSection8Question](./feature-flags/enableSection8Question.md) | When true, the Section 8 listing data will be visible |
+| [enableSexualOrientationQuestion](./feature-flags/enableSexualOrientationQuestion.md) | When true, the sexual orientation question is displayed in the public and partner application demographics section |
 | [enableSingleUseCode](./feature-flags/enableSingleUseCode.md) | When true, the backend allows for logging into this jurisdiction using the single use code flow |
 | [enableSmokingPolicyRadio](./feature-flags/enableSmokingPolicyRadio.md) | When true, the listing 'Smoking policy' field is a radio group |
 | [enableSpokenLanguage](./feature-flags/enableSpokenLanguage.md) | When true, the application demographics section displays a spoken language question with options configured on the jurisdiction |

--- a/docs/feature-flags/enableSexualOrientationQuestion.md
+++ b/docs/feature-flags/enableSexualOrientationQuestion.md
@@ -1,0 +1,13 @@
+# enableSexualOrientationQuestion
+
+## Name
+
+`enableSexualOrientationQuestion`
+
+## Description
+
+When true, the sexual orientation question is displayed in the public and partner application demographics section
+
+## Additional Information
+
+## Images

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -10736,6 +10736,7 @@ export enum FeatureFlagEnum {
   "enableFilterByBathroom" = "enableFilterByBathroom",
   "enableFullTimeStudentQuestion" = "enableFullTimeStudentQuestion",
   "enableGenderQuestion" = "enableGenderQuestion",
+  "enableSexualOrientationQuestion" = "enableSexualOrientationQuestion",
   "enableGeocodingPreferences" = "enableGeocodingPreferences",
   "enableGeocodingRadiusMethod" = "enableGeocodingRadiusMethod",
   "enableHomeType" = "enableHomeType",

--- a/shared-helpers/src/utilities/formKeys.ts
+++ b/shared-helpers/src/utilities/formKeys.ts
@@ -93,6 +93,17 @@ export const genderKeys = [
   "preferNoResponse",
 ]
 
+export const sexualOrientationKeys = [
+  "asexual",
+  "bisexual",
+  "gayLesbianSameGenderLoving",
+  "questioningUnsure",
+  "straightHeterosexual",
+  "differentTerm",
+  "dontKnow",
+  "preferNoResponse",
+]
+
 export const sexualOrientation = [
   "bisexual",
   "gayLesbianSameGenderLoving",

--- a/sites/partners/__tests__/components/applications/PaperApplicationForm/sections/FormDemographics.test.tsx
+++ b/sites/partners/__tests__/components/applications/PaperApplicationForm/sections/FormDemographics.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import userEvent from "@testing-library/user-event"
-import { genderKeys } from "@bloom-housing/shared-helpers"
+import { genderKeys, sexualOrientationKeys } from "@bloom-housing/shared-helpers"
 import { RaceEthnicityConfiguration } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { defaultRaceEthnicityConfiguration } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { t } from "@bloom-housing/ui-components"
@@ -271,6 +271,7 @@ describe("<FormDemographics>", () => {
     expect(screen.getByLabelText("Ethnicity")).toBeInTheDocument()
     expect(screen.getByText("Race", { selector: "legend" })).toBeInTheDocument()
   })
+
   it("should render race options with custom configuration", () => {
     render(
       <FormProviderWrapper>
@@ -501,6 +502,58 @@ describe("<FormDemographics>", () => {
     expect(
       screen.queryByRole("combobox", {
         name: t("application.add.gender"),
+      })
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows sexual orientation select when enableSexualOrientationQuestion is enabled", () => {
+    render(
+      <FormProviderWrapper>
+        <FormDemographics
+          formValues={{
+            id: "id",
+            race: [],
+            howDidYouHear: [],
+          }}
+          raceEthnicityConfiguration={defaultRaceEthnicityConfiguration}
+          enableLimitedHowDidYouHear={false}
+          disableEthnicityQuestion={false}
+          enableGenderQuestion={false}
+          enableSexualOrientationQuestion={true}
+        />
+      </FormProviderWrapper>
+    )
+
+    const select = screen.getByRole("combobox", {
+      name: t("application.add.sexualOrientation"),
+    })
+    expect(select).toBeInTheDocument()
+
+    const optionValues = Array.from(select.querySelectorAll("option")).map((option) => option.value)
+    expect(optionValues).toEqual(expect.arrayContaining(["", ...sexualOrientationKeys]))
+  })
+
+  it("", () => {
+    render(
+      <FormProviderWrapper>
+        <FormDemographics
+          formValues={{
+            id: "id",
+            race: [],
+            howDidYouHear: [],
+          }}
+          raceEthnicityConfiguration={defaultRaceEthnicityConfiguration}
+          enableLimitedHowDidYouHear={false}
+          disableEthnicityQuestion={false}
+          enableGenderQuestion={false}
+          enableSexualOrientationQuestion={false}
+        />
+      </FormProviderWrapper>
+    )
+
+    expect(
+      screen.queryByRole("combobox", {
+        name: t("application.add.sexualOrientation"),
       })
     ).not.toBeInTheDocument()
   })

--- a/sites/partners/__tests__/components/applications/PaperApplicationForm/sections/FormDemographics.test.tsx
+++ b/sites/partners/__tests__/components/applications/PaperApplicationForm/sections/FormDemographics.test.tsx
@@ -533,7 +533,7 @@ describe("<FormDemographics>", () => {
     expect(optionValues).toEqual(expect.arrayContaining(["", ...sexualOrientationKeys]))
   })
 
-  it("", () => {
+  it("hides sexual orientation select when enableSexualOrientationQuestion is disabled", () => {
     render(
       <FormProviderWrapper>
         <FormDemographics

--- a/sites/partners/page_content/locales/general.json
+++ b/sites/partners/page_content/locales/general.json
@@ -49,6 +49,7 @@
   "application.add.sameAddressAsPrimary": "Same address as primary",
   "application.add.sameResidence": "Same residence",
   "application.add.saveAndExit": "Save & exit",
+  "application.add.sexualOrientation": "Sexual orientation",
   "application.add.spokenLanguage": "Spoken language",
   "application.add.timeReceivedAt": "Time received at",
   "application.add.timeSubmitted": "Time submitted",

--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -96,6 +96,10 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
     FeatureFlagEnum.enableGenderQuestion,
     listingDto?.jurisdictions.id
   )
+  const enableSexualOrientationQuestion = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enableSexualOrientationQuestion,
+    listingDto?.jurisdictions.id
+  )
 
   const swapCommunityTypeWithPrograms = doJurisdictionsHaveFeatureFlagOn(
     FeatureFlagEnum.swapCommunityTypeWithPrograms,
@@ -409,6 +413,7 @@ const ApplicationForm = ({ listingId, editMode, application }: ApplicationFormPr
                       enableSpokenLanguage={enableSpokenLanguage}
                       visibleSpokenLanguages={jurisdictionData?.visibleSpokenLanguages}
                       enableGenderQuestion={enableGenderQuestion}
+                      enableSexualOrientationQuestion={enableSexualOrientationQuestion}
                     />
 
                     <FormTerms />

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
@@ -124,6 +124,7 @@ const FormDemographics = ({
           )}
           {(!disableEthnicityQuestion ||
             enableGenderQuestion ||
+            enableSexualOrientationQuestion ||
             (enableSpokenLanguage && visibleSpokenLanguages?.length > 0)) && (
             <Grid.Cell>
               {!disableEthnicityQuestion && (
@@ -152,20 +153,30 @@ const FormDemographics = ({
                 </div>
               )}
               {enableSexualOrientationQuestion && (
-                <Select
-                  id="application.demographics.sexualOrientation"
-                  name="application.demographics.sexualOrientation"
-                  label={t("application.add.sexualOrientation")}
-                  register={register}
-                  controlClassName="control"
-                  options={["", ...sexualOrientationKeys]}
-                  keyPrefix="application.review.demographics.sexualOrientationOptions"
-                />
+                <div
+                  className={
+                    !disableEthnicityQuestion || enableGenderQuestion ? "seeds-m-bs-4" : ""
+                  }
+                >
+                  <Select
+                    id="application.demographics.sexualOrientation"
+                    name="application.demographics.sexualOrientation"
+                    label={t("application.add.sexualOrientation")}
+                    register={register}
+                    controlClassName="control"
+                    options={["", ...sexualOrientationKeys]}
+                    keyPrefix="application.review.demographics.sexualOrientationOptions"
+                  />
+                </div>
               )}
               {enableSpokenLanguage && visibleSpokenLanguages?.length > 0 && (
                 <div
                   className={
-                    !disableEthnicityQuestion || enableGenderQuestion ? "seeds-m-bs-4" : ""
+                    !disableEthnicityQuestion ||
+                    enableGenderQuestion ||
+                    enableSexualOrientationQuestion
+                      ? "seeds-m-bs-4"
+                      : ""
                   }
                 >
                   <Select

--- a/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/sections/FormDemographics.tsx
@@ -10,6 +10,7 @@ import {
   howDidYouHear,
   limitedHowDidYouHear,
   getRaceEthnicityOptions,
+  sexualOrientationKeys,
 } from "@bloom-housing/shared-helpers"
 import {
   Demographic,
@@ -25,6 +26,7 @@ type FormDemographicsProps = {
   enableSpokenLanguage?: boolean
   visibleSpokenLanguages?: string[]
   enableGenderQuestion?: boolean
+  enableSexualOrientationQuestion?: boolean
 }
 
 const FormDemographics = ({
@@ -35,6 +37,7 @@ const FormDemographics = ({
   enableSpokenLanguage,
   visibleSpokenLanguages,
   enableGenderQuestion,
+  enableSexualOrientationQuestion,
 }: FormDemographicsProps) => {
   const formMethods = useFormContext()
 
@@ -147,6 +150,17 @@ const FormDemographics = ({
                     keyPrefix="application.review.demographics.genderOptions"
                   />
                 </div>
+              )}
+              {enableSexualOrientationQuestion && (
+                <Select
+                  id="application.demographics.sexualOrientation"
+                  name="application.demographics.sexualOrientation"
+                  label={t("application.add.sexualOrientation")}
+                  register={register}
+                  controlClassName="control"
+                  options={["", ...sexualOrientationKeys]}
+                  keyPrefix="application.review.demographics.sexualOrientationOptions"
+                />
               )}
               {enableSpokenLanguage && visibleSpokenLanguages?.length > 0 && (
                 <div

--- a/sites/public/src/pages/applications/review/demographics.tsx
+++ b/sites/public/src/pages/applications/review/demographics.tsx
@@ -57,7 +57,7 @@ const ApplicationDemographics = () => {
       demographics: {
         ethnicity: data.ethnicity || "",
         gender: enableGenderQuestion ? data.gender : "",
-        sexualOrientation: "",
+        sexualOrientation: enableSexualOrientationQuestion ? data.sexualOrientation : "",
         howDidYouHear: data.howDidYouHear,
         race: fieldGroupObjectToArray(data, "race"),
         spokenLanguage: enableSpokenLanguage

--- a/sites/public/src/pages/applications/review/demographics.tsx
+++ b/sites/public/src/pages/applications/review/demographics.tsx
@@ -20,6 +20,7 @@ import {
   limitedHowDidYouHear,
   getRaceEthnicityOptions,
   genderKeys,
+  sexualOrientationKeys,
 } from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { isFeatureFlagOn } from "../../../lib/helpers"
@@ -87,6 +88,11 @@ const ApplicationDemographics = () => {
   const enableGenderQuestion = isFeatureFlagOn(
     conductor.config,
     FeatureFlagEnum.enableGenderQuestion
+  )
+
+  const enableSexualOrientationQuestion = isFeatureFlagOn(
+    conductor.config,
+    FeatureFlagEnum.enableSexualOrientationQuestion
   )
 
   const getSpokenLanguageOptions = () => {
@@ -257,6 +263,32 @@ const ApplicationDemographics = () => {
                   options={genderKeys}
                   keyPrefix="application.review.demographics.genderOptions"
                   dataTestId={"app-demographics-gender"}
+                />
+              </div>
+            )}
+            {enableSexualOrientationQuestion && (
+              <div
+                className={
+                  showRaceQuestion ||
+                  showEthnicitySection ||
+                  showSpokenLanguageSection ||
+                  enableGenderQuestion
+                    ? "seeds-p-bs-8"
+                    : ""
+                }
+              >
+                <Select
+                  id="sexualOrientation"
+                  name="sexualOrientation"
+                  label={t("application.review.demographics.sexualOrientationLabel")}
+                  defaultValue={application.demographics.sexualOrientation}
+                  placeholder={t("t.selectOne")}
+                  register={register}
+                  labelClassName="text__caps-spaced mb-0"
+                  controlClassName="control"
+                  options={sexualOrientationKeys}
+                  keyPrefix="application.review.demographics.sexualOrientationOptions"
+                  dataTestId={"app-demographics-sexual-orientation"}
                 />
               </div>
             )}


### PR DESCRIPTION
This PR addresses #6219

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Adds a new `enableSexualOrientationQuestion` feature flag.
* Adds the new optional "Sexual Orientation" select component to the partners' application form demographics section.
* Adds the new optional "Sexual Orientation" select component to the public application
* Adds new necessary translation strings
* Adds the "Sexual Orientation" column to the applications CSV export
* Adds integration changes covering new component updates

## How Can This Be Tested/Reviewed?

1. Re-seed the database.
2. Using Prisma Studio, make sure the public configured jurisdiction has the `enableSexualOrientationQuestion` feature flag set to true.
3. Go to the public site `/listings` page
4. Select any open listing and press the "Apply Online" button.
5. Got through the application till the "Demographics" section - the new "Sexual Orientation" select component should be visible in the form.
6. Go to the partner's site and select a listing from the landing page table from a jurisdiction configured in step 2.
7. Go to the "Applications" tab and click the "Add Application" button.
8. Scroll down to the "Demographic information" section - the new "Sexual Orientation" select component should be visible in the form.
9. Go back to the "Applications" table view and click the "Export" button. The new "Sexual Orientation" should be visible in the generated CSV fille

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
