### PR TITLE
fix: create notification preferences if they do not exist

### DIFF
--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -924,9 +924,6 @@ export class UserService {
         middleName: dto.middleName,
         lastName: dto.lastName,
         dob: dto.dob,
-        notificationPreferences: {
-          create: {},
-        },
         jurisdictions: jurisdictionsToConnect
           ? {
               connect: jurisdictionsToConnect.map((juris) => ({
@@ -1027,9 +1024,6 @@ export class UserService {
           create: {
             ...dto.userRoles,
           },
-        },
-        notificationPreferences: {
-          create: {},
         },
         jurisdictions: dto.jurisdictions
           ? {
@@ -1138,9 +1132,6 @@ export class UserService {
           },
         },
         isAdvocate: true,
-        notificationPreferences: {
-          create: {},
-        },
         jurisdictions: jurisdictionsToConnect
           ? {
               connect: jurisdictionsToConnect,
@@ -1755,9 +1746,7 @@ export class UserService {
       });
 
     if (!notificationPreferences) {
-      throw new NotFoundException(
-        'Failed to retrieve user notification preferences',
-      );
+      return mapTo(UserNotificationPreferences, { regions: [] });
     }
 
     return mapTo(UserNotificationPreferences, notificationPreferences);

--- a/api/src/services/user.service.ts
+++ b/api/src/services/user.service.ts
@@ -1776,8 +1776,12 @@ export class UserService {
       },
     );
 
-    await this.prisma.userNotificationPreferences.update({
-      data: {
+    await this.prisma.userNotificationPreferences.upsert({
+      create: {
+        ...dto,
+        userId: requestingUser.id,
+      },
+      update: {
         ...dto,
       },
       where: {

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -4306,7 +4306,7 @@ describe('Testing user service', () => {
 
   describe('updatePreferences', () => {
     it('should update requesting users notification preferences', async () => {
-      prisma.userNotificationPreferences.update = jest.fn();
+      prisma.userNotificationPreferences.upsert = jest.fn();
 
       const newPreferences: UserNotificationPreferences = {
         mobility: true,
@@ -4322,8 +4322,12 @@ describe('Testing user service', () => {
       );
 
       expect(res).toEqual({ success: true });
-      expect(prisma.userNotificationPreferences.update).toHaveBeenCalledWith({
-        data: {
+      expect(prisma.userNotificationPreferences.upsert).toHaveBeenCalledWith({
+        create: {
+          ...newPreferences,
+          userId: requestingUser.id,
+        },
+        update: {
           ...newPreferences,
         },
         where: {

--- a/api/test/unit/services/user.service.spec.ts
+++ b/api/test/unit/services/user.service.spec.ts
@@ -2644,9 +2644,6 @@ describe('Testing user service', () => {
           firstName: 'Partner User firstName',
           lastName: 'Partner User lastName',
           mfaEnabled: true,
-          notificationPreferences: {
-            create: {},
-          },
           jurisdictions: {
             connect: [{ id: jurisId }],
           },
@@ -2914,9 +2911,6 @@ describe('Testing user service', () => {
           lastName: 'public User lastName',
           listings: undefined,
           middleName: undefined,
-          notificationPreferences: {
-            create: {},
-          },
           jurisdictions: {
             connect: [{ id: expect.anything() }],
           },
@@ -3101,9 +3095,6 @@ describe('Testing user service', () => {
           listings: undefined,
           middleName: undefined,
           isAdvocate: true,
-          notificationPreferences: {
-            create: {},
-          },
           agency: {
             connect: {
               id: 'test_agency_id',

--- a/sites/public/src/components/account/NotificationPreferences.tsx
+++ b/sites/public/src/components/account/NotificationPreferences.tsx
@@ -94,7 +94,7 @@ export const NotificationPreferences = ({ jurisdiction }: NotificationPreference
       .then(() =>
         addToast(t("account.settings.notifications.updateSuccess"), { variant: "success" })
       )
-      .catch(() => addToast("account.settings.notifications.updateFail", { variant: "alert" }))
+      .catch(() => addToast(t("account.settings.notifications.updateFail"), { variant: "alert" }))
   }
 
   return (


### PR DESCRIPTION
## Description

Ensure we create notification preferences if they don't yet exist, and ensure the string is translated.

## How Can This Be Tested/Reviewed?

In deployed environments, with only existing users, you were able to add notification preferences because the default preferences did not yet exist and we were not creating them.

Additionally, the error toast needs to be wrapped in the translation string.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
