### PR TITLE
feat: add aws sms integration

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -26,12 +26,22 @@ MFA_CODE_VALID=60000
 AUTH_LOCK_LOGIN_COOLDOWN=1800000
 # how many failed login attempts before a lock occurs
 AUTH_LOCK_LOGIN_AFTER_FAILED_ATTEMPTS=5
+# sms provider to use, either 'twilio' or 'aws' (defaults to twilio)
+SMS_PROVIDER=
 # phone number for twilio account
 TWILIO_PHONE_NUMBER=
 # account sid for twilio
 TWILIO_ACCOUNT_SID=
 # account auth token for twilio
 TWILIO_AUTH_TOKEN=
+# aws region for end user messaging (required when SMS_PROVIDER=aws)
+AWS_SMS_REGION=
+# access key id for aws end user messaging (optional, falls back to IAM role)
+AWS_SMS_ACCESS_KEY_ID=
+# secret access key for aws end user messaging (optional, falls back to IAM role)
+AWS_SMS_SECRET_ACCESS_KEY=
+# origination number arn or phone pool arn for aws end user messaging
+AWS_SMS_ORIGINATION_NUMBER=
 # url for the partner front end
 PARTNERS_PORTAL_URL=http://localhost:3001
 # sendgrid email api key

--- a/api/package.json
+++ b/api/package.json
@@ -38,6 +38,7 @@
     "translations:sql": "ts-node scripts/generate-db-translation-sql.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-pinpoint-sms-voice-v2": "^3.1003.0",
     "@aws-sdk/client-s3": "^3.1003.0",
     "@aws-sdk/client-sesv2": "^3.1003.0",
     "@aws-sdk/lib-storage": "^3.1003.0",

--- a/api/src/services/sms.service.ts
+++ b/api/src/services/sms.service.ts
@@ -1,12 +1,35 @@
 import { Injectable } from '@nestjs/common';
+import { AwsCredentialIdentity } from '@aws-sdk/types';
+import {
+  PinpointSMSVoiceV2Client,
+  SendTextMessageCommand,
+} from '@aws-sdk/client-pinpoint-sms-voice-v2';
 import twilio from 'twilio';
 import TwilioClient from 'twilio/lib/rest/Twilio';
 
 @Injectable()
 export class SmsService {
   client: TwilioClient;
+  awsClient: PinpointSMSVoiceV2Client;
   public constructor() {
-    if (process.env.TWILIO_ACCOUNT_SID && process.env.TWILIO_AUTH_TOKEN) {
+    if (process.env.SMS_PROVIDER === 'aws') {
+      let credentials: undefined | AwsCredentialIdentity;
+      const keyId = process.env.AWS_SMS_ACCESS_KEY_ID;
+      const secret = process.env.AWS_SMS_SECRET_ACCESS_KEY;
+      if (keyId && secret) {
+        credentials = {
+          accessKeyId: keyId,
+          secretAccessKey: secret,
+        };
+      }
+      this.awsClient = new PinpointSMSVoiceV2Client({
+        region: process.env.AWS_SMS_REGION,
+        credentials,
+      });
+    } else if (
+      process.env.TWILIO_ACCOUNT_SID &&
+      process.env.TWILIO_AUTH_TOKEN
+    ) {
       this.client = twilio(
         process.env.TWILIO_ACCOUNT_SID,
         process.env.TWILIO_AUTH_TOKEN,
@@ -17,13 +40,27 @@ export class SmsService {
     phoneNumber: string,
     singleUseCode: string,
   ): Promise<void> {
-    if (!this.client) {
-      return;
+    if (process.env.SMS_PROVIDER === 'aws') {
+      if (!this.awsClient) {
+        return;
+      }
+      await this.awsClient.send(
+        new SendTextMessageCommand({
+          DestinationPhoneNumber: phoneNumber,
+          OriginationIdentity: process.env.AWS_SMS_ORIGINATION_NUMBER,
+          MessageBody: `Your Partners Portal account access token: ${singleUseCode}`,
+          MessageType: 'TRANSACTIONAL',
+        }),
+      );
+    } else {
+      if (!this.client) {
+        return;
+      }
+      await this.client.messages.create({
+        body: `Your Partners Portal account access token: ${singleUseCode}`,
+        from: process.env.TWILIO_PHONE_NUMBER,
+        to: phoneNumber,
+      });
     }
-    await this.client.messages.create({
-      body: `Your Partners Portal account access token: ${singleUseCode}`,
-      from: process.env.TWILIO_PHONE_NUMBER,
-      to: phoneNumber,
-    });
   }
 }

--- a/api/src/services/sms.service.ts
+++ b/api/src/services/sms.service.ts
@@ -13,7 +13,13 @@ export class SmsService {
   awsClient: PinpointSMSVoiceV2Client;
   public constructor() {
     if (process.env.SMS_PROVIDER === 'aws') {
-      if (process.env.AWS_SMS_REGION) {
+      if (!process.env.AWS_SMS_REGION) {
+        console.warn('SMS_PROVIDER is aws but AWS_SMS_REGION is not set.');
+      } else if (!process.env.AWS_SMS_ORIGINATION_NUMBER) {
+        console.warn(
+          'SMS_PROVIDER is aws but AWS_SMS_ORIGINATION_NUMBER is not set.',
+        );
+      } else {
         let credentials: undefined | AwsCredentialIdentity;
         const keyId = process.env.AWS_SMS_ACCESS_KEY_ID;
         const secret = process.env.AWS_SMS_SECRET_ACCESS_KEY;
@@ -44,6 +50,9 @@ export class SmsService {
   ): Promise<void> {
     if (process.env.SMS_PROVIDER === 'aws') {
       if (!this.awsClient) {
+        console.warn(
+          'AWS SMS client is not initialized, skipping MFA SMS send.',
+        );
         return;
       }
       await this.awsClient.send(
@@ -56,6 +65,9 @@ export class SmsService {
       );
     } else {
       if (!this.client) {
+        console.warn(
+          'Twilio SMS client is not initialized, skipping MFA SMS send.',
+        );
         return;
       }
       await this.client.messages.create({

--- a/api/src/services/sms.service.ts
+++ b/api/src/services/sms.service.ts
@@ -13,19 +13,21 @@ export class SmsService {
   awsClient: PinpointSMSVoiceV2Client;
   public constructor() {
     if (process.env.SMS_PROVIDER === 'aws') {
-      let credentials: undefined | AwsCredentialIdentity;
-      const keyId = process.env.AWS_SMS_ACCESS_KEY_ID;
-      const secret = process.env.AWS_SMS_SECRET_ACCESS_KEY;
-      if (keyId && secret) {
-        credentials = {
-          accessKeyId: keyId,
-          secretAccessKey: secret,
-        };
+      if (process.env.AWS_SMS_REGION) {
+        let credentials: undefined | AwsCredentialIdentity;
+        const keyId = process.env.AWS_SMS_ACCESS_KEY_ID;
+        const secret = process.env.AWS_SMS_SECRET_ACCESS_KEY;
+        if (keyId && secret) {
+          credentials = {
+            accessKeyId: keyId,
+            secretAccessKey: secret,
+          };
+        }
+        this.awsClient = new PinpointSMSVoiceV2Client({
+          region: process.env.AWS_SMS_REGION,
+          credentials,
+        });
       }
-      this.awsClient = new PinpointSMSVoiceV2Client({
-        region: process.env.AWS_SMS_REGION,
-        credentials,
-      });
     } else if (
       process.env.TWILIO_ACCOUNT_SID &&
       process.env.TWILIO_AUTH_TOKEN

--- a/api/test/unit/services/sms.service.spec.ts
+++ b/api/test/unit/services/sms.service.spec.ts
@@ -1,0 +1,93 @@
+import { SmsService } from '../../../src/services/sms.service';
+
+describe('Testing sms service', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('Twilio provider (default)', () => {
+    it('should initialize Twilio client when credentials are present', () => {
+      process.env.TWILIO_ACCOUNT_SID = 'AC123';
+      process.env.TWILIO_AUTH_TOKEN = 'auth-token';
+      const service = new SmsService();
+      expect(service.client).toBeDefined();
+      expect(service.awsClient).toBeUndefined();
+    });
+
+    it('should not initialize Twilio client when credentials are missing', () => {
+      delete process.env.TWILIO_ACCOUNT_SID;
+      delete process.env.TWILIO_AUTH_TOKEN;
+      const service = new SmsService();
+      expect(service.client).toBeUndefined();
+    });
+
+    it('should silently return when Twilio client is not initialized', async () => {
+      delete process.env.TWILIO_ACCOUNT_SID;
+      delete process.env.TWILIO_AUTH_TOKEN;
+      const service = new SmsService();
+      await expect(
+        service.sendMfaCode('+15555555555', '12345'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should send message via Twilio', async () => {
+      process.env.TWILIO_ACCOUNT_SID = 'AC123';
+      process.env.TWILIO_AUTH_TOKEN = 'auth-token';
+      process.env.TWILIO_PHONE_NUMBER = '+15550001111';
+      const service = new SmsService();
+      service.client = {
+        messages: { create: jest.fn().mockResolvedValue({}) },
+      } as any;
+      await service.sendMfaCode('+15555555555', '12345');
+      expect(service.client.messages.create).toHaveBeenCalledWith({
+        body: 'Your Partners Portal account access token: 12345',
+        from: '+15550001111',
+        to: '+15555555555',
+      });
+    });
+  });
+
+  describe('AWS End User Messaging provider', () => {
+    it('should initialize AWS client when SMS_PROVIDER is aws', () => {
+      process.env.SMS_PROVIDER = 'aws';
+      process.env.AWS_SMS_REGION = 'us-east-1';
+      const service = new SmsService();
+      expect(service.awsClient).toBeDefined();
+      expect(service.client).toBeUndefined();
+    });
+
+    it('should silently return when AWS client is not initialized', async () => {
+      process.env.SMS_PROVIDER = 'aws';
+      delete process.env.AWS_SMS_REGION;
+      const service = new SmsService();
+      await expect(
+        service.sendMfaCode('+15555555555', '12345'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should send message via AWS End User Messaging', async () => {
+      process.env.SMS_PROVIDER = 'aws';
+      process.env.AWS_SMS_REGION = 'us-east-1';
+      process.env.AWS_SMS_ORIGINATION_NUMBER =
+        'arn:aws:sms-voice:us-east-1:123456789012:phone-number/test';
+      const service = new SmsService();
+      const sendMock = jest.fn().mockResolvedValue({});
+      service.awsClient = { send: sendMock } as any;
+      await service.sendMfaCode('+15555555555', '12345');
+      const [command] = sendMock.mock.calls[0];
+      expect(command.input).toEqual({
+        DestinationPhoneNumber: '+15555555555',
+        OriginationIdentity:
+          'arn:aws:sms-voice:us-east-1:123456789012:phone-number/test',
+        MessageBody: 'Your Partners Portal account access token: 12345',
+        MessageType: 'TRANSACTIONAL',
+      });
+    });
+  });
+});

--- a/api/test/unit/services/sms.service.spec.ts
+++ b/api/test/unit/services/sms.service.spec.ts
@@ -57,25 +57,52 @@ describe('Testing sms service', () => {
     it('should initialize AWS client when SMS_PROVIDER is aws', () => {
       process.env.SMS_PROVIDER = 'aws';
       process.env.AWS_SMS_REGION = 'us-east-1';
+      process.env.AWS_SMS_ORIGINATION_NUMBER = '1234567890';
       const service = new SmsService();
       expect(service.awsClient).toBeDefined();
       expect(service.client).toBeUndefined();
     });
 
-    it('should silently return when AWS client is not initialized', async () => {
+    it('should not initialize AWS client when region is missing', () => {
       process.env.SMS_PROVIDER = 'aws';
       delete process.env.AWS_SMS_REGION;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+      const service = new SmsService();
+      expect(service.awsClient).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'SMS_PROVIDER is aws but AWS_SMS_REGION is not set.',
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should not initialize AWS client when origination number is missing', () => {
+      process.env.SMS_PROVIDER = 'aws';
+      process.env.AWS_SMS_REGION = 'us-east-1';
+      delete process.env.AWS_SMS_ORIGINATION_NUMBER;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+      const service = new SmsService();
+      expect(service.awsClient).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'SMS_PROVIDER is aws but AWS_SMS_ORIGINATION_NUMBER is not set.',
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should warn and return when AWS client is not initialized', async () => {
+      process.env.SMS_PROVIDER = 'aws';
+      delete process.env.AWS_SMS_REGION;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
       const service = new SmsService();
       await expect(
         service.sendMfaCode('+15555555555', '12345'),
       ).resolves.toBeUndefined();
+      warnSpy.mockRestore();
     });
 
     it('should send message via AWS End User Messaging', async () => {
       process.env.SMS_PROVIDER = 'aws';
       process.env.AWS_SMS_REGION = 'us-east-1';
-      process.env.AWS_SMS_ORIGINATION_NUMBER =
-        'arn:aws:sms-voice:us-east-1:123456789012:phone-number/test';
+      process.env.AWS_SMS_ORIGINATION_NUMBER = '1234567890';
       const service = new SmsService();
       const sendMock = jest.fn().mockResolvedValue({});
       service.awsClient = { send: sendMock } as any;
@@ -83,8 +110,7 @@ describe('Testing sms service', () => {
       const [command] = sendMock.mock.calls[0];
       expect(command.input).toEqual({
         DestinationPhoneNumber: '+15555555555',
-        OriginationIdentity:
-          'arn:aws:sms-voice:us-east-1:123456789012:phone-number/test',
+        OriginationIdentity: '1234567890',
         MessageBody: 'Your Partners Portal account access token: 12345',
         MessageType: 'TRANSACTIONAL',
       });

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -196,6 +196,22 @@
     "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
+"@aws-sdk/client-pinpoint-sms-voice-v2@^3.1003.0":
+  version "3.1070.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/client-pinpoint-sms-voice-v2/-/client-pinpoint-sms-voice-v2-3.1070.0.tgz#5e74234bf41888d2dd49fae7ba899bd106b34c48"
+  integrity sha512-KpshziWg5lkJl7f5D9LUROvMwlDUijRiDWBsLpLiaKxvDkqdLYmHstLb09YTc05wPp8D3CLgmhBdyglpqxTpew==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/credential-provider-node" "^3.972.56"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/client-s3@^3.1003.0":
   version "3.1003.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/client-s3/-/client-s3-3.1003.0.tgz#a55b67f954e5976d31f2e1f06b65dd4a1020a413"
@@ -322,6 +338,20 @@
     "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
+"@aws-sdk/core@^3.974.21":
+  version "3.974.21"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/core/-/core-3.974.21.tgz#bf173e6c3585dfc01e9ff6563ed12b6ad1bda330"
+  integrity sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==
+  dependencies:
+    "@aws-sdk/types" "^3.973.13"
+    "@aws-sdk/xml-builder" "^3.972.30"
+    "@aws/lambda-invoke-store" "^0.2.2"
+    "@smithy/core" "^3.24.6"
+    "@smithy/signature-v4" "^5.4.6"
+    "@smithy/types" "^4.14.3"
+    bowser "^2.11.0"
+    tslib "^2.6.2"
+
 "@aws-sdk/crc64-nvme@^3.972.4":
   version "3.972.4"
   resolved "https://registry.yarnpkg.com/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.4.tgz#b99494c76064231aa66f70a5b1095624e7984700"
@@ -352,6 +382,17 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-env@^3.972.47":
+  version "3.972.47"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.47.tgz#1a1fdb32eae2750d9ab49cd615bd51f285552f30"
+  integrity sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-http@^3.972.18":
   version "3.972.18"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.18.tgz#3cc2439f2f68f7488c27336464e8dff8b763df19"
@@ -366,6 +407,19 @@
     "@smithy/smithy-client" "^4.12.2"
     "@smithy/types" "^4.13.0"
     "@smithy/util-stream" "^4.5.17"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-http@^3.972.49":
+  version "3.972.49"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.49.tgz#af9beb1597e98b57382b7cc1bdb314e8bc84bad0"
+  integrity sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-ini@^3.972.16":
@@ -388,6 +442,25 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-ini@^3.972.54":
+  version "3.972.54"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.54.tgz#57281b580804cd9801bcd40a40b1b5c8f4ffacae"
+  integrity sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/credential-provider-env" "^3.972.47"
+    "@aws-sdk/credential-provider-http" "^3.972.49"
+    "@aws-sdk/credential-provider-login" "^3.972.53"
+    "@aws-sdk/credential-provider-process" "^3.972.47"
+    "@aws-sdk/credential-provider-sso" "^3.972.53"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.53"
+    "@aws-sdk/nested-clients" "^3.997.21"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/credential-provider-imds" "^4.3.7"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-login@^3.972.16":
   version "3.972.16"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.16.tgz#5d63340188e6a91a4c53e6a823b400d078e6e864"
@@ -400,6 +473,18 @@
     "@smithy/protocol-http" "^5.3.11"
     "@smithy/shared-ini-file-loader" "^4.4.6"
     "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-login@^3.972.53":
+  version "3.972.53"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.53.tgz#cd61cb6e4656553f1728cb45caf60c7bc04d25f0"
+  integrity sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/nested-clients" "^3.997.21"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-node@^3.972.17":
@@ -420,6 +505,23 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-node@^3.972.56":
+  version "3.972.56"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.56.tgz#8d040683a7c8bfb6d97fc5d2d133532ae503cf42"
+  integrity sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==
+  dependencies:
+    "@aws-sdk/credential-provider-env" "^3.972.47"
+    "@aws-sdk/credential-provider-http" "^3.972.49"
+    "@aws-sdk/credential-provider-ini" "^3.972.54"
+    "@aws-sdk/credential-provider-process" "^3.972.47"
+    "@aws-sdk/credential-provider-sso" "^3.972.53"
+    "@aws-sdk/credential-provider-web-identity" "^3.972.53"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/credential-provider-imds" "^4.3.7"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-process@^3.972.16":
   version "3.972.16"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.16.tgz#2fa86e773d553b184ad022a369b2d3d950f49069"
@@ -430,6 +532,17 @@
     "@smithy/property-provider" "^4.2.11"
     "@smithy/shared-ini-file-loader" "^4.4.6"
     "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-process@^3.972.47":
+  version "3.972.47"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.47.tgz#bfc176edb72910264f39d6ebf2b16bdc91dbbd5f"
+  integrity sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-provider-sso@^3.972.16":
@@ -446,6 +559,19 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/credential-provider-sso@^3.972.53":
+  version "3.972.53"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.53.tgz#018bf9178299b749871d74b657bf1488af3d3bab"
+  integrity sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/nested-clients" "^3.997.21"
+    "@aws-sdk/token-providers" "3.1069.0"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/credential-provider-web-identity@^3.972.16":
   version "3.972.16"
   resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.16.tgz#db50e6fca024ff37347d39702cf6dc0562cb93b5"
@@ -457,6 +583,18 @@
     "@smithy/property-provider" "^4.2.11"
     "@smithy/shared-ini-file-loader" "^4.4.6"
     "@smithy/types" "^4.13.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/credential-provider-web-identity@^3.972.53":
+  version "3.972.53"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.53.tgz#830f7a598610f47c8424f9452f8d04d28ca1a066"
+  integrity sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/nested-clients" "^3.997.21"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
     tslib "^2.6.2"
 
 "@aws-sdk/credential-providers@3.1003.0":
@@ -666,6 +804,22 @@
     "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
+"@aws-sdk/nested-clients@^3.997.21":
+  version "3.997.21"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/nested-clients/-/nested-clients-3.997.21.tgz#1b21a56409f22af63c8a4e731fbc1a51b6360b2b"
+  integrity sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==
+  dependencies:
+    "@aws-crypto/sha256-browser" "5.2.0"
+    "@aws-crypto/sha256-js" "5.2.0"
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/signature-v4-multi-region" "^3.996.35"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/fetch-http-handler" "^5.4.6"
+    "@smithy/node-http-handler" "^4.7.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/rds-signer@^3.1003.0":
   version "3.1003.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/rds-signer/-/rds-signer-3.1003.0.tgz#a059c4d12fd2e4d3196b80e125945e8f146b2d56"
@@ -709,6 +863,16 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/signature-v4-multi-region@^3.996.35":
+  version "3.996.35"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz#2994b9f33e84b9c74392b7495f89e5c958bda503"
+  integrity sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==
+  dependencies:
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/signature-v4" "^5.4.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/signature-v4-multi-region@^3.996.6":
   version "3.996.6"
   resolved "https://registry.yarnpkg.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.6.tgz#b818d724fa411f2c5bf4ad960ed13da9e6556fdf"
@@ -734,12 +898,32 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@aws-sdk/token-providers@3.1069.0":
+  version "3.1069.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/token-providers/-/token-providers-3.1069.0.tgz#0cc290f99ca683d7e0cb711ce4904ae70bdcd17f"
+  integrity sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==
+  dependencies:
+    "@aws-sdk/core" "^3.974.21"
+    "@aws-sdk/nested-clients" "^3.997.21"
+    "@aws-sdk/types" "^3.973.13"
+    "@smithy/core" "^3.24.6"
+    "@smithy/types" "^4.14.3"
+    tslib "^2.6.2"
+
 "@aws-sdk/types@^3.222.0":
   version "3.734.0"
   resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.734.0.tgz#af5e620b0e761918282aa1c8e53cac6091d169a2"
   integrity sha512-o11tSPTT70nAkGV1fN9wm/hAIiLPyWX6SuGf+9JyTp7S/rC2cFWhR26MvA69nplcjNaXVzB0f+QFrLXXjOqCrg==
   dependencies:
     "@smithy/types" "^4.1.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.973.13":
+  version "3.973.13"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.973.13.tgz#c076f611e94394a49c1bc1aeb64371ef6db4b3da"
+  integrity sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==
+  dependencies:
+    "@smithy/types" "^4.14.3"
     tslib "^2.6.2"
 
 "@aws-sdk/types@^3.973.5":
@@ -813,6 +997,15 @@
   dependencies:
     "@smithy/types" "^4.13.0"
     fast-xml-parser "5.4.1"
+    tslib "^2.6.2"
+
+"@aws-sdk/xml-builder@^3.972.30":
+  version "3.972.30"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.30.tgz#a52f9d8a69b1ceedb21012dd7830f098aa11102c"
+  integrity sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==
+  dependencies:
+    "@smithy/types" "^4.14.3"
+    fast-xml-parser "5.7.3"
     tslib "^2.6.2"
 
 "@aws/lambda-invoke-store@^0.2.2":
@@ -1855,6 +2048,11 @@
   resolved "https://registry.yarnpkg.com/@nestjs/throttler/-/throttler-5.1.2.tgz#dc65634153c8b887329b1cc6061db2e556517dcb"
   integrity sha512-60MqhSLYUqWOgc38P6C6f76JIpf6mVjly7gpuPBCKtVd0p5e8Fq855j7bJuO4/v25vgaOo1OdVs0U1qtgYioGw==
 
+"@nodable/entities@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.2.0.tgz#a1d45a992b022591b1c2b03a77935c939375b642"
+  integrity sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2394,6 +2592,15 @@
     "@smithy/uuid" "^1.1.2"
     tslib "^2.6.2"
 
+"@smithy/core@^3.24.6", "@smithy/core@^3.25.0":
+  version "3.25.0"
+  resolved "https://registry.yarnpkg.com/@smithy/core/-/core-3.25.0.tgz#7247961c444311bdb19125a4802f876e16344b34"
+  integrity sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==
+  dependencies:
+    "@aws-crypto/crc32" "5.2.0"
+    "@smithy/types" "^4.15.0"
+    tslib "^2.6.2"
+
 "@smithy/credential-provider-imds@^4.2.11":
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz#106dda92b2a4275879e84f348826c311a1bb1b05"
@@ -2403,6 +2610,15 @@
     "@smithy/property-provider" "^4.2.11"
     "@smithy/types" "^4.13.0"
     "@smithy/url-parser" "^4.2.11"
+    tslib "^2.6.2"
+
+"@smithy/credential-provider-imds@^4.3.7":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.0.tgz#f9fa2ae1a9ddf936c1cc9deaf99f054f2fcce5db"
+  integrity sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A==
+  dependencies:
+    "@smithy/core" "^3.25.0"
+    "@smithy/types" "^4.15.0"
     tslib "^2.6.2"
 
 "@smithy/eventstream-codec@^4.2.11":
@@ -2459,6 +2675,15 @@
     "@smithy/querystring-builder" "^4.2.11"
     "@smithy/types" "^4.13.0"
     "@smithy/util-base64" "^4.3.2"
+    tslib "^2.6.2"
+
+"@smithy/fetch-http-handler@^5.4.6":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.0.tgz#15ac7cdabffaf919eae1a499b45628ef982556ff"
+  integrity sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA==
+  dependencies:
+    "@smithy/core" "^3.25.0"
+    "@smithy/types" "^4.15.0"
     tslib "^2.6.2"
 
 "@smithy/hash-blob-browser@^4.2.12":
@@ -2597,6 +2822,15 @@
     "@smithy/types" "^4.13.0"
     tslib "^2.6.2"
 
+"@smithy/node-http-handler@^4.7.6":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@smithy/node-http-handler/-/node-http-handler-4.8.0.tgz#515f710b17f6086f0e1eccc85fbd5c4014dac16d"
+  integrity sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==
+  dependencies:
+    "@smithy/core" "^3.25.0"
+    "@smithy/types" "^4.15.0"
+    tslib "^2.6.2"
+
 "@smithy/property-provider@^4.2.11":
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/@smithy/property-provider/-/property-provider-4.2.11.tgz#7a1b16ae2083272f80e380ee7948ddc103301db1"
@@ -2659,6 +2893,15 @@
     "@smithy/util-utf8" "^4.2.2"
     tslib "^2.6.2"
 
+"@smithy/signature-v4@^5.4.6":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@smithy/signature-v4/-/signature-v4-5.5.0.tgz#12879a3a8b37a952fa1f2ba87a273830931ef99c"
+  integrity sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg==
+  dependencies:
+    "@smithy/core" "^3.25.0"
+    "@smithy/types" "^4.15.0"
+    tslib "^2.6.2"
+
 "@smithy/smithy-client@^4.12.2":
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/@smithy/smithy-client/-/smithy-client-4.12.2.tgz#feaf2ddd9e568da4abaf6a2663995770d241f5b3"
@@ -2683,6 +2926,13 @@
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.13.0.tgz#9787297a07ee72ef74d4f7d93c744d10ed664c21"
   integrity sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/types@^4.14.3", "@smithy/types@^4.15.0":
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.15.0.tgz#0346065c3e810755428df89c9a84427969931357"
+  integrity sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==
   dependencies:
     tslib "^2.6.2"
 
@@ -3658,6 +3908,11 @@ anymatch@^3.0.3, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+anynum@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/anynum/-/anynum-1.0.0.tgz#afe3f3a78c6621fbdf1e107154fac01eef711cc5"
+  integrity sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==
 
 append-field@^1.0.0:
   version "1.0.0"
@@ -5349,7 +5604,7 @@ fast-uri@^3.0.1:
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
-fast-xml-builder@^1.0.0:
+fast-xml-builder@^1.0.0, fast-xml-builder@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
   integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
@@ -5364,6 +5619,16 @@ fast-xml-parser@5.4.1:
   dependencies:
     fast-xml-builder "^1.0.0"
     strnum "^2.1.2"
+
+fast-xml-parser@5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz#309b04b08d835defc62ab657a0bb340c0e0fbe6a"
+  integrity sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==
+  dependencies:
+    "@nodable/entities" "^2.1.0"
+    fast-xml-builder "^1.1.7"
+    path-expression-matcher "^1.5.0"
+    strnum "^2.2.3"
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -8613,6 +8878,13 @@ strnum@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.2.0.tgz#8b582b637e4621f62ff714493e0ce30846f903a6"
   integrity sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==
+
+strnum@^2.2.3:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-2.4.0.tgz#304881c3299b017855f1934a4ce85bfb60b1ca2a"
+  integrity sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==
+  dependencies:
+    anynum "^1.0.0"
 
 structured-log@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This PR addresses #6228 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

 - Adds AWS End User Messaging (Pinpoint SMS Voice V2) as an alternative SMS provider alongside the existing Twilio integration
 - Provider is selected at runtime via a `SMS_PROVIDER` env var (`twilio` or `aws`); defaults to `twilio` so existing behavior is unchanged

## How Can This Be Tested/Reviewed?

This is part 1 of the ticket and will need part 2 in order to be fully operable. For now, please inspect the code and ensure it looks good.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
