### PR TITLE
fix: redirect ensure internal link

### DIFF
--- a/sites/public/__tests__/components/account/ConfirmationModal.test.tsx
+++ b/sites/public/__tests__/components/account/ConfirmationModal.test.tsx
@@ -16,8 +16,8 @@ const renderConfirmationModal = (
   authContextOverrides: Record<string, unknown> = {},
   query: Record<string, unknown> = {}
 ) => {
-  mockNextRouter(query)
-  return render(
+  const { pushMock } = mockNextRouter(query)
+  const renderResult = render(
     <MessageContext.Provider value={TOAST_MESSAGE}>
       <AuthContext.Provider
         value={{
@@ -34,6 +34,7 @@ const renderConfirmationModal = (
       </AuthContext.Provider>
     </MessageContext.Provider>
   )
+  return { ...renderResult, pushMock }
 }
 
 beforeAll(() => {
@@ -118,6 +119,68 @@ describe("ConfirmationModal", () => {
       expect(pushMock).toHaveBeenCalledWith(
         expect.objectContaining({ pathname: "/account/dashboard" })
       )
+    })
+  })
+
+  describe("redirect URL validation with showMandatedAccounts", () => {
+    let originalShowMandatedAccounts: string
+
+    beforeEach(() => {
+      originalShowMandatedAccounts = process.env.showMandatedAccounts
+      process.env.showMandatedAccounts = "TRUE"
+      mockConfirmAccount.mockResolvedValue(undefined)
+    })
+
+    afterEach(() => {
+      process.env.showMandatedAccounts = originalShowMandatedAccounts
+    })
+
+    it("redirects to a valid internal redirectUrl", async () => {
+      const { pushMock } = renderConfirmationModal(
+        {},
+        { token: "abc123", redirectUrl: "/listings/abc", listingId: "abc" }
+      )
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith(
+          expect.objectContaining({ pathname: "/listings/abc" })
+        )
+      })
+    })
+
+    it("falls back to /account/dashboard for an external redirectUrl", async () => {
+      const { pushMock } = renderConfirmationModal(
+        {},
+        { token: "abc123", redirectUrl: "https://bad.com", listingId: "abc" }
+      )
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith(
+          expect.objectContaining({ pathname: "/account/dashboard" })
+        )
+      })
+    })
+
+    it("falls back to /account/dashboard for a protocol-relative redirectUrl", async () => {
+      const { pushMock } = renderConfirmationModal(
+        {},
+        { token: "abc123", redirectUrl: "//bad.com", listingId: "abc" }
+      )
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith(
+          expect.objectContaining({ pathname: "/account/dashboard" })
+        )
+      })
+    })
+
+    it("falls back to /account/dashboard for a javascript: redirectUrl", async () => {
+      const { pushMock } = renderConfirmationModal(
+        {},
+        { token: "abc123", redirectUrl: "javascript:alert(1)", listingId: "abc" }
+      )
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith(
+          expect.objectContaining({ pathname: "/account/dashboard" })
+        )
+      })
     })
   })
 

--- a/sites/public/__tests__/pages/reset-password.test.tsx
+++ b/sites/public/__tests__/pages/reset-password.test.tsx
@@ -199,4 +199,88 @@ describe("Public Reset Password Page", () => {
       expect(pushMock).toHaveBeenCalledWith("/account/applications")
     })
   })
+
+  describe("redirect URL validation with showMandatedAccounts", () => {
+    let originalShowMandatedAccounts: string
+
+    beforeEach(() => {
+      originalShowMandatedAccounts = process.env.showMandatedAccounts
+      process.env.showMandatedAccounts = "TRUE"
+      server.use(
+        rest.put("http://localhost/api/adapter/auth/update-password", (_req, res, ctx) => {
+          return res(ctx.json({ success: true }))
+        }),
+        rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+          return res(
+            ctx.json({ ...user, firstName: "John", listings: [], agreedToTermsOfService: true })
+          )
+        })
+      )
+    })
+
+    afterEach(() => {
+      process.env.showMandatedAccounts = originalShowMandatedAccounts
+    })
+
+    const submitForm = async () => {
+      await userEvent.type(screen.getByLabelText(/^password$/i, { selector: "input" }), "Password")
+      await userEvent.type(
+        screen.getByLabelText(/password confirmation/i, { selector: "input" }),
+        "Password"
+      )
+      await userEvent.click(screen.getByRole("button", { name: /change password/i }))
+    }
+
+    it("redirects to a valid internal redirectUrl", async () => {
+      const { pushMock } = mockNextRouter({
+        token: "ex4mpl3-tok3n",
+        redirectUrl: "/listings/abc",
+        listingId: "abc",
+      })
+      render(<ResetPassword />)
+      await submitForm()
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/listings/abc?listingId=abc")
+      })
+    })
+
+    it("falls back to /account/applications for an external redirectUrl", async () => {
+      const { pushMock } = mockNextRouter({
+        token: "ex4mpl3-tok3n",
+        redirectUrl: "https://bad.com",
+        listingId: "abc",
+      })
+      render(<ResetPassword />)
+      await submitForm()
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/account/applications")
+      })
+    })
+
+    it("falls back to /account/applications for a protocol-relative redirectUrl", async () => {
+      const { pushMock } = mockNextRouter({
+        token: "ex4mpl3-tok3n",
+        redirectUrl: "//bad.com",
+        listingId: "abc",
+      })
+      render(<ResetPassword />)
+      await submitForm()
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/account/applications")
+      })
+    })
+
+    it("falls back to /account/applications for a javascript: redirectUrl", async () => {
+      const { pushMock } = mockNextRouter({
+        token: "ex4mpl3-tok3n",
+        redirectUrl: "javascript:alert(1)",
+        listingId: "abc",
+      })
+      render(<ResetPassword />)
+      await submitForm()
+      await waitFor(() => {
+        expect(pushMock).toHaveBeenCalledWith("/account/applications")
+      })
+    })
+  })
 })

--- a/sites/public/__tests__/pages/reset-password.test.tsx
+++ b/sites/public/__tests__/pages/reset-password.test.tsx
@@ -11,7 +11,7 @@ const server = setupServer()
 
 beforeAll(() => {
   server.listen()
-  mockNextRouter({ token: "ex4mpl3-tok3n" })
+  mockNextRouter({ token: "test-reset-token" })
 })
 
 afterEach(() => server.resetHandlers())
@@ -165,7 +165,7 @@ describe("Public Reset Password Page", () => {
   })
 
   it("should navigate on success", async () => {
-    const { pushMock } = mockNextRouter({ token: "ex4mpl3-tok3n" })
+    const { pushMock } = mockNextRouter({ token: "test-reset-token" })
     server.use(
       rest.put("http://localhost/api/adapter/auth/update-password", (_req, res, ctx) => {
         return res(
@@ -233,7 +233,7 @@ describe("Public Reset Password Page", () => {
 
     it("redirects to a valid internal redirectUrl", async () => {
       const { pushMock } = mockNextRouter({
-        token: "ex4mpl3-tok3n",
+        token: "test-reset-token",
         redirectUrl: "/listings/abc",
         listingId: "abc",
       })
@@ -246,7 +246,7 @@ describe("Public Reset Password Page", () => {
 
     it("falls back to /account/applications for an external redirectUrl", async () => {
       const { pushMock } = mockNextRouter({
-        token: "ex4mpl3-tok3n",
+        token: "test-reset-token",
         redirectUrl: "https://bad.com",
         listingId: "abc",
       })
@@ -259,7 +259,7 @@ describe("Public Reset Password Page", () => {
 
     it("falls back to /account/applications for a protocol-relative redirectUrl", async () => {
       const { pushMock } = mockNextRouter({
-        token: "ex4mpl3-tok3n",
+        token: "test-reset-token",
         redirectUrl: "//bad.com",
         listingId: "abc",
       })
@@ -272,7 +272,7 @@ describe("Public Reset Password Page", () => {
 
     it("falls back to /account/applications for a javascript: redirectUrl", async () => {
       const { pushMock } = mockNextRouter({
-        token: "ex4mpl3-tok3n",
+        token: "test-reset-token",
         redirectUrl: "javascript:alert(1)",
         listingId: "abc",
       })

--- a/sites/public/src/components/account/ConfirmationModal.tsx
+++ b/sites/public/src/components/account/ConfirmationModal.tsx
@@ -3,7 +3,13 @@ import { useRouter } from "next/router"
 import { useForm } from "react-hook-form"
 import { t, Field } from "@bloom-housing/ui-components"
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
-import { AuthContext, Form, emailRegex, useToastyRef } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  Form,
+  emailRegex,
+  useToastyRef,
+  isInternalLink,
+} from "@bloom-housing/shared-helpers"
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ConfirmationModalProps {}
@@ -48,7 +54,7 @@ const ConfirmationModal = () => {
     const listingId = router.query?.listingId as string
 
     const routerRedirectUrl =
-      process.env.showMandatedAccounts && redirectUrl && listingId
+      process.env.showMandatedAccounts && redirectUrl && listingId && isInternalLink(redirectUrl)
         ? `${redirectUrl}`
         : "/account/dashboard"
     if (router?.query?.token && initialStateLoaded && !hasCalledConfirm.current) {

--- a/sites/public/src/pages/reset-password.tsx
+++ b/sites/public/src/pages/reset-password.tsx
@@ -11,6 +11,7 @@ import {
   BloomCard,
   Form,
   MessageContext,
+  isInternalLink,
 } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../lib/constants"
 import FormsLayout from "../layouts/forms"
@@ -49,7 +50,7 @@ const ResetPassword = () => {
       const listingId = router.query?.listingId as string
 
       const routerRedirectUrl =
-        process.env.showMandatedAccounts && redirectUrl && listingId
+        process.env.showMandatedAccounts && redirectUrl && listingId && isInternalLink(redirectUrl)
           ? `${redirectUrl}?listingId=${listingId}`
           : "/account/applications"
       addToast(t(`authentication.signIn.success`, { name: user.firstName }), { variant: "success" })


### PR DESCRIPTION
[Code scanning alert](https://github.com/bloom-housing/bloom/security/code-scanning/44)

## Description

If showMandatedAccounts is enabled and somehow a bad actor could get a victim to submit the reset-password form (using for example the actor's own valid reset token), router.push(routerRedirectUrl) will navigate to whatever URL redirectUrl specifies, which could right now be anything external. Next.js 15 should prevent XSS on router.push(), but we should validate it's an internal link out of an abundance of caution.

## How Can This Be Tested/Reviewed?

Enable showMandatedAccounts

Trigger a password reset to get a valid token
Visit /reset-password?token=<token>&redirectUrl=https://anything.com&listingId=<any-id> - after submitting, confirm it redirects to /account/applications instead of anything.com
With a legitimate internal redirectUrl like /listings/<id> - confirm it does redirect there after submit

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
