### PR TITLE
fix: notifications translations

### DIFF
--- a/api/prisma/migrations/61_restore_accessible_marketing_flyer_translation/migration.sql
+++ b/api/prisma/migrations/61_restore_accessible_marketing_flyer_translation/migration.sql
@@ -3,6 +3,7 @@
 -- "footer" and "accessibilityType", replacing those nested objects entirely
 -- rather than merging into them. This dropped accessibleMarketingFlyer from
 -- footer and all accessibilityType subtypes except hearingAndVision.
+-- Only targets global translations (jurisdiction_id IS NULL).
 
 -- Restore footer.accessibleMarketingFlyer
 
@@ -10,81 +11,81 @@ UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Accessible marketing flyer"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "Accessible marketing flyer"}'::jsonb
 )
-WHERE language = 'en';
+WHERE language = 'en' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Volante de marketing accesible"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "Volante de marketing accesible"}'::jsonb
 )
-WHERE language = 'es';
+WHERE language = 'es' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Tờ rơi tiếp thị có thể truy cập"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "Tờ rơi tiếp thị có thể truy cập"}'::jsonb
 )
-WHERE language = 'vi';
+WHERE language = 'vi' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "无障碍营销传单"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "无障碍营销传单"}'::jsonb
 )
-WHERE language = 'zh';
+WHERE language = 'zh' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Naa-access na flyer sa marketing"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "Naa-access na flyer sa marketing"}'::jsonb
 )
-WHERE language = 'tl';
+WHERE language = 'tl' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "অ্যাক্সেসযোগ্য মার্কেটিং ফ্লায়ার"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "অ্যাক্সেসযোগ্য মার্কেটিং ফ্লায়ার"}'::jsonb
 )
-WHERE language = 'bn';
+WHERE language = 'bn' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "نشرة تسويقية ميسّرة"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "نشرة تسويقية ميسّرة"}'::jsonb
 )
-WHERE language = 'ar';
+WHERE language = 'ar' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "접근 가능한 마케팅 전단지"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "접근 가능한 마케팅 전단지"}'::jsonb
 )
-WHERE language = 'ko';
+WHERE language = 'ko' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "بروشور بازاریابی قابل دسترس"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "بروشور بازاریابی قابل دسترس"}'::jsonb
 )
-WHERE language = 'fa';
+WHERE language = 'fa' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,footer}',
-  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Հասանելի մարքեթինգային թռուցիկ"}'::jsonb
+  COALESCE(translations->'rentalOpportunity'->'footer', '{}'::jsonb) || '{"accessibleMarketingFlyer": "Հասանելի մարքեթինգային թռուցիկ"}'::jsonb
 )
-WHERE language = 'hy';
+WHERE language = 'hy' AND jurisdiction_id IS NULL;
 
 -- Restore accessibilityType subtypes (hearing, mobility, vision,
 -- mobilityAndHearing, mobilityAndVision, mobilityHearingAndVision).
@@ -94,7 +95,7 @@ UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "Hearing",
     "mobility": "Mobility",
     "vision": "Vision",
@@ -103,13 +104,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "Mobility and Hearing/Vision"
   }'::jsonb
 )
-WHERE language = 'en';
+WHERE language = 'en' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "Auditiva",
     "mobility": "Movilidad",
     "vision": "Visual",
@@ -118,13 +119,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "Movilidad y auditiva/visual"
   }'::jsonb
 )
-WHERE language = 'es';
+WHERE language = 'es' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "Thính giác",
     "mobility": "Di chuyển",
     "vision": "Thị giác",
@@ -133,13 +134,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "Di chuyển và thính giác/thị giác"
   }'::jsonb
 )
-WHERE language = 'vi';
+WHERE language = 'vi' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "听力",
     "mobility": "行动",
     "vision": "视力",
@@ -148,13 +149,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "行动和听力/视力"
   }'::jsonb
 )
-WHERE language = 'zh';
+WHERE language = 'zh' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "Pandinig",
     "mobility": "Mobilidad",
     "vision": "Paningin",
@@ -163,13 +164,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "Mobilidad at pandinig/paningin"
   }'::jsonb
 )
-WHERE language = 'tl';
+WHERE language = 'tl' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "শ্রবণ",
     "mobility": "গতিশীলতা",
     "vision": "দৃষ্টি",
@@ -178,13 +179,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "গতিশীলতা এবং শ্রবণ/দৃষ্টি"
   }'::jsonb
 )
-WHERE language = 'bn';
+WHERE language = 'bn' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "السمع",
     "mobility": "الحركة",
     "vision": "البصر",
@@ -193,13 +194,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "الحركة والسمع/البصر"
   }'::jsonb
 )
-WHERE language = 'ar';
+WHERE language = 'ar' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "청각",
     "mobility": "이동성",
     "vision": "시각",
@@ -208,13 +209,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "이동성 및 청각/시각"
   }'::jsonb
 )
-WHERE language = 'ko';
+WHERE language = 'ko' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "شنوایی",
     "mobility": "تحرک",
     "vision": "بینایی",
@@ -223,13 +224,13 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "تحرک و شنوایی/بینایی"
   }'::jsonb
 )
-WHERE language = 'fa';
+WHERE language = 'fa' AND jurisdiction_id IS NULL;
 
 UPDATE translations
 SET translations = jsonb_set(
   translations,
   '{rentalOpportunity,accessibilityType}',
-  (translations->'rentalOpportunity'->'accessibilityType') || '{
+  COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) || '{
     "hearing": "Լսողություն",
     "mobility": "Շարժունակություն",
     "vision": "Տեսողություն",
@@ -238,5 +239,5 @@ SET translations = jsonb_set(
     "mobilityHearingAndVision": "Շարժունակություն և լսողություն/տեսողություն"
   }'::jsonb
 )
-WHERE language = 'hy';
+WHERE language = 'hy' AND jurisdiction_id IS NULL;
 

--- a/api/prisma/migrations/61_restore_accessible_marketing_flyer_translation/migration.sql
+++ b/api/prisma/migrations/61_restore_accessible_marketing_flyer_translation/migration.sql
@@ -1,0 +1,242 @@
+-- Restores keys dropped by migration 59's shallow JSONB merge.
+-- Migration 59 used || at the rentalOpportunity level with objects for both
+-- "footer" and "accessibilityType", replacing those nested objects entirely
+-- rather than merging into them. This dropped accessibleMarketingFlyer from
+-- footer and all accessibilityType subtypes except hearingAndVision.
+
+-- Restore footer.accessibleMarketingFlyer
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Accessible marketing flyer"}'::jsonb
+)
+WHERE language = 'en';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Volante de marketing accesible"}'::jsonb
+)
+WHERE language = 'es';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Tờ rơi tiếp thị có thể truy cập"}'::jsonb
+)
+WHERE language = 'vi';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "无障碍营销传单"}'::jsonb
+)
+WHERE language = 'zh';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Naa-access na flyer sa marketing"}'::jsonb
+)
+WHERE language = 'tl';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "অ্যাক্সেসযোগ্য মার্কেটিং ফ্লায়ার"}'::jsonb
+)
+WHERE language = 'bn';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "نشرة تسويقية ميسّرة"}'::jsonb
+)
+WHERE language = 'ar';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "접근 가능한 마케팅 전단지"}'::jsonb
+)
+WHERE language = 'ko';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "بروشور بازاریابی قابل دسترس"}'::jsonb
+)
+WHERE language = 'fa';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,footer}',
+  (translations->'rentalOpportunity'->'footer') || '{"accessibleMarketingFlyer": "Հասանելի մարքեթինգային թռուցիկ"}'::jsonb
+)
+WHERE language = 'hy';
+
+-- Restore accessibilityType subtypes (hearing, mobility, vision,
+-- mobilityAndHearing, mobilityAndVision, mobilityHearingAndVision).
+-- hearingAndVision is intentionally excluded -- migration 59 updated its value.
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "Hearing",
+    "mobility": "Mobility",
+    "vision": "Vision",
+    "mobilityAndHearing": "Mobility and Hearing",
+    "mobilityAndVision": "Mobility and Vision",
+    "mobilityHearingAndVision": "Mobility and Hearing/Vision"
+  }'::jsonb
+)
+WHERE language = 'en';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "Auditiva",
+    "mobility": "Movilidad",
+    "vision": "Visual",
+    "mobilityAndHearing": "Movilidad y auditiva",
+    "mobilityAndVision": "Movilidad y visual",
+    "mobilityHearingAndVision": "Movilidad y auditiva/visual"
+  }'::jsonb
+)
+WHERE language = 'es';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "Thính giác",
+    "mobility": "Di chuyển",
+    "vision": "Thị giác",
+    "mobilityAndHearing": "Di chuyển và thính giác",
+    "mobilityAndVision": "Di chuyển và thị giác",
+    "mobilityHearingAndVision": "Di chuyển và thính giác/thị giác"
+  }'::jsonb
+)
+WHERE language = 'vi';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "听力",
+    "mobility": "行动",
+    "vision": "视力",
+    "mobilityAndHearing": "行动和听力",
+    "mobilityAndVision": "行动和视力",
+    "mobilityHearingAndVision": "行动和听力/视力"
+  }'::jsonb
+)
+WHERE language = 'zh';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "Pandinig",
+    "mobility": "Mobilidad",
+    "vision": "Paningin",
+    "mobilityAndHearing": "Mobilidad at pandinig",
+    "mobilityAndVision": "Mobilidad at paningin",
+    "mobilityHearingAndVision": "Mobilidad at pandinig/paningin"
+  }'::jsonb
+)
+WHERE language = 'tl';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "শ্রবণ",
+    "mobility": "গতিশীলতা",
+    "vision": "দৃষ্টি",
+    "mobilityAndHearing": "গতিশীলতা ও শ্রবণ",
+    "mobilityAndVision": "গতিশীলতা ও দৃষ্টি",
+    "mobilityHearingAndVision": "গতিশীলতা এবং শ্রবণ/দৃষ্টি"
+  }'::jsonb
+)
+WHERE language = 'bn';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "السمع",
+    "mobility": "الحركة",
+    "vision": "البصر",
+    "mobilityAndHearing": "الحركة والسمع",
+    "mobilityAndVision": "الحركة والبصر",
+    "mobilityHearingAndVision": "الحركة والسمع/البصر"
+  }'::jsonb
+)
+WHERE language = 'ar';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "청각",
+    "mobility": "이동성",
+    "vision": "시각",
+    "mobilityAndHearing": "이동성 및 청각",
+    "mobilityAndVision": "이동성 및 시각",
+    "mobilityHearingAndVision": "이동성 및 청각/시각"
+  }'::jsonb
+)
+WHERE language = 'ko';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "شنوایی",
+    "mobility": "تحرک",
+    "vision": "بینایی",
+    "mobilityAndHearing": "تحرک و شنوایی",
+    "mobilityAndVision": "تحرک و بینایی",
+    "mobilityHearingAndVision": "تحرک و شنوایی/بینایی"
+  }'::jsonb
+)
+WHERE language = 'fa';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{rentalOpportunity,accessibilityType}',
+  (translations->'rentalOpportunity'->'accessibilityType') || '{
+    "hearing": "Լսողություն",
+    "mobility": "Շարժունակություն",
+    "vision": "Տեսողություն",
+    "mobilityAndHearing": "Շարժունակություն և լսողություն",
+    "mobilityAndVision": "Շարժունակություն և տեսողություն",
+    "mobilityHearingAndVision": "Շարժունակություն և լսողություն/տեսողություն"
+  }'::jsonb
+)
+WHERE language = 'hy';
+

--- a/api/scripts/generate-db-translation-sql.ts
+++ b/api/scripts/generate-db-translation-sql.ts
@@ -406,8 +406,13 @@ export const buildSql = (
 
     groupedByDepth2.forEach((group) => {
       const pathLiteral = `{${group.path.join(',')}}`;
+      const existingExpr = group.path.reduce(
+        (acc, key) => `${acc}->'${key}'`,
+        'translations',
+      );
       const valueLiteral = toJsonbLiteral(group.subtree);
-      updateExpression = `jsonb_set(${updateExpression}, '${pathLiteral}', ${valueLiteral}, true)`;
+      // Merge into the existing sub-object so unrelated sibling keys are preserved.
+      updateExpression = `jsonb_set(${updateExpression}, '${pathLiteral}', COALESCE(${existingExpr}, '{}'::jsonb) || ${valueLiteral}, true)`;
     });
 
     const insertPayloadLiteral = toJsonbLiteral(insertPayload);

--- a/api/test/unit/scripts/generate-db-translation-sql.spec.ts
+++ b/api/test/unit/scripts/generate-db-translation-sql.spec.ts
@@ -55,6 +55,32 @@ describe('generate-db-translation-sql helpers', () => {
     );
   });
 
+  it('merges into existing sub-object for depth-3 paths instead of replacing it', () => {
+    const sql = buildSql(
+      {
+        en: [
+          {
+            path: [
+              'rentalOpportunity',
+              'accessibilityType',
+              'hearingAndVision',
+            ],
+            value: 'Hearing/Vision',
+          },
+        ],
+      } as any,
+      ['en'],
+    );
+
+    // Should merge into the existing accessibilityType sub-object, not replace it
+    expect(sql).toContain(
+      "COALESCE(translations->'rentalOpportunity'->'accessibilityType', '{}'::jsonb) ||",
+    );
+    expect(sql).not.toContain(
+      "jsonb_set(COALESCE(translations, '{}'::jsonb), '{rentalOpportunity,accessibilityType}', '{\"hearingAndVision\"",
+    );
+  });
+
   it('builds non-destructive SQL with coalesced root and nested jsonb_set paths', () => {
     const sql = buildSql(
       {


### PR DESCRIPTION
## Description

<img width="276" height="88" alt="Screenshot 2026-06-11 at 5 47 28 PM" src="https://github.com/user-attachments/assets/01592337-2613-4653-8f11-ce9ba1bde179" />
<img width="401" height="268" alt="Screenshot 2026-06-11 at 5 47 24 PM" src="https://github.com/user-attachments/assets/205f2e05-447f-405e-8b2a-d706d00a91e9" />

Some notifications db translations are not appearing despite being added in previous migrations.

This PR restores translation keys dropped by migration 59's shallow JSONB merge.

Migration 59 (59_update_rental_opportunity_email_translations) updated rentalOpportunity.accessibilityType.hearingAndVision and introduced rentalOpportunity.footer.unsubscribeAndEmailSettings. It did this with a shallow || merge at the {rentalOpportunity} level, passing accessibilityType and footer as plain JSON objects. Because || is a shallow merge, it replaced those two nested objects entirely rather than patching individual keys, silently dropping:

* rentalOpportunity.footer.accessibleMarketingFlyer
* rentalOpportunity.accessibilityType.hearing, mobility, vision, mobilityAndHearing, mobilityAndVision, mobilityHearingAndVision

This migration restores both dropped key groups for all languages.

It also fixed the same latent bug in the script scripts/generate-db-translation-sql.ts. Note that Migration 59 was not generated by the script, so no previously-generated migrations are affected, but the bug seemed present there as well.

## How Can This Be Tested/Reviewed?

This is more difficult to testing locally because the translation factory after a seed will apply the values.

On main: reseed and verify the issue exist: these should be null:

SELECT language,
  translations->'rentalOpportunity'->'footer'->'accessibleMarketingFlyer' AS flyer,
  translations->'rentalOpportunity'->'accessibilityType'->'mobility' AS mobility
FROM translations
WHERE language NOT IN ('en', 'es') AND jurisdiction_id IS NULL
ORDER BY language;

Then switch to this branch and run migration 61
Re-run the same query - all rows should now be populated

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
