### PR TITLE
fix: exclude paper apps from public lottery emails

### DIFF
--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
+  ApplicationSubmissionTypeEnum,
   LanguagesEnum,
   ListingEventsTypeEnum,
   ListingsStatusEnum,
@@ -395,6 +396,9 @@ export class LotteryService {
         listingId,
         markedAsDuplicate: {
           not: true,
+        },
+        submissionType: {
+          not: ApplicationSubmissionTypeEnum.paper,
         },
       },
     });

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -1192,6 +1192,21 @@ describe('Lottery Controller Tests', () => {
           {
             preferences: [],
             status: ApplicationStatusEnum.submitted,
+            confirmationCode: 'ABC678',
+            submissionType: ApplicationSubmissionTypeEnum.paper,
+            language: LanguagesEnum.en,
+            userAccounts: {
+              create: {
+                email: 'partner@email.com',
+                firstName: 'first',
+                lastName: 'last',
+                passwordHash: 'abcd1234',
+              },
+            },
+          },
+          {
+            preferences: [],
+            status: ApplicationStatusEnum.submitted,
             confirmationCode: 'MNOP3456',
             submissionType: ApplicationSubmissionTypeEnum.electronical,
             language: null,
@@ -1260,10 +1275,10 @@ describe('Lottery Controller Tests', () => {
           name: listing.name,
           juris: expect.stringMatching(jurisdictionAId),
         },
-        expect.objectContaining({
+        {
           en: ['applicant@email.com', 'applicant3@email.com'],
           es: ['applicant2@email.com'],
-        }),
+        },
       );
     });
   });


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When a partner user submits applications via the partner site they receive an email for each one of those application after the lottery results are published to the public. This PR removes paper apps from being considered

## How Can This Be Tested/Reviewed?

1. Seed the data
2. Create a partner user using your email. Submit at least one application to a lottery listing on the partner site with that account
3. Create a public user using an email you have access to. Submit an application to the same listing
4. Login as admin to partner site, close the listing, run the lottery, and release to partners
5. Login as a partner user that has access to that listing and publish the lottery results to the public
6. Verify you only receive 1 lottery results email (the one from the public account)

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
