### PR TITLE
fix: notifications bash issues

### DIFF
--- a/api/prisma/migrations/62_update_unit_type_label_translation/migration.sql
+++ b/api/prisma/migrations/62_update_unit_type_label_translation/migration.sql
@@ -1,0 +1,41 @@
+-- Updates unitType label in rental opportunity notification email from "Unit type" to "Available accessible units"
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"Available accessible units"'::jsonb)
+WHERE language = 'en';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"Unidades accesibles disponibles"'::jsonb)
+WHERE language = 'es';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"Các căn hộ có sẵn"'::jsonb)
+WHERE language = 'vi';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"可用的无障碍单元"'::jsonb)
+WHERE language = 'zh';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"Mga available na accessible unit"'::jsonb)
+WHERE language = 'tl';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"উপলব্ধ প্রবেশযোগ্য ইউনিট"'::jsonb)
+WHERE language = 'bn';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"الوحدات المتاحة لذوي الاحتياجات الخاصة"'::jsonb)
+WHERE language = 'ar';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"장애인 접근 가능 객실"'::jsonb)
+WHERE language = 'ko';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"Հասանելի հաշմանդամների համար նախատեսված միավորներ"'::jsonb)
+WHERE language = 'hy';
+
+UPDATE translations
+SET translations = jsonb_set(translations, '{rentalOpportunity,unitType}', '"واحدهای قابل دسترس موجود"'::jsonb)
+WHERE language = 'fa';

--- a/api/prisma/seed-helpers/translation-factory.ts
+++ b/api/prisma/seed-helpers/translation-factory.ts
@@ -175,7 +175,7 @@ const translations = (
           address: 'Dirección',
           neighborhood: 'Vecindario',
           region: 'Región',
-          unitType: 'Tipo de unidad',
+          unitType: 'Unidades accesibles disponibles',
           accessibilityType: {
             hearing: 'Auditiva',
             mobility: 'Movilidad',
@@ -275,7 +275,7 @@ const translations = (
           address: 'Địa chỉ',
           neighborhood: 'Khu phố',
           region: 'Vùng đất',
-          unitType: 'Loại căn hộ',
+          unitType: 'Các căn hộ có sẵn',
           accessibilityType: {
             hearing: 'Thính giác',
             mobility: 'Di chuyển',
@@ -370,7 +370,7 @@ const translations = (
           address: '地址',
           neighborhood: '街区',
           region: '地区',
-          unitType: '单元类型',
+          unitType: '可用的无障碍单元',
           accessibilityType: {
             hearing: '听力',
             mobility: '行动',
@@ -468,7 +468,7 @@ const translations = (
           address: 'Address',
           neighborhood: 'Kapitbahayan',
           region: 'Rehiyon',
-          unitType: 'Uri ng unit',
+          unitType: 'Mga available na accessible unit',
           accessibilityType: {
             hearing: 'Pandinig',
             mobility: 'Mobilidad',
@@ -568,7 +568,7 @@ const translations = (
           address: 'ঠিকানা',
           neighborhood: 'এলাকা',
           region: 'অঞ্চল',
-          unitType: 'ইউনিটের ধরন',
+          unitType: 'উপলব্ধ প্রবেশযোগ্য ইউনিট',
           accessibilityType: {
             hearing: 'শ্রবণ',
             mobility: 'গতিশীলতা',
@@ -664,7 +664,7 @@ const translations = (
           address: 'العنوان',
           neighborhood: 'الحي',
           region: 'منطقة',
-          unitType: 'نوع الوحدة',
+          unitType: 'الوحدات المتاحة لذوي الاحتياجات الخاصة',
           accessibilityType: {
             hearing: 'السمع',
             mobility: 'الحركة',
@@ -761,7 +761,7 @@ const translations = (
           address: '주소',
           neighborhood: '동네',
           region: '지역',
-          unitType: '유닛 유형',
+          unitType: '장애인 접근 가능 객실',
           accessibilityType: {
             hearing: '청각',
             mobility: '이동성',
@@ -858,7 +858,7 @@ const translations = (
           address: 'Հասցե',
           neighborhood: 'Թաղամաս',
           region: 'Տարածաշրջան',
-          unitType: 'Բնակարանի տեսակ',
+          unitType: 'Հասանելի հաշմանդամների համար նախատեսված միավորներ',
           accessibilityType: {
             hearing: 'Լսողություն',
             mobility: 'Շարժունակություն',
@@ -958,7 +958,7 @@ const translations = (
           address: 'آدرس',
           neighborhood: 'محله',
           region: 'منطقه',
-          unitType: 'نوع واحد',
+          unitType: 'واحدهای قابل دسترس موجود',
           accessibilityType: {
             hearing: 'شنوایی',
             mobility: 'تحرک',
@@ -1189,7 +1189,7 @@ const translations = (
           changePassword: 'Change my password',
         },
         requestApproval: {
-          header: 'Listing approval requested',
+          header: 'Listing approval requested - %{listingName}',
           partnerRequest:
             'A Partner has submitted an approval request to publish the %{listingName} listing.',
           logInToReviewStart: 'Please log into the',
@@ -1199,7 +1199,7 @@ const translations = (
             'To access the listing after logging in, please click the link below',
         },
         changesRequested: {
-          header: 'Listing changes requested',
+          header: 'Listing changes requested - %{listingName}',
           adminRequestStart:
             'An administrator is requesting changes to the %{listingName} listing. Please log into the',
           adminRequestEnd:
@@ -1219,7 +1219,7 @@ const translations = (
             'The %{listingName} listing has been approved by an administrator and is scheduled to be automatically published on %{date} between 12:00 AM and 2:00 AM. If you have questions or require changes, please contact an administrator.',
         },
         listingPublished: {
-          header: 'New published listing',
+          header: 'New published listing - %{listingName}',
           subject: 'New published listing - %{listingName}',
           autoPublished:
             'The %{listingName} listing has been automatically published.',
@@ -1306,7 +1306,7 @@ const translations = (
           address: 'Address',
           neighborhood: 'Neighborhood',
           region: 'Region',
-          unitType: 'Unit type',
+          unitType: 'Available accessible units',
           accessibilityType: {
             hearing: 'Hearing',
             mobility: 'Mobility',

--- a/api/prisma/seed-helpers/translation-factory.ts
+++ b/api/prisma/seed-helpers/translation-factory.ts
@@ -1189,7 +1189,7 @@ const translations = (
           changePassword: 'Change my password',
         },
         requestApproval: {
-          header: 'Listing approval requested - %{listingName}',
+          header: 'Listing approval requested',
           partnerRequest:
             'A Partner has submitted an approval request to publish the %{listingName} listing.',
           logInToReviewStart: 'Please log into the',
@@ -1199,7 +1199,7 @@ const translations = (
             'To access the listing after logging in, please click the link below',
         },
         changesRequested: {
-          header: 'Listing changes requested - %{listingName}',
+          header: 'Listing changes requested',
           adminRequestStart:
             'An administrator is requesting changes to the %{listingName} listing. Please log into the',
           adminRequestEnd:

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -1468,6 +1468,7 @@ export class ListingService implements OnModuleInit {
         id: true,
         featureFlags: true,
         listingApprovalPermissions: true,
+        publicUrl: true,
       },
       where: {
         id: dto.jurisdictions.id,
@@ -1874,16 +1875,33 @@ export class ListingService implements OnModuleInit {
         approvingRoles: rawJurisdiction.listingApprovalPermissions,
         jurisId: rawJurisdiction.id,
       });
-    } else if (
-      enableV2MSQ &&
-      mappedListing.status === ListingsStatusEnum.active
-    ) {
-      const multiselectQuestions =
-        mappedListing.listingMultiselectQuestions.map(
-          (listingMultiselectQuestion) =>
-            listingMultiselectQuestion.multiselectQuestions,
-        );
-      void this.multiselectQuestionService.activateMany(multiselectQuestions);
+    } else if (mappedListing.status === ListingsStatusEnum.active) {
+      if (enableV2MSQ) {
+        const multiselectQuestions =
+          mappedListing.listingMultiselectQuestions.map(
+            (listingMultiselectQuestion) =>
+              listingMultiselectQuestion.multiselectQuestions,
+          );
+        void this.multiselectQuestionService.activateMany(multiselectQuestions);
+      }
+      const userInfo = await this.getUserEmailInfo(
+        [
+          UserRoleEnum.partner,
+          UserRoleEnum.admin,
+          UserRoleEnum.jurisdictionAdmin,
+          UserRoleEnum.limitedJurisdictionAdmin,
+          UserRoleEnum.supportAdmin,
+        ],
+        mappedListing.id,
+        rawJurisdiction.id,
+      );
+      await this.emailService.listingPublished(
+        { id: rawJurisdiction.id },
+        { id: mappedListing.id, name: mappedListing.name },
+        userInfo.emails,
+        rawJurisdiction.publicUrl || '',
+      );
+      await this.sendListingPublishNotification(mappedListing);
     }
     await this.cachePurge(undefined, dto.status, mappedListing.id);
     return mappedListing;
@@ -2964,6 +2982,32 @@ export class ListingService implements OnModuleInit {
         jurisId: rawJurisdiction.id,
         scheduledPublishAt: incomingDto.scheduledPublishAt,
       });
+    else if (
+      incomingDto.status === ListingsStatusEnum.active &&
+      storedListing.status === ListingsStatusEnum.pending
+    ) {
+      const userInfo = await this.getUserEmailInfo(
+        [
+          UserRoleEnum.partner,
+          UserRoleEnum.admin,
+          UserRoleEnum.jurisdictionAdmin,
+          UserRoleEnum.limitedJurisdictionAdmin,
+          UserRoleEnum.supportAdmin,
+        ],
+        mappedListing.id,
+        rawJurisdiction.id,
+      );
+      const jurisdiction = await this.prisma.jurisdictions.findUnique({
+        select: { publicUrl: true },
+        where: { id: rawJurisdiction.id },
+      });
+      await this.emailService.listingPublished(
+        { id: rawJurisdiction.id },
+        { id: mappedListing.id, name: mappedListing.name },
+        userInfo.emails,
+        jurisdiction.publicUrl || '',
+      );
+    }
 
     if (sendPublishNotificationEmail) {
       await this.sendListingPublishNotification(mappedListing);

--- a/api/src/views/listing-published.hbs
+++ b/api/src/views/listing-published.hbs
@@ -1,6 +1,6 @@
 {{#> layout_default }}
     <h1>
-        {{ t "listingPublished.header" appOptions}}
+        {{ t "listingPublished.header" }}
     </h1>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
         <tbody>

--- a/api/src/views/listing-published.hbs
+++ b/api/src/views/listing-published.hbs
@@ -1,6 +1,6 @@
 {{#> layout_default }}
     <h1>
-        {{ t "listingPublished.header"}}
+        {{ t "listingPublished.header" appOptions}}
     </h1>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0">
         <tbody>

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -75,6 +75,7 @@ describe('Listing Controller Tests', () => {
     lotteryReleased: async () => {},
     lotteryPublishedAdmin: async () => {},
     lotteryPublishedApplicant: async () => {},
+    listingPublished: async () => {},
   };
   const mockChangesRequested = jest.spyOn(testEmailService, 'changesRequested');
   const mockRequestApproval = jest.spyOn(testEmailService, 'requestApproval');

--- a/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-admin.e2e-spec.ts
@@ -74,6 +74,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-correct-juris.e2e-spec.ts
@@ -72,6 +72,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-juris-admin-wrong-juris.e2e-spec.ts
@@ -71,6 +71,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-limited-juris-admin-correct-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-limited-juris-admin-correct-juris.e2e-spec.ts
@@ -72,6 +72,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   applicationConfirmation: jest.fn(),
   listingPublishNotification: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-limited-juris-admin-wrong-juris.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-limited-juris-admin-wrong-juris.e2e-spec.ts
@@ -71,6 +71,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-no-user.e2e-spec.ts
@@ -73,6 +73,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-correct-listing.e2e-spec.ts
@@ -75,6 +75,7 @@ const testEmailService = {
   applicationConfirmation: jest.fn(),
   lotteryPublishedAdmin: jest.fn(),
   lotteryPublishedApplicant: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-partner-wrong-listing.e2e-spec.ts
@@ -71,6 +71,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-public.e2e-spec.ts
@@ -74,6 +74,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/integration/permission-tests/permission-as-support-admin.e2e-spec.ts
+++ b/api/test/integration/permission-tests/permission-as-support-admin.e2e-spec.ts
@@ -76,6 +76,7 @@ const testEmailService = {
   sendMfaCode: jest.fn(),
   sendCSV: jest.fn(),
   applicationConfirmation: jest.fn(),
+  listingPublished: jest.fn(),
 };
 
 const testCronJobService = {

--- a/api/test/unit/services/email.service.spec.ts
+++ b/api/test/unit/services/email.service.spec.ts
@@ -977,7 +977,7 @@ describe('Testing email service', () => {
       applicationsDue: 'Applications Due',
       address: 'Address',
       neighborhood: 'Neighborhood',
-      unitType: 'Unit type',
+      unitType: 'Available accessible units',
       opportunityType: 'Opportunity type',
       rent: 'Rent',
       minIncome: 'Minimum Income',

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -4571,6 +4571,7 @@ describe('Testing listing service', () => {
       });
 
       prisma.multiselectQuestions.findMany = jest.fn().mockResolvedValue([]);
+      prisma.userAccounts.findMany = jest.fn().mockResolvedValue([]);
 
       prisma.listings.create = jest.fn().mockResolvedValue({
         id: 'example id',

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -4963,6 +4963,50 @@ describe('Testing listing service', () => {
         },
       ]);
     });
+
+    it('should send listingPublished and public notification when creating directly as active', async () => {
+      prisma.listings.create = jest.fn().mockResolvedValue({
+        id: 'listing-id',
+        name: 'listing name',
+        status: ListingsStatusEnum.active,
+        listingMultiselectQuestions: [],
+        units: [],
+      });
+      prisma.jurisdictions.findUnique = jest.fn().mockResolvedValue({
+        id: 'jurisdiction-id',
+        publicUrl: 'public.housing.gov',
+        listingApprovalPermissions: [],
+      });
+      jest
+        .spyOn(service, 'getUserEmailInfo')
+        .mockResolvedValueOnce({ emails: ['partner@email.com'] });
+      jest
+        .spyOn(service, 'sendListingPublishNotification')
+        .mockResolvedValueOnce(undefined);
+
+      await service.create(
+        {
+          name: 'listing name',
+          depositMin: '5',
+          assets: [],
+          jurisdictions: { id: 'jurisdiction-id' },
+          status: ListingsStatusEnum.active,
+          displayWaitlistSize: false,
+          unitsSummary: null,
+          listingEvents: [],
+          isVerified: true,
+        } as ListingCreate,
+        user,
+      );
+
+      expect(listingPublishedMock).toHaveBeenCalledWith(
+        { id: 'jurisdiction-id' },
+        { id: 'listing-id', name: 'listing name' },
+        ['partner@email.com'],
+        'public.housing.gov',
+      );
+      expect(service.sendListingPublishNotification).toHaveBeenCalled();
+    });
   });
 
   describe('Test duplicate endpoint', () => {
@@ -6913,6 +6957,72 @@ describe('Testing listing service', () => {
       });
 
       expect(listingApprovedMock).toBeCalledTimes(0);
+    });
+
+    it('should send listingPublished when publishing from draft with no approval permissions', async () => {
+      prisma.jurisdictions.findUnique = jest.fn().mockResolvedValue({
+        id: 'jurisdiction-id',
+        publicUrl: 'public.housing.gov',
+        featureFlags: [],
+        listingApprovalPermissions: [],
+      });
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: 'listing-id',
+        name: 'listing name',
+        status: ListingsStatusEnum.pending,
+        jurisdictionId: 'jurisdiction-id',
+        listingMultiselectQuestions: [],
+      });
+      prisma.listings.update = jest.fn().mockResolvedValue({
+        id: 'listing-id',
+        name: 'listing name',
+        status: ListingsStatusEnum.active,
+        listingMultiselectQuestions: [],
+        units: [],
+      });
+      prisma.listingEvents.findMany = jest.fn().mockResolvedValue([]);
+      prisma.listingSnapshot.create = jest
+        .fn()
+        .mockResolvedValue({ id: 'snapshot-id' });
+      prisma.$transaction = jest.fn().mockResolvedValue([
+        {
+          id: 'listing-id',
+          name: 'listing name',
+          status: ListingsStatusEnum.active,
+          listingMultiselectQuestions: [],
+          units: [],
+        },
+      ]);
+      jest
+        .spyOn(service, 'getUserEmailInfo')
+        .mockResolvedValueOnce({ emails: ['partner@email.com'] });
+      jest
+        .spyOn(service, 'sendListingPublishNotification')
+        .mockResolvedValueOnce(undefined);
+
+      await service.update(
+        {
+          id: 'listing-id',
+          name: 'listing name',
+          depositMin: '5',
+          assets: [],
+          jurisdictions: { id: 'jurisdiction-id' },
+          status: ListingsStatusEnum.active,
+          displayWaitlistSize: false,
+          unitsSummary: null,
+          listingEvents: [],
+          lastUpdatedByUser: user,
+        } as ListingUpdate,
+        user,
+      );
+
+      expect(listingPublishedMock).toHaveBeenCalledWith(
+        { id: 'jurisdiction-id' },
+        { id: 'listing-id', name: 'listing name' },
+        ['partner@email.com'],
+        'public.housing.gov',
+      );
+      expect(service.sendListingPublishNotification).toHaveBeenCalled();
     });
   });
 

--- a/shared-helpers/src/locales/ar.json
+++ b/shared-helpers/src/locales/ar.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "إعدادات الحساب",
   "account.accountSettingsSubtitle": "إعدادات الحساب والبريد الإلكتروني وكلمة المرور",
+  "account.accountSettingsSubtitleWithNotifications": "إعدادات الحساب، البريد الإلكتروني، كلمة المرور، والإشعارات",
   "account.accountSettingsUpdate": "تحديث إعدادات الحساب",
   "account.allMyApplications": "جميع تطبيقاتي",
   "account.allMyApplicationsSubtitle": "شاهد قوائم العقارات التي تقدمت بطلب للحصول عليها.",
@@ -198,7 +199,7 @@
   "application.contact.givenName": "الاسم الأول",
   "application.contact.mailingAddress": "عنوان البريد",
   "application.contact.noPhoneNumber": "ليس لدي رقم هاتف",
-  "application.contact.number.subNote": "10 أرقام، على سبيل المثال \u2066999-999-9999\u2069",
+  "application.contact.number.subNote": "10 أرقام، على سبيل المثال ⁦999-999-9999⁩",
   "application.contact.number": "رقم",
   "application.contact.phoneNumberTypes.cell": "زنزانة",
   "application.contact.phoneNumberTypes.home": "الصفحة الرئيسية",

--- a/shared-helpers/src/locales/bn.json
+++ b/shared-helpers/src/locales/bn.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "অ্যাকাউন্ট সেটিংস",
   "account.accountSettingsSubtitle": "অ্যাকাউন্ট সেটিংস, ইমেল এবং পাসওয়ার্ড",
+  "account.accountSettingsSubtitleWithNotifications": "অ্যাকাউন্ট সেটিংস, ইমেল, পাসওয়ার্ড এবং বিজ্ঞপ্তি",
   "account.accountSettingsUpdate": "অ্যাকাউন্ট সেটিংস আপডেট করুন",
   "account.allMyApplications": "আমার সকল আবেদনপত্র",
   "account.allMyApplicationsSubtitle": "আপনার আবেদনকৃত সম্পত্তির তালিকা দেখুন।",

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "Configuraciones de la cuenta",
   "account.accountSettingsSubtitle": "Configuraciones de la cuenta, email y contraseña",
+  "account.accountSettingsSubtitleWithNotifications": "Configuración de la cuenta, correo electrónico, contraseña y notificaciones",
   "account.accountSettingsUpdate": "Actualizar la configuración de la cuenta",
   "account.allMyApplications": "Todas mis aplicaciones",
   "account.allMyApplicationsSubtitle": "Ver listados de propiedades a las que has aplicado.",

--- a/shared-helpers/src/locales/fa.json
+++ b/shared-helpers/src/locales/fa.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "تنظیمات حساب",
   "account.accountSettingsSubtitle": "تنظیمات حساب، ایمیل و رمز عبور",
+  "account.accountSettingsSubtitleWithNotifications": "تنظیمات حساب، ایمیل، رمز عبور و اعلان‌ها",
   "account.accountSettingsUpdate": "تنظیمات حساب را به‌روزرسانی کنید",
   "account.allMyApplications": "تمام برنامه‌های من",
   "account.allMyApplicationsSubtitle": "لیست املاکی که برای آنها درخواست داده‌اید را مشاهده کنید.",
@@ -198,7 +199,7 @@
   "application.contact.givenName": "نام داده شده",
   "application.contact.mailingAddress": "آدرس پستی",
   "application.contact.noPhoneNumber": "شماره تلفن ندارم",
-  "application.contact.number.subNote": "ده رقمی، مثلاً \u2066999-999-9999\u2069",
+  "application.contact.number.subNote": "ده رقمی، مثلاً ⁦999-999-9999⁩",
   "application.contact.number": "شماره",
   "application.contact.phoneNumberTypes.cell": "سلول",
   "application.contact.phoneNumberTypes.home": "خانه",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "Account settings",
   "account.accountSettingsSubtitle": "Account settings, email and password",
+  "account.accountSettingsSubtitleWithNotifications": "Account settings, email, password and notifications",
   "account.accountSettingsUpdate": "Update account settings",
   "account.allMyApplications": "All my applications",
   "account.allMyApplicationsSubtitle": "See listings for properties for which you’ve applied.",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -1,7 +1,7 @@
 {
   "account.accountSettings": "Account settings",
   "account.accountSettingsSubtitle": "Account settings, email and password",
-  "account.accountSettingsSubtitleWithNotifications": "Account settings, email, password and notifications",
+  "account.accountSettingsSubtitleWithNotifications": "Account settings, email, password, and notifications",
   "account.accountSettingsUpdate": "Update account settings",
   "account.allMyApplications": "All my applications",
   "account.allMyApplicationsSubtitle": "See listings for properties for which you’ve applied.",

--- a/shared-helpers/src/locales/hy.json
+++ b/shared-helpers/src/locales/hy.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "Հաշվի կարգավորումներ",
   "account.accountSettingsSubtitle": "Հաշվի կարգավորումներ, էլ․ փոստ և գաղտնաբառ",
+  "account.accountSettingsSubtitleWithNotifications": "Հաշվի կարգավորումներ, էլ. փոստ, գաղտնաբառ և ծանուցումներ",
   "account.accountSettingsUpdate": "Հաշվի կարգավորումների թարմացում",
   "account.allMyApplications": "Իմ բոլոր դիմումները",
   "account.allMyApplicationsSubtitle": "Տեսեք այն անշարժ գույքի ցուցակները, որոնց համար դիմել եք։",

--- a/shared-helpers/src/locales/ko.json
+++ b/shared-helpers/src/locales/ko.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "계정 설정",
   "account.accountSettingsSubtitle": "계정 설정, 이메일 및 비밀번호",
+  "account.accountSettingsSubtitleWithNotifications": "계정 설정, 이메일, 비밀번호 및 알림",
   "account.accountSettingsUpdate": "계정 설정 업데이트",
   "account.allMyApplications": "내 모든 지원서",
   "account.allMyApplicationsSubtitle": "신청하신 매물 목록을 확인하세요.",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "Mga setting ng account",
   "account.accountSettingsSubtitle": "Mga setting ng account, email at password",
+  "account.accountSettingsSubtitleWithNotifications": "Mga setting ng account, email, password at mga notification",
   "account.accountSettingsUpdate": "I-update ang mga setting ng account",
   "account.allMyApplications": "Lahat ng aking mga aplikasyon",
   "account.allMyApplicationsSubtitle": "Tingnan ang mga listahan para sa mga ari-arian na inapplyan mo.",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "Cài đặt tài khoản",
   "account.accountSettingsSubtitle": "Cài đặt tài khoản, email và mật khẩu",
+  "account.accountSettingsSubtitleWithNotifications": "Cài đặt tài khoản, email, mật khẩu và thông báo",
   "account.accountSettingsUpdate": "Cập nhật cài đặt tài khoản",
   "account.allMyApplications": "Tất cả các ứng dụng của tôi",
   "account.allMyApplicationsSubtitle": "Xem danh sách các bất động sản mà bạn đã đăng ký.",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -1,6 +1,7 @@
 {
   "account.accountSettings": "帐户设置",
   "account.accountSettingsSubtitle": "账户设置、邮箱和密码",
+  "account.accountSettingsSubtitleWithNotifications": "账户设置、电子邮件、密码和通知",
   "account.accountSettingsUpdate": "更新帐户设置",
   "account.allMyApplications": "我的所有申請",
   "account.allMyApplicationsSubtitle": "查看您已申請的房源列表。",

--- a/sites/public/__tests__/pages/account/dashboard.test.tsx
+++ b/sites/public/__tests__/pages/account/dashboard.test.tsx
@@ -187,4 +187,45 @@ describe("<Dashboard>", () => {
     ).not.toBeInTheDocument()
     expect(screen.queryByRole("link", { name: /view applications/i })).not.toBeInTheDocument()
   })
+
+  it("should show notifications subtitle when enableCustomListingNotifications flag is enabled", () => {
+    render(
+      <AuthContext.Provider
+        value={{
+          profile: {
+            ...user,
+            listings: [],
+            jurisdictions: [],
+          },
+        }}
+      >
+        <Dashboard
+          jurisdiction={{
+            ...jurisdiction,
+            featureFlags: [
+              ...jurisdiction.featureFlags,
+              {
+                name: FeatureFlagEnum.enableCustomListingNotifications,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                id: "4ac85a8b-c319-4257-bedb-2db95133fab3",
+                description: "Enables custom listing notification preferences for users",
+                active: true,
+                jurisdictions: [],
+              },
+            ],
+          }}
+        />
+      </AuthContext.Provider>
+    )
+
+    const dashboardCards = screen.getAllByRole("article")
+    const accountSettingsCard = dashboardCards.find((card) =>
+      within(card).queryByRole("heading", { level: 2, name: /account settings/i })
+    )
+
+    expect(
+      within(accountSettingsCard).getByText("Account settings, email, password and notifications")
+    ).toBeInTheDocument()
+  })
 })

--- a/sites/public/__tests__/pages/account/dashboard.test.tsx
+++ b/sites/public/__tests__/pages/account/dashboard.test.tsx
@@ -225,7 +225,7 @@ describe("<Dashboard>", () => {
     )
 
     expect(
-      within(accountSettingsCard).getByText("Account settings, email, password and notifications")
+      within(accountSettingsCard).getByText("Account settings, email, password, and notifications")
     ).toBeInTheDocument()
   })
 })

--- a/sites/public/__tests__/pages/sign-in.test.tsx
+++ b/sites/public/__tests__/pages/sign-in.test.tsx
@@ -256,6 +256,77 @@ describe("Sign In Page", () => {
       expect(getByLabelText("Password")).toBeInTheDocument()
     })
   })
+
+  describe("User already logged in", () => {
+    it("redirects to redirectUrl when already authenticated", async () => {
+      const mockRouter = { query: { redirectUrl: "/account/notifications" }, push: jest.fn() }
+      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+      render(
+        <AuthContext.Provider
+          value={{
+            initialStateLoaded: true,
+            profile: { firstName: "User", id: "user-123" } as User,
+          }}
+        >
+          <MessageContext.Provider value={TOAST_MESSAGE}>
+            <SignInComponent jurisdiction={jurisdiction} />
+          </MessageContext.Provider>
+        </AuthContext.Provider>
+      )
+
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith("/account/notifications")
+      })
+    })
+
+    it("redirects to dashboard when no redirectUrl and already authenticated", async () => {
+      const mockRouter = { query: {}, push: jest.fn() }
+      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+      render(
+        <AuthContext.Provider
+          value={{
+            initialStateLoaded: true,
+            profile: { firstName: "User", id: "user-123" } as User,
+          }}
+        >
+          <MessageContext.Provider value={TOAST_MESSAGE}>
+            <SignInComponent jurisdiction={jurisdiction} />
+          </MessageContext.Provider>
+        </AuthContext.Provider>
+      )
+
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith("/account/dashboard")
+      })
+    })
+
+    it.each([
+      ["https://evil.com", "external URL"],
+      ["//evil.com", "protocol-relative URL"],
+    ])("redirects to dashboard instead of %s (%s)", async (maliciousUrl) => {
+      const mockRouter = { query: { redirectUrl: maliciousUrl }, push: jest.fn() }
+      ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+
+      render(
+        <AuthContext.Provider
+          value={{
+            initialStateLoaded: true,
+            profile: { firstName: "User", id: "user-123" } as User,
+          }}
+        >
+          <MessageContext.Provider value={TOAST_MESSAGE}>
+            <SignInComponent jurisdiction={jurisdiction} />
+          </MessageContext.Provider>
+        </AuthContext.Provider>
+      )
+
+      await waitFor(() => {
+        expect(mockRouter.push).toHaveBeenCalledWith("/account/dashboard")
+      })
+    })
+  })
 })
 
 describe("Passwordless Sign In page", () => {

--- a/sites/public/src/pages/account/dashboard.tsx
+++ b/sites/public/src/pages/account/dashboard.tsx
@@ -104,7 +104,14 @@ function Dashboard(props: DashboardProps) {
                     iconSymbol="userCircle"
                     iconClass={"card-icon"}
                     title={t("account.accountSettings")}
-                    subtitle={t("account.accountSettingsSubtitle")}
+                    subtitle={t(
+                      isFeatureFlagOn(
+                        props.jurisdiction,
+                        FeatureFlagEnum.enableCustomListingNotifications
+                      )
+                        ? "account.accountSettingsSubtitleWithNotifications"
+                        : "account.accountSettingsSubtitle"
+                    )}
                     headingClass={"seeds-large-heading"}
                     id="account-dashboard-settings"
                     variant={"block"}

--- a/sites/public/src/pages/sign-in.tsx
+++ b/sites/public/src/pages/sign-in.tsx
@@ -42,7 +42,8 @@ const SignIn = (props: SignInProps) => {
   const { addToast } = useContext(MessageContext)
   const router = useRouter()
 
-  const { login, requestSingleUseCode, userService } = useContext(AuthContext)
+  const { login, requestSingleUseCode, userService, initialStateLoaded, profile } =
+    useContext(AuthContext)
   const signUpCopy = process.env.showMandatedAccounts
   const reCaptchaEnabled = !!process.env.reCaptchaKey
 
@@ -83,6 +84,14 @@ const SignIn = (props: SignInProps) => {
     reset: resetResendConfirmation,
     isLoading: isResendConfirmationLoading,
   } = useMutate<SuccessDTO>()
+
+  useEffect(() => {
+    if (initialStateLoaded && profile) {
+      const redirectUrl = (router.query?.redirectUrl as string) || "/account/dashboard"
+      void router.push(redirectUrl)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialStateLoaded, profile])
 
   useEffect(() => {
     pushGtmEvent<PageView>({

--- a/sites/public/src/pages/sign-in.tsx
+++ b/sites/public/src/pages/sign-in.tsx
@@ -20,6 +20,7 @@ import {
   NetworkErrorMessage,
   useMutate,
   getListingRedirectUrl,
+  isInternalLink,
 } from "@bloom-housing/shared-helpers"
 import { UserStatus } from "../lib/constants"
 import { PasswordExpiredModal } from "../components/account/PasswordExpiredModal"
@@ -87,7 +88,9 @@ const SignIn = (props: SignInProps) => {
 
   useEffect(() => {
     if (initialStateLoaded && profile) {
-      const redirectUrl = (router.query?.redirectUrl as string) || "/account/dashboard"
+      const rawRedirectUrl = router.query?.redirectUrl as string
+      const redirectUrl =
+        rawRedirectUrl && isInternalLink(rawRedirectUrl) ? rawRedirectUrl : "/account/dashboard"
       void router.push(redirectUrl)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Description

- ✨ This is the only blocking issue, and is just UX feedback ✨ Renames the "Unit type" label in rental opportunity notification emails from "Unit type" to "Available accessible units"
<img width="354" height="148" alt="Screenshot 2026-06-16 at 9 08 47 PM" src="https://github.com/user-attachments/assets/3081a9ea-78a1-47ae-ba0e-e330569a09ff" />

- When enableCustomListingNotifications is on, the account settings dashboard card now shows "Account settings, email, password and notifications" instead of the generic subtitle
<img width="508" height="325" alt="Screenshot 2026-06-16 at 9 09 14 PM" src="https://github.com/user-attachments/assets/c3c6c92f-ae80-42a4-9117-83f03c3d9496" />

- Sign-in auto-redirect for authenticated users for the "unsubscribe and manage email settings" link in notification emails — logged-in users visiting /sign-in?redirectUrl=... are now redirected immediately to the target URL instead of always being shown the login form

- Fixes missing partner admin and public notification emails when a listing is published directly from draft (bypassing the approval workflow) - unlikely to ever happen in practice

## How Can This Be Tested/Reviewed?

-  Receive a rental opportunity notification email with any accessible unit and confirm the label reads "Available accessible units" - publishing directly from draft
-  On the account dashboard, with enableCustomListingNotifications on confirm subtitle changes
-  While logged in, click the "unsubscribe and manage email settings" link from a notification email - confirm redirect to /account/notifications without hitting login screen

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
