### PR TITLE
fix: clear temp files cron job crash

### DIFF
--- a/api/src/services/app.service.ts
+++ b/api/src/services/app.service.ts
@@ -48,7 +48,7 @@ export class AppService implements OnModuleInit {
     );
     try {
       const files = await fs.promises.readdir(join(process.cwd(), 'src/temp/'));
-      const filesToDelete = files.filter((f) => !f.includes('.git'));
+      const filesToDelete = files.filter((f) => f !== '.gitignore');
       await Promise.all(
         filesToDelete.map((f) =>
           fs.promises.rm(join(process.cwd(), 'src/temp/', f), {
@@ -60,6 +60,7 @@ export class AppService implements OnModuleInit {
         `listing csv clear job completed: ${filesToDelete.length} files were deleted`,
       );
     } catch (e) {
+      this.logger.error('listing csv clear job failed', e);
       throw new InternalServerErrorException(e);
     }
     return {

--- a/api/src/services/app.service.ts
+++ b/api/src/services/app.service.ts
@@ -46,35 +46,22 @@ export class AppService implements OnModuleInit {
     await this.cronJobService.markCronJobAsStarted(
       TEMP_FILE_CLEAR_CRON_JOB_NAME,
     );
-    let filesDeletedCount = 0;
-    await fs.readdir(join(process.cwd(), 'src/temp/'), (err, files) => {
-      if (err) {
-        throw new InternalServerErrorException(err);
-      }
-      Promise.all(
-        files.map((f) => {
-          if (!f.includes('.git')) {
-            filesDeletedCount++;
-            try {
-              fs.rm(
-                join(process.cwd(), 'src/temp/', f),
-                { recursive: true },
-                (err) => {
-                  if (err) {
-                    throw new InternalServerErrorException(err);
-                  }
-                },
-              );
-            } catch (e) {
-              throw new InternalServerErrorException(e);
-            }
-          }
-        }),
+    try {
+      const files = await fs.promises.readdir(join(process.cwd(), 'src/temp/'));
+      const filesToDelete = files.filter((f) => !f.includes('.git'));
+      await Promise.all(
+        filesToDelete.map((f) =>
+          fs.promises.rm(join(process.cwd(), 'src/temp/', f), {
+            recursive: true,
+          }),
+        ),
       );
       this.logger.warn(
-        `listing csv clear job completed: ${filesDeletedCount} files were deleted`,
+        `listing csv clear job completed: ${filesToDelete.length} files were deleted`,
       );
-    });
+    } catch (e) {
+      throw new InternalServerErrorException(e);
+    }
     return {
       success: true,
     };

--- a/api/test/unit/services/app.service.spec.ts
+++ b/api/test/unit/services/app.service.spec.ts
@@ -1,5 +1,7 @@
+import fs from 'fs';
+import { join } from 'path';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Logger } from '@nestjs/common';
+import { InternalServerErrorException, Logger } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { AppService } from '../../../src/services/app.service';
 import { PrismaService } from '../../../src/services/prisma.service';
@@ -8,6 +10,8 @@ import { CronJobService } from '../../../src/services/cron-job.service';
 describe('Testing app service', () => {
   let service: AppService;
   let prisma: PrismaService;
+  let cronJobService: CronJobService;
+
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -21,6 +25,7 @@ describe('Testing app service', () => {
 
     service = module.get<AppService>(AppService);
     prisma = module.get<PrismaService>(PrismaService);
+    cronJobService = module.get<CronJobService>(CronJobService);
   });
 
   it('should return a successDTO with success true', async () => {
@@ -29,5 +34,72 @@ describe('Testing app service', () => {
       success: true,
     });
     expect(prisma.$queryRaw).toHaveBeenCalled();
+  });
+
+  describe('clearTempFiles', () => {
+    beforeEach(() => {
+      cronJobService.markCronJobAsStarted = jest.fn().mockResolvedValue(null);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should delete non-.git files and return success', async () => {
+      jest
+        .spyOn(fs.promises, 'readdir')
+        .mockResolvedValue(['file1.csv', 'file2.zip', '.gitkeep'] as any);
+      const rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+
+      const result = await service.clearTempFiles();
+
+      expect(result).toEqual({ success: true });
+      expect(rmSpy).toHaveBeenCalledTimes(2);
+      expect(rmSpy).toHaveBeenCalledWith(
+        join(process.cwd(), 'src/temp/', 'file1.csv'),
+        { recursive: true },
+      );
+      expect(rmSpy).toHaveBeenCalledWith(
+        join(process.cwd(), 'src/temp/', 'file2.zip'),
+        { recursive: true },
+      );
+      expect(rmSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('.gitkeep'),
+        expect.anything(),
+      );
+    });
+
+    it('should skip deletion and return success when temp dir is empty', async () => {
+      jest.spyOn(fs.promises, 'readdir').mockResolvedValue([] as any);
+      const rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
+
+      const result = await service.clearTempFiles();
+
+      expect(result).toEqual({ success: true });
+      expect(rmSpy).not.toHaveBeenCalled();
+    });
+
+    it('should throw InternalServerErrorException when readdir fails', async () => {
+      jest
+        .spyOn(fs.promises, 'readdir')
+        .mockRejectedValue(new Error('ENOENT: no such file or directory'));
+
+      await expect(service.clearTempFiles()).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
+
+    it('should throw InternalServerErrorException when rm fails', async () => {
+      jest
+        .spyOn(fs.promises, 'readdir')
+        .mockResolvedValue(['file1.csv'] as any);
+      jest
+        .spyOn(fs.promises, 'rm')
+        .mockRejectedValue(new Error('EACCES: permission denied'));
+
+      await expect(service.clearTempFiles()).rejects.toThrow(
+        InternalServerErrorException,
+      );
+    });
   });
 });

--- a/api/test/unit/services/app.service.spec.ts
+++ b/api/test/unit/services/app.service.spec.ts
@@ -48,7 +48,7 @@ describe('Testing app service', () => {
     it('should delete non-.git files and return success', async () => {
       jest
         .spyOn(fs.promises, 'readdir')
-        .mockResolvedValue(['file1.csv', 'file2.zip', '.gitkeep'] as any);
+        .mockResolvedValue(['file1.csv', 'file2.zip', '.gitignore'] as any);
       const rmSpy = jest.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
 
       const result = await service.clearTempFiles();
@@ -64,7 +64,7 @@ describe('Testing app service', () => {
         { recursive: true },
       );
       expect(rmSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('.gitkeep'),
+        expect.stringContaining('.gitignore'),
         expect.anything(),
       );
     });


### PR DESCRIPTION
[Code scanning alert](https://github.com/bloom-housing/bloom/security/code-scanning/37)

## Description

This PR fixes an issue with the temp file cron job.

The previous implementation used fs.readdir and fs.rm with throw inside the callbacks. Because the await on fs.readdir resolves immediately (before the callback fires), any thrown exception escapes the async context as an unhandled rejection, which crashes the Node process. This affected both the scheduled cron job and the admin HTTP endpoint.

This rewrites the method using fs.promises.readdir and fs.promises.rm so all operations are properly awaited, with a single try/catch that surfaces errors as InternalServerErrorException without crashing the server.

## How Can This Be Tested/Reviewed?

Happy path: hit PUT /clearTempFiles as an admin while files exist in api/src/temp/. Verify the files are gone and the response is { success: true }.

Error path: the old code would crash the server - verify the new code doesn't. You can simulate a read error by temporarily renaming src/temp/ to something else before hitting the endpoint, then confirm the API returns a 500 and the server keeps running and handles subsequent requests normally.

Cron path: set TEMP_FILE_CLEAR_CRON_STRING to run every minute in a local env, let it fire, and confirm it completes without crashing.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
