### PR TITLE
fix: set default form submit as post

### DIFF
--- a/shared-helpers/__tests__/Form.test.tsx
+++ b/shared-helpers/__tests__/Form.test.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+import { render, cleanup } from "@testing-library/react"
+import { Form } from "../src/views/forms/Form"
+
+afterEach(cleanup)
+
+describe("<Form>", () => {
+  it("renders with method post", () => {
+    const { container } = render(<Form>content</Form>)
+    expect(container.querySelector("form")).toHaveAttribute("method", "post")
+  })
+})

--- a/shared-helpers/__tests__/Form.test.tsx
+++ b/shared-helpers/__tests__/Form.test.tsx
@@ -5,8 +5,13 @@ import { Form } from "../src/views/forms/Form"
 afterEach(cleanup)
 
 describe("<Form>", () => {
-  it("renders with method post", () => {
+  it("defaults to method post", () => {
     const { container } = render(<Form>content</Form>)
     expect(container.querySelector("form")).toHaveAttribute("method", "post")
+  })
+
+  it("accepts method get", () => {
+    const { container } = render(<Form method="get">content</Form>)
+    expect(container.querySelector("form")).toHaveAttribute("method", "get")
   })
 })

--- a/shared-helpers/src/views/forgot-password/FormForgotPassword.tsx
+++ b/shared-helpers/src/views/forgot-password/FormForgotPassword.tsx
@@ -71,7 +71,11 @@ const FormForgotPassword = ({
         )}
 
         <CardSection>
-          <Form id="sign-in" onSubmit={handleSubmit(onSubmit, onError)}>
+          <Form
+            id="sign-in"
+            suppressSubmitOnEnter={false}
+            onSubmit={handleSubmit(onSubmit, onError)}
+          >
             <Field
               name="email"
               label={t("t.email")}

--- a/shared-helpers/src/views/forms/Form.tsx
+++ b/shared-helpers/src/views/forms/Form.tsx
@@ -23,7 +23,14 @@ export const Form = ({ children, id, className, suppressSubmitOnEnter, onSubmit 
 
   return (
     // eslint-disable-next-line  jsx-a11y/no-noninteractive-element-interactions
-    <form id={id} className={className} onSubmit={onSubmit} onKeyDown={onKeyDown} noValidate>
+    <form
+      id={id}
+      className={className}
+      onSubmit={onSubmit}
+      onKeyDown={onKeyDown}
+      noValidate
+      method="post"
+    >
       {children}
     </form>
   )

--- a/shared-helpers/src/views/forms/Form.tsx
+++ b/shared-helpers/src/views/forms/Form.tsx
@@ -4,11 +4,19 @@ export interface FormProps {
   children: React.ReactNode
   className?: string
   id?: string
+  method?: "get" | "post"
   onSubmit?: () => unknown
   suppressSubmitOnEnter?: boolean
 }
 
-export const Form = ({ children, id, className, suppressSubmitOnEnter, onSubmit }: FormProps) => {
+export const Form = ({
+  children,
+  id,
+  className,
+  method = "post",
+  suppressSubmitOnEnter = true,
+  onSubmit,
+}: FormProps) => {
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       if (
@@ -29,7 +37,7 @@ export const Form = ({ children, id, className, suppressSubmitOnEnter, onSubmit 
       onSubmit={onSubmit}
       onKeyDown={onKeyDown}
       noValidate
-      method="post"
+      method={method}
     >
       {children}
     </form>

--- a/shared-helpers/src/views/sign-in/FormSignInDefault.tsx
+++ b/shared-helpers/src/views/sign-in/FormSignInDefault.tsx
@@ -37,7 +37,7 @@ const FormSignInDefault = ({
   const forgetPasswordURL = getListingRedirectUrl(listingIdRedirect, "/forgot-password")
 
   return (
-    <Form id="sign-in" onSubmit={handleSubmit(onSubmit, onError)}>
+    <Form id="sign-in" suppressSubmitOnEnter={false} onSubmit={handleSubmit(onSubmit, onError)}>
       <Field
         className={styles["sign-in-email-input"]}
         name="email"

--- a/shared-helpers/src/views/sign-in/FormSignInPwdless.tsx
+++ b/shared-helpers/src/views/sign-in/FormSignInPwdless.tsx
@@ -41,7 +41,7 @@ const FormSignInPwdless = ({
   const forgetPasswordURL = getListingRedirectUrl(listingIdRedirect, "/forgot-password")
 
   return (
-    <Form id="sign-in" onSubmit={handleSubmit(onSubmit, onError)}>
+    <Form id="sign-in" suppressSubmitOnEnter={false} onSubmit={handleSubmit(onSubmit, onError)}>
       <Field
         className={styles["sign-in-email-input"]}
         name="email"

--- a/shared-helpers/src/views/sign-in/ResendConfirmationModal.tsx
+++ b/shared-helpers/src/views/sign-in/ResendConfirmationModal.tsx
@@ -1,4 +1,5 @@
-import { t, Form, Field } from "@bloom-housing/ui-components"
+import { t, Field } from "@bloom-housing/ui-components"
+import { Form } from "@bloom-housing/shared-helpers"
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
 import React, { useCallback, useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"

--- a/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
+++ b/sites/partners/src/components/applications/PaperApplicationForm/PaperApplicationForm.tsx
@@ -1,8 +1,13 @@
 import React, { useState, useContext, useEffect } from "react"
 import { useRouter } from "next/router"
-import { t, Form, AlertBox } from "@bloom-housing/ui-components"
+import { t, AlertBox } from "@bloom-housing/ui-components"
 import { Button, Dialog, LoadingState } from "@bloom-housing/ui-seeds"
-import { AuthContext, MessageContext, listingSectionQuestions } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  Form,
+  MessageContext,
+  listingSectionQuestions,
+} from "@bloom-housing/shared-helpers"
 import { useForm, FormProvider } from "react-hook-form"
 import {
   Application,

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useContext, useMemo } from "react"
-import { t, Field, Select, FieldGroup, Form, numberOptions } from "@bloom-housing/ui-components"
+import { t, Field, Select, FieldGroup, numberOptions } from "@bloom-housing/ui-components"
 import { Button, Card, Drawer, Grid, LoadingState } from "@bloom-housing/ui-seeds"
-import { AuthContext } from "@bloom-housing/shared-helpers"
+import { AuthContext, Form } from "@bloom-housing/shared-helpers"
 import { useWatch, useForm } from "react-hook-form"
 import { TempUnit } from "../../../lib/listings/formTypes"
 import {

--- a/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitGroupAmiForm.tsx
@@ -1,9 +1,9 @@
 import { Button, Card, Drawer, Grid } from "@bloom-housing/ui-seeds"
 import SectionWithGrid from "../../shared/SectionWithGrid"
-import { Field, FieldGroup, Form, Select, SelectOption, t } from "@bloom-housing/ui-components"
+import { Field, FieldGroup, Select, SelectOption, t } from "@bloom-housing/ui-components"
 import { useForm, useWatch } from "react-hook-form"
 import { useCallback, useContext, useEffect, useState } from "react"
-import { AuthContext } from "@bloom-housing/shared-helpers"
+import { AuthContext, Form } from "@bloom-housing/shared-helpers"
 import { fieldHasError } from "../../../lib/helpers"
 import {
   AmiChartItem,

--- a/sites/partners/src/components/listings/PaperListingForm/dialogs/RequestChangesDialog.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/dialogs/RequestChangesDialog.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { Form, t, Textarea } from "@bloom-housing/ui-components"
+import { t, Textarea } from "@bloom-housing/ui-components"
+import { Form } from "@bloom-housing/shared-helpers"
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
 import { useForm } from "react-hook-form"
 import { ListingsStatusEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -3,12 +3,13 @@ import { useRouter } from "next/router"
 import dayjs from "dayjs"
 import { CharacterCount as CharacterCountExtension } from "@tiptap/extension-character-count"
 import { useEditor } from "@tiptap/react"
-import { t, Form, AlertBox } from "@bloom-housing/ui-components"
+import { t, AlertBox } from "@bloom-housing/ui-components"
 import { Button, Icon, LoadingState, Tabs } from "@bloom-housing/ui-seeds"
 import ChevronLeftIcon from "@heroicons/react/20/solid/ChevronLeftIcon"
 import ChevronRightIcon from "@heroicons/react/20/solid/ChevronRightIcon"
 import {
   AuthContext,
+  Form,
   LatitudeLongitude,
   MessageContext,
   listingSectionQuestions,

--- a/sites/partners/src/components/listings/PaperListingForm/sections/AccessibilityFeatures.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/AccessibilityFeatures.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react"
 import { useFormContext } from "react-hook-form"
-import { t, FieldGroup, Form } from "@bloom-housing/ui-components"
+import { t, FieldGroup } from "@bloom-housing/ui-components"
+import { Form } from "@bloom-housing/shared-helpers"
 import { Button, Card, Drawer, Grid, Heading } from "@bloom-housing/ui-seeds"
 import { ListingFeaturesConfiguration } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { addAsterisk, fieldHasError, getLabel } from "../../../../lib/helpers"

--- a/sites/partners/src/components/users/FormTerms.tsx
+++ b/sites/partners/src/components/users/FormTerms.tsx
@@ -1,9 +1,9 @@
 import React from "react"
 import Markdown from "markdown-to-jsx"
 import { useForm } from "react-hook-form"
-import { Field, Form, MarkdownSection, t } from "@bloom-housing/ui-components"
+import { Field, MarkdownSection, t } from "@bloom-housing/ui-components"
 import { Button, Card, LoadingState } from "@bloom-housing/ui-seeds"
-import { BloomCard } from "@bloom-housing/shared-helpers"
+import { BloomCard, Form } from "@bloom-housing/shared-helpers"
 
 type FormTermsInValues = {
   agree: boolean

--- a/sites/partners/src/components/users/FormUserManage.tsx
+++ b/sites/partners/src/components/users/FormUserManage.tsx
@@ -1,11 +1,12 @@
 import React, { useMemo, useContext, useState, useCallback } from "react"
 import { FormProvider, useForm } from "react-hook-form"
-import { t, Form, Field, Select } from "@bloom-housing/ui-components"
+import { t, Field, Select } from "@bloom-housing/ui-components"
 import { Button, Card, Dialog, Drawer, Grid, Tag } from "@bloom-housing/ui-seeds"
 import {
-  RoleOption,
   AuthContext,
+  Form,
   MessageContext,
+  RoleOption,
   emailRegex,
   useMutate,
 } from "@bloom-housing/shared-helpers"

--- a/sites/public/src/components/account/ConfirmationModal.tsx
+++ b/sites/public/src/components/account/ConfirmationModal.tsx
@@ -1,9 +1,9 @@
 import { useContext, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
-import { t, Form, Field } from "@bloom-housing/ui-components"
+import { t, Field } from "@bloom-housing/ui-components"
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
-import { AuthContext, useToastyRef, emailRegex } from "@bloom-housing/shared-helpers"
+import { AuthContext, Form, emailRegex, useToastyRef } from "@bloom-housing/shared-helpers"
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ConfirmationModalProps {}
@@ -91,7 +91,11 @@ const ConfirmationModal = () => {
         {t("authentication.createAccount.linkExpired")}
       </Dialog.Header>
       <Dialog.Content>
-        <Form id="resend-confirmation" onSubmit={handleSubmit(onSubmit)}>
+        <Form
+          id="resend-confirmation"
+          suppressSubmitOnEnter={false}
+          onSubmit={handleSubmit(onSubmit)}
+        >
           <Field
             type="email"
             name="email"

--- a/sites/public/src/components/account/NotificationPreferences.tsx
+++ b/sites/public/src/components/account/NotificationPreferences.tsx
@@ -2,9 +2,9 @@ import { useContext, useEffect, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import PlusIcon from "@heroicons/react/24/solid/PlusIcon"
 import MinusIcon from "@heroicons/react/24/solid/MinusIcon"
-import { AuthContext, BloomCard, MessageContext } from "@bloom-housing/shared-helpers"
+import { AuthContext, BloomCard, Form, MessageContext } from "@bloom-housing/shared-helpers"
 import { Button, Card, Icon, LoadingState } from "@bloom-housing/ui-seeds"
-import { Field, FieldGroup, Form, t } from "@bloom-housing/ui-components"
+import { Field, FieldGroup, t } from "@bloom-housing/ui-components"
 import {
   Jurisdiction,
   UserNotificationPreferences,

--- a/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
+++ b/sites/public/src/components/applications/ApplicationMultiselectQuestionStep.tsx
@@ -1,25 +1,26 @@
 import React, { useContext, useEffect, useMemo, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
-import { Form, t } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
+  AddressHolder,
   AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
   getAllOptions,
   getCheckboxOption,
   getExclusiveKeys,
   getInputType,
   getPageQuestion,
   getRadioOption,
-  listingSectionQuestions,
-  mapApiToMultiselectFormV1,
-  mapApiToMultiselectForm,
-  mapCheckboxesToApiV1,
-  mapCheckboxesToApi,
-  OnClientSide,
-  PageView,
-  pushGtmEvent,
-  AddressHolder,
   getSelectionsForApplicationSection,
+  listingSectionQuestions,
+  mapApiToMultiselectForm,
+  mapApiToMultiselectFormV1,
+  mapCheckboxesToApi,
+  mapCheckboxesToApiV1,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import {
   ApplicationSelectionCreate,

--- a/sites/public/src/components/browse/FilterDrawer.tsx
+++ b/sites/public/src/components/browse/FilterDrawer.tsx
@@ -1,4 +1,5 @@
-import { Form, t } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
+import { Form } from "@bloom-housing/shared-helpers"
 import { Button, Drawer } from "@bloom-housing/ui-seeds"
 import { useForm } from "react-hook-form"
 import {
@@ -111,7 +112,7 @@ const FilterDrawer = (props: FilterDrawerProps) => {
       <Drawer.Header id="drawer-heading">{t("t.filter")}</Drawer.Header>
       <Drawer.Content id="drawer-content">
         <div role="document">
-          <Form onSubmit={handleSubmit(props.onSubmit)} id="filter">
+          <Form method="get" onSubmit={handleSubmit(props.onSubmit)} id="filter">
             {enableIsVerified && (
               <CheckboxGroup
                 groupLabel={t("listings.confirmedListings")}

--- a/sites/public/src/components/finder/RentalsFinder.tsx
+++ b/sites/public/src/components/finder/RentalsFinder.tsx
@@ -1,7 +1,7 @@
 import { FormProvider, useForm } from "react-hook-form"
 import { useRouter } from "next/router"
 import { useCallback, useMemo, useRef, useState } from "react"
-import { BloomCard, CustomIconMap } from "@bloom-housing/shared-helpers"
+import { BloomCard, CustomIconMap, Form } from "@bloom-housing/shared-helpers"
 import {
   FeatureFlagEnum,
   ListingFeaturesConfiguration,
@@ -9,7 +9,7 @@ import {
   MultiselectQuestion,
   RegionEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { Form, ProgressNav, StepHeader, t } from "@bloom-housing/ui-components"
+import { ProgressNav, StepHeader, t } from "@bloom-housing/ui-components"
 import { Button, Heading, Icon } from "@bloom-housing/ui-seeds"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import FinderDisclaimer from "./FinderDisclaimer"
@@ -297,7 +297,7 @@ export default function RentalsFinder({
           subtitle={activeQuestion.subtitle}
           headingPriority={2}
         >
-          <Form id="finderForm" onSubmit={handleSubmit(onSubmit)}>
+          <Form id="finderForm" method="get" onSubmit={handleSubmit(onSubmit)}>
             <CardSection className={styles["questions-section"]} divider="flush">
               <div className={styles["questions-wrapper"]}>
                 <FormProvider {...formMethods}>{activeQuestion.content}</FormProvider>

--- a/sites/public/src/pages/applications/contact/address.tsx
+++ b/sites/public/src/pages/applications/contact/address.tsx
@@ -1,18 +1,19 @@
 import React, { useContext, useEffect, useState, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { FormErrorMessage } from "@bloom-housing/ui-seeds"
-import { Field, FieldGroup, Form, PhoneField, Select, t } from "@bloom-housing/ui-components"
+import { Field, FieldGroup, PhoneField, Select, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
-  contactPreferencesKeys,
-  phoneNumberKeys,
-  stateKeys,
-  blankApplication,
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
+  blankApplication,
+  contactPreferencesKeys,
   mergeDeep,
+  phoneNumberKeys,
+  pushGtmEvent,
+  stateKeys,
 } from "@bloom-housing/shared-helpers"
 import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import FormsLayout from "../../../layouts/forms"

--- a/sites/public/src/pages/applications/contact/alternate-contact-contact.tsx
+++ b/sites/public/src/pages/applications/contact/alternate-contact-contact.tsx
@@ -1,14 +1,15 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { Field, Form, PhoneField, Select, t } from "@bloom-housing/ui-components"
+import { Field, PhoneField, Select, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
+  emailRegex,
   pushGtmEvent,
   stateKeys,
-  AuthContext,
-  emailRegex,
 } from "@bloom-housing/shared-helpers"
 import { useFormConductor } from "../../../lib/hooks"
 import { UserStatus } from "../../../lib/constants"

--- a/sites/public/src/pages/applications/contact/alternate-contact-name.tsx
+++ b/sites/public/src/pages/applications/contact/alternate-contact-name.tsx
@@ -1,8 +1,14 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { Form, Field, t } from "@bloom-housing/ui-components"
+import { Field, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import FormsLayout from "../../../layouts/forms"
 import { isFeatureFlagOn } from "../../../lib/helpers"

--- a/sites/public/src/pages/applications/contact/alternate-contact-type.tsx
+++ b/sites/public/src/pages/applications/contact/alternate-contact-type.tsx
@@ -2,12 +2,13 @@ import React, { Fragment, useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { FormErrorMessage } from "@bloom-housing/ui-seeds"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
-import { Field, Form, t } from "@bloom-housing/ui-components"
+import { Field, t } from "@bloom-housing/ui-components"
 import {
-  altContactRelationshipKeys,
   AuthContext,
+  Form,
   OnClientSide,
   PageView,
+  altContactRelationshipKeys,
   pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"

--- a/sites/public/src/pages/applications/contact/name.tsx
+++ b/sites/public/src/pages/applications/contact/name.tsx
@@ -1,13 +1,14 @@
 import React, { useContext, useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
-import { DOBField, Field, Form, t } from "@bloom-housing/ui-components"
+import { DOBField, Field, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
   emailRegex,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { useFormConductor } from "../../../lib/hooks"

--- a/sites/public/src/pages/applications/financial/income.tsx
+++ b/sites/public/src/pages/applications/financial/income.tsx
@@ -1,14 +1,15 @@
 import React, { useContext, useEffect, useState } from "react"
 import Link from "next/link"
 import { useForm } from "react-hook-form"
-import { AlertBox, AlertNotice, Field, FieldGroup, Form, t } from "@bloom-housing/ui-components"
+import { AlertBox, AlertNotice, Field, FieldGroup, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
   listingSectionQuestions,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import {
   FeatureFlagEnum,

--- a/sites/public/src/pages/applications/financial/vouchers.tsx
+++ b/sites/public/src/pages/applications/financial/vouchers.tsx
@@ -1,13 +1,14 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { Form, t, FieldGroup } from "@bloom-housing/ui-components"
+import { t, FieldGroup } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
   listingSectionQuestions,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import { MultiselectQuestionsApplicationSectionEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import FormsLayout from "../../../layouts/forms"

--- a/sites/public/src/pages/applications/household/ada.tsx
+++ b/sites/public/src/pages/applications/household/ada.tsx
@@ -1,13 +1,14 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { FormErrorMessage } from "@bloom-housing/ui-seeds"
-import { Form, t, FieldGroup, FieldSingle } from "@bloom-housing/ui-components"
+import { t, FieldGroup, FieldSingle } from "@bloom-housing/ui-components"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
   adaFeatureKeys,
-  AuthContext,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import FormsLayout from "../../../layouts/forms"

--- a/sites/public/src/pages/applications/household/add-members.tsx
+++ b/sites/public/src/pages/applications/household/add-members.tsx
@@ -2,8 +2,14 @@ import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { useRouter } from "next/router"
 import { Button } from "@bloom-housing/ui-seeds"
-import { t, Form } from "@bloom-housing/ui-components"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import FormsLayout from "../../../layouts/forms"
 import { HouseholdSizeField } from "../../../components/applications/HouseholdSizeField"

--- a/sites/public/src/pages/applications/household/changes.tsx
+++ b/sites/public/src/pages/applications/household/changes.tsx
@@ -1,8 +1,14 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { FieldGroup, Form, t } from "@bloom-housing/ui-components"
+import { FieldGroup, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { useFormConductor } from "../../../lib/hooks"
 import { UserStatus } from "../../../lib/constants"

--- a/sites/public/src/pages/applications/household/live-alone.tsx
+++ b/sites/public/src/pages/applications/household/live-alone.tsx
@@ -1,8 +1,14 @@
 import React, { ChangeEvent, useContext, useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
-import { FieldGroup, Form, t } from "@bloom-housing/ui-components"
+import { FieldGroup, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { HouseholdSizeField } from "../../../components/applications/HouseholdSizeField"
 import { useFormConductor } from "../../../lib/hooks"

--- a/sites/public/src/pages/applications/household/members-info.tsx
+++ b/sites/public/src/pages/applications/household/members-info.tsx
@@ -1,8 +1,14 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { useRouter } from "next/router"
-import { Form, t } from "@bloom-housing/ui-components"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { useFormConductor } from "../../../lib/hooks"
 import { UserStatus } from "../../../lib/constants"

--- a/sites/public/src/pages/applications/household/preferred-units.tsx
+++ b/sites/public/src/pages/applications/household/preferred-units.tsx
@@ -1,15 +1,16 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { FieldGroup, Form, t } from "@bloom-housing/ui-components"
+import { FieldGroup, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
-  createUnitTypeId,
-  getUniqueUnitTypes,
-  getUniqueUnitGroupUnitTypes,
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
+  createUnitTypeId,
+  getUniqueUnitGroupUnitTypes,
+  getUniqueUnitTypes,
   pushGtmEvent,
-  AuthContext,
 } from "@bloom-housing/shared-helpers"
 import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { isFeatureFlagOn } from "../../../lib/helpers"

--- a/sites/public/src/pages/applications/household/reasonable-accommodations.tsx
+++ b/sites/public/src/pages/applications/household/reasonable-accommodations.tsx
@@ -1,8 +1,14 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { Form, t, Textarea } from "@bloom-housing/ui-components"
+import { t, Textarea } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { useFormConductor } from "../../../lib/hooks"
 import { UserStatus } from "../../../lib/constants"

--- a/sites/public/src/pages/applications/household/student.tsx
+++ b/sites/public/src/pages/applications/household/student.tsx
@@ -1,9 +1,15 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { FieldGroup, Form, t } from "@bloom-housing/ui-components"
+import { FieldGroup, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import { FeatureFlagEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { useFormConductor } from "../../../lib/hooks"
 import { UserStatus } from "../../../lib/constants"

--- a/sites/public/src/pages/applications/preferences/general.tsx
+++ b/sites/public/src/pages/applications/preferences/general.tsx
@@ -1,12 +1,13 @@
 import React, { useContext, useEffect } from "react"
 import { useForm } from "react-hook-form"
-import { t, Form } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
   listingSectionQuestions,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { useFormConductor } from "../../../lib/hooks"

--- a/sites/public/src/pages/applications/review/demographics.tsx
+++ b/sites/public/src/pages/applications/review/demographics.tsx
@@ -1,25 +1,26 @@
 import React, { useContext, useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"
-import { Field, FieldGroup, Form, Select, t } from "@bloom-housing/ui-components"
+import { Field, FieldGroup, Select, t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
   FeatureFlagEnum,
   MultiselectQuestionsApplicationSectionEnum,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import {
-  ethnicityKeys,
-  isKeyIncluded,
-  getCustomValue,
-  howDidYouHear,
-  fieldGroupObjectToArray,
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
-  listingSectionQuestions,
-  limitedHowDidYouHear,
-  getRaceEthnicityOptions,
+  ethnicityKeys,
+  fieldGroupObjectToArray,
   genderKeys,
+  getCustomValue,
+  getRaceEthnicityOptions,
+  howDidYouHear,
+  isKeyIncluded,
+  limitedHowDidYouHear,
+  listingSectionQuestions,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"
 import { isFeatureFlagOn } from "../../../lib/helpers"

--- a/sites/public/src/pages/applications/review/summary.tsx
+++ b/sites/public/src/pages/applications/review/summary.tsx
@@ -2,15 +2,16 @@ import React, { useContext, useEffect, useState } from "react"
 import { useForm } from "react-hook-form"
 import { useRouter } from "next/router"
 import { Alert, Button } from "@bloom-housing/ui-seeds"
-import { Form, t } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
-  useToastyRef,
   listingSectionQuestions,
+  pushGtmEvent,
+  useToastyRef,
 } from "@bloom-housing/shared-helpers"
 import {
   ApplicationCreate,

--- a/sites/public/src/pages/applications/review/terms.tsx
+++ b/sites/public/src/pages/applications/review/terms.tsx
@@ -2,14 +2,15 @@ import React, { useContext, useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
 import Markdown from "markdown-to-jsx"
-import { t, FieldGroup, Form, AlertBox } from "@bloom-housing/ui-components"
+import { t, FieldGroup, AlertBox } from "@bloom-housing/ui-components"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import {
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
   listingSectionQuestions,
+  pushGtmEvent,
   useToastyRef,
 } from "@bloom-housing/shared-helpers"
 import FormsLayout from "../../../layouts/forms"

--- a/sites/public/src/pages/applications/start/autofill.tsx
+++ b/sites/public/src/pages/applications/start/autofill.tsx
@@ -1,14 +1,15 @@
 import React, { useContext, useState, useEffect, useCallback, useRef } from "react"
 import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
-import { Form, t } from "@bloom-housing/ui-components"
+import { t } from "@bloom-housing/ui-components"
 import {
-  blankApplication,
+  AuthContext,
+  Form,
   OnClientSide,
   PageView,
-  pushGtmEvent,
-  AuthContext,
+  blankApplication,
   getPreferredUnitTypes,
+  pushGtmEvent,
 } from "@bloom-housing/shared-helpers"
 import { Button, LoadingState } from "@bloom-housing/ui-seeds"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"

--- a/sites/public/src/pages/applications/start/community-disclaimer.tsx
+++ b/sites/public/src/pages/applications/start/community-disclaimer.tsx
@@ -1,5 +1,11 @@
-import { AuthContext, OnClientSide, PageView, pushGtmEvent } from "@bloom-housing/shared-helpers"
-import { Form, t } from "@bloom-housing/ui-components"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
 import React, { useContext, useEffect } from "react"
 
 import ApplicationFormLayout from "../../../layouts/application-form"

--- a/sites/public/src/pages/applications/start/what-to-expect.tsx
+++ b/sites/public/src/pages/applications/start/what-to-expect.tsx
@@ -3,8 +3,14 @@ import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
 import Markdown from "markdown-to-jsx"
 import { ReviewOrderTypeEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
-import { t, Form } from "@bloom-housing/ui-components"
-import { OnClientSide, PageView, pushGtmEvent, AuthContext } from "@bloom-housing/shared-helpers"
+import { t } from "@bloom-housing/ui-components"
+import {
+  AuthContext,
+  Form,
+  OnClientSide,
+  PageView,
+  pushGtmEvent,
+} from "@bloom-housing/shared-helpers"
 import { Button } from "@bloom-housing/ui-seeds"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
 import FormsLayout from "../../../layouts/forms"

--- a/sites/public/src/pages/complete-advocate-account.tsx
+++ b/sites/public/src/pages/complete-advocate-account.tsx
@@ -1,11 +1,11 @@
 import React, { useContext, useEffect, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import { useRouter } from "next/router"
-import { Form, t, AlertBox, Field } from "@bloom-housing/ui-components"
+import { t, AlertBox, Field } from "@bloom-housing/ui-components"
 import { Agency, User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { Button, LoadingState } from "@bloom-housing/ui-seeds"
 import { CardSection } from "@bloom-housing/ui-seeds/src/blocks/Card"
-import { BloomCard, AuthContext, emailRegex } from "@bloom-housing/shared-helpers"
+import { AuthContext, BloomCard, Form, emailRegex } from "@bloom-housing/shared-helpers"
 import { fetchAgencies, fetchJurisdictionByName } from "../lib/hooks"
 import FormsLayout from "../layouts/forms"
 import {
@@ -158,7 +158,11 @@ const CreateAdvocateAccount = ({ agencies }: CreateAdvocateAccountProps) => {
 
   const formContent = (
     <>
-      <Form id="complete-advocate-account" onSubmit={handleSubmit(onSubmit)}>
+      <Form
+        id="complete-advocate-account"
+        suppressSubmitOnEnter={false}
+        onSubmit={handleSubmit(onSubmit)}
+      >
         <LoadingState loading={submitLoading}>
           <CardSection
             divider={"inset"}
@@ -210,7 +214,11 @@ const CreateAdvocateAccount = ({ agencies }: CreateAdvocateAccountProps) => {
         <p className={`${accountCardStyles["card-content"]} seeds-m-be-6`}>
           {t("advocateAccount.linkExpiredMessage")}
         </p>
-        <Form id="resend-advocate-confirmation" onSubmit={resendHandleSubmit(onResend)}>
+        <Form
+          id="resend-advocate-confirmation"
+          suppressSubmitOnEnter={false}
+          onSubmit={resendHandleSubmit(onResend)}
+        >
           <Field
             name="resendEmail"
             type="email"

--- a/sites/public/src/pages/verify.tsx
+++ b/sites/public/src/pages/verify.tsx
@@ -8,15 +8,16 @@ import {
   DialogFooter,
   DialogHeader,
 } from "@bloom-housing/ui-seeds/src/overlays/Dialog"
-import { Field, Form, t } from "@bloom-housing/ui-components"
+import { Field, t } from "@bloom-housing/ui-components"
 import {
+  AuthContext,
+  BloomCard,
+  Form,
+  FormSignInErrorBox,
+  MessageContext,
   PageView,
   pushGtmEvent,
   useCatchNetworkError,
-  BloomCard,
-  AuthContext,
-  MessageContext,
-  FormSignInErrorBox,
 } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../lib/constants"
 import FormsLayout from "../layouts/forms"
@@ -117,7 +118,7 @@ const Verify = () => {
 
             {alertMessage && <Message className={styles["verify-message"]}>{alertMessage}</Message>}
 
-            <Form id="verify" onSubmit={handleSubmit(onSubmit)}>
+            <Form id="verify" suppressSubmitOnEnter={false} onSubmit={handleSubmit(onSubmit)}>
               <Field
                 name="code"
                 label={t("account.pwdless.code")}


### PR DESCRIPTION
Some form submissions if done before hydration are being submitted as `GET` instead of `POST` because we are not setting post on our internal Form component.

## Description

The `form` element has no method set and defaults to `GET` which results in all form values being added as URL parameters. `react-hook-forms` will call preventDefault before we run our custom submit handlers which use `POST`. With Next.js, the server renders the HTML first and then the JS bundles asynchronously load, and if you submit before that finishes, the browser handles it natively and would `GET` in this scenario.

On a very slow connection and submitting very quickly is when submitting before hydration is most likely.

We were using a mix of a shared-helpers Form and one from UIC. They both had the issue, but I migrated us to the shared-helpers one so that we could make the change in core.

## How Can This Be Tested/Reviewed?

On main to see this happen, you can bypass the form itself and see the behavior, you can run `document.getElementById('sign-in').submit()` directly in the browser console, to mimic bypassing React's event handling, to see the parameters added into the URL. That no longer happens on this branch.

For us, only filter/search experiences should be `GET`, so those are set explicitly and we otherwise default to `POST`.

Most of our forms should also suppress submit on Enter as they are longer and more involved. Only our account access flows like signing in or the forgot password flow are passing that flag, allowing the form to submit on Enter.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
