### PR TITLE
fix: call full view to get email from in email service

### DIFF
--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -25,6 +25,7 @@ import { Listing } from '../dtos/listings/listing.dto';
 import { IdDTO } from '../dtos/shared/id.dto';
 import { User } from '../dtos/users/user.dto';
 import { FeatureFlagEnum } from '../enums/feature-flags/feature-flags-enum';
+import { JurisdictionViews } from '../enums/jurisdictions/view-enum';
 import { doJurisdictionHaveFeatureFlagSet } from '../utilities/feature-flag-utilities';
 import { getPublicEmailURL } from '../utilities/get-public-email-url';
 import type { ApplicationStatusChangeItem } from '../utilities/applicationStatusChanges';
@@ -35,7 +36,6 @@ import {
 } from '../utilities/listing-data-formatters';
 import { unitTypeMapping } from '../../prisma/seed-helpers/unit-type-factory';
 import { UnitAccessibilityPriorityTypeEnum } from '../enums/units/accessibility-priority-type-enum';
-import { JurisdictionViews } from 'src/enums/jurisdictions/view-enum';
 dayjs.extend(utc);
 dayjs.extend(tz);
 dayjs.extend(advanced);

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -35,6 +35,7 @@ import {
 } from '../utilities/listing-data-formatters';
 import { unitTypeMapping } from '../../prisma/seed-helpers/unit-type-factory';
 import { UnitAccessibilityPriorityTypeEnum } from '../enums/units/accessibility-priority-type-enum';
+import { JurisdictionViews } from 'src/enums/jurisdictions/view-enum';
 dayjs.extend(utc);
 dayjs.extend(tz);
 dayjs.extend(advanced);
@@ -160,10 +161,12 @@ export class EmailService {
     if (jurisdictionIds?.length === 1) {
       return await this.jurisdictionService.findOne({
         jurisdictionId: jurisdictionIds[0]?.id,
+        view: JurisdictionViews.full,
       });
     } else if (jurisdictionName) {
       return await this.jurisdictionService.findOne({
         jurisdictionName: jurisdictionName,
+        view: JurisdictionViews.full,
       });
     }
     return null;
@@ -181,6 +184,7 @@ export class EmailService {
     if (jurisdictionIds.length > 1) {
       const firstJurisdiction = await this.jurisdictionService.findOne({
         jurisdictionId: jurisdictionIds[0].id,
+        view: JurisdictionViews.full,
       });
       return firstJurisdiction?.emailFromAddress || '';
     }

--- a/api/src/services/jurisdiction.service.ts
+++ b/api/src/services/jurisdiction.service.ts
@@ -117,7 +117,6 @@ export class JurisdictionService {
     jurisdictionName?: string;
     view?: JurisdictionViews;
   }): Promise<Jurisdiction> {
-    console.warn('here');
     if (!condition.jurisdictionId && !condition.jurisdictionName) {
       throw new BadRequestException(
         'a jurisdiction id or jurisdiction name must be provided',


### PR DESCRIPTION
This PR addresses [bug created with this PR](https://github.com/bloom-housing/bloom/pull/6323)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

With the refactor of jurisdiction views one place was missed and emails are no longer able to be sent. This is because the emailFromAddress is not returned in the default view. The PR changes the view to be the "full" view. 

A better long term solution would be to only select the specific fields that are needed. This can be done by either creating a new view specific to emails or calling the database directly from the email service.

## How Can This Be Tested/Reviewed?

Go through any flow that would trigger an email and it should be sent

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
