### PR TITLE
fix: allow admins to submit scheduled listings

### DIFF
--- a/sites/partners/__tests__/components/listings/PaperListingForm/PublishListingDialog.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/PublishListingDialog.test.tsx
@@ -1,0 +1,159 @@
+import React from "react"
+import { cleanup, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+import { ListingsStatusEnum } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import PublishListingDialog from "../../../../src/components/listings/PaperListingForm/dialogs/PublishListingDialog"
+import { mockNextRouter, render } from "../../../testUtils"
+
+dayjs.extend(utc)
+
+afterEach(cleanup)
+
+describe("PublishListingDialog", () => {
+  beforeAll(() => {
+    mockNextRouter()
+  })
+
+  it("renders default publish copy when enableAutopublish is false", () => {
+    render(
+      <PublishListingDialog
+        isOpen={true}
+        setOpen={jest.fn()}
+        submitFormWithStatus={jest.fn()}
+        enableAutopublish={false}
+        scheduledPublishAt={new Date("2026-06-15T00:00:00.000Z")}
+      />
+    )
+
+    expect(screen.getByRole("heading", { name: "Are you sure?" })).toBeInTheDocument()
+    expect(
+      screen.getByText("Publishing will push the listing live on the public site.")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Publish" })).toBeInTheDocument()
+    expect(screen.queryByText(/publish automatically/)).not.toBeInTheDocument()
+  })
+
+  it("renders default publish copy when enableAutopublish is true but no scheduled date", () => {
+    render(
+      <PublishListingDialog
+        isOpen={true}
+        setOpen={jest.fn()}
+        submitFormWithStatus={jest.fn()}
+        enableAutopublish={true}
+        scheduledPublishAt={null}
+      />
+    )
+
+    expect(
+      screen.getByText("Publishing will push the listing live on the public site.")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Publish" })).toBeInTheDocument()
+    expect(screen.queryByText(/publish automatically/)).not.toBeInTheDocument()
+  })
+
+  it("renders default publish copy when enableAutopublish is true but scheduled date is in the past", () => {
+    jest.useFakeTimers("modern")
+    jest.setSystemTime(new Date("2026-06-16T00:00:01"))
+
+    render(
+      <PublishListingDialog
+        isOpen={true}
+        setOpen={jest.fn()}
+        submitFormWithStatus={jest.fn()}
+        enableAutopublish={true}
+        scheduledPublishAt={new Date("2026-06-15T00:00:00.000Z")}
+      />
+    )
+
+    expect(
+      screen.getByText("Publishing will push the listing live on the public site.")
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Publish" })).toBeInTheDocument()
+    expect(screen.queryByText(/publish automatically/)).not.toBeInTheDocument()
+    jest.useRealTimers()
+  })
+
+  it("renders scheduled publish copy when enableAutopublish is true with a valid future scheduled date", () => {
+    jest.useFakeTimers("modern")
+    jest.setSystemTime(new Date("2026-06-14T23:30:00"))
+
+    render(
+      <PublishListingDialog
+        isOpen={true}
+        setOpen={jest.fn()}
+        submitFormWithStatus={jest.fn()}
+        enableAutopublish={true}
+        scheduledPublishAt={new Date("2026-06-15T00:00:00.000Z")}
+      />
+    )
+
+    expect(screen.getByRole("heading", { name: "Are you sure?" })).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "This listing will publish automatically on 06/15/2026 between 12:00 AM and 2:00 AM."
+      )
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Publish" })).not.toBeInTheDocument()
+    jest.useRealTimers()
+  })
+
+  it("submits with scheduled status when confirming with a future scheduled date", async () => {
+    const setOpen = jest.fn()
+    const submitFormWithStatus = jest.fn()
+
+    render(
+      <PublishListingDialog
+        isOpen={true}
+        setOpen={setOpen}
+        submitFormWithStatus={submitFormWithStatus}
+        enableAutopublish={true}
+        scheduledPublishAt={new Date("2099-12-31T00:00:00.000Z")}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Submit" }))
+
+    expect(setOpen).toHaveBeenCalledWith(false)
+    expect(submitFormWithStatus).toHaveBeenCalledWith("redirect", ListingsStatusEnum.scheduled)
+  })
+
+  it("submits with active status when confirming without a scheduled date", async () => {
+    const setOpen = jest.fn()
+    const submitFormWithStatus = jest.fn()
+
+    render(
+      <PublishListingDialog
+        isOpen={true}
+        setOpen={setOpen}
+        submitFormWithStatus={submitFormWithStatus}
+        enableAutopublish={false}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Publish" }))
+
+    expect(setOpen).toHaveBeenCalledWith(false)
+    expect(submitFormWithStatus).toHaveBeenCalledWith("redirect", ListingsStatusEnum.active)
+  })
+
+  it("closes without submitting when cancel is clicked", async () => {
+    const setOpen = jest.fn()
+    const submitFormWithStatus = jest.fn()
+
+    render(
+      <PublishListingDialog
+        isOpen={true}
+        setOpen={setOpen}
+        submitFormWithStatus={submitFormWithStatus}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(setOpen).toHaveBeenCalledWith(false)
+    expect(submitFormWithStatus).not.toHaveBeenCalled()
+  })
+})

--- a/sites/partners/__tests__/components/listings/PaperListingForm/PublishListingDialog.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/PublishListingDialog.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cleanup, screen } from "@testing-library/react"
+import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import dayjs from "dayjs"
 import utc from "dayjs/plugin/utc"
@@ -8,8 +8,6 @@ import PublishListingDialog from "../../../../src/components/listings/PaperListi
 import { mockNextRouter, render } from "../../../testUtils"
 
 dayjs.extend(utc)
-
-afterEach(cleanup)
 
 describe("PublishListingDialog", () => {
   beforeAll(() => {

--- a/sites/partners/__tests__/components/listings/PaperListingForm/SaveScheduledListingDialog.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/SaveScheduledListingDialog.test.tsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { screen } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
 import SaveScheduledListingDialog from "../../../../src/components/listings/PaperListingForm/dialogs/SaveScheduledListingDialog"
 import { mockNextRouter, render } from "../../../testUtils"
 

--- a/sites/partners/__tests__/components/listings/PaperListingForm/SaveScheduledListingDialog.test.tsx
+++ b/sites/partners/__tests__/components/listings/PaperListingForm/SaveScheduledListingDialog.test.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import SaveScheduledListingDialog from "../../../../src/components/listings/PaperListingForm/dialogs/SaveScheduledListingDialog"
+import { mockNextRouter, render } from "../../../testUtils"
+
+describe("SaveScheduledListingDialog", () => {
+  beforeAll(() => {
+    mockNextRouter()
+  })
+
+  beforeEach(() => {
+    jest.useFakeTimers("modern")
+    jest.setSystemTime(new Date("2026-06-15T12:00:00.000Z"))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("renders no-date copy when currentScheduledPublishAt is null", () => {
+    render(
+      <SaveScheduledListingDialog
+        isOpen={true}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        currentScheduledPublishAt={null}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        "This listing no longer has a scheduled publish date entered. As it is already approved, saving will publish it immediately. To delay publication, set a publish date before saving, or Unapprove the listing."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("renders past-date copy when currentScheduledPublishAt is in the past", () => {
+    render(
+      <SaveScheduledListingDialog
+        isOpen={true}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        currentScheduledPublishAt={new Date("2026-06-14T00:00:00.000Z")}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        "The scheduled publish date entered on this listing is in the past. As it is already approved, saving will publish it immediately. To delay publication, update the scheduled publish date before saving, or Unapprove the listing."
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("renders scheduled copy with formatted date when currentScheduledPublishAt is in the future", () => {
+    render(
+      <SaveScheduledListingDialog
+        isOpen={true}
+        onClose={jest.fn()}
+        onConfirm={jest.fn()}
+        currentScheduledPublishAt={new Date("2026-06-20T00:00:00.000Z")}
+      />
+    )
+
+    expect(
+      screen.getByText(
+        "This listing is approved and scheduled to publish on 06/20/2026 between 12:00 AM and 2:00 AM. Saving will not affect its scheduled publication on this date."
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/sites/partners/__tests__/components/listings/helpers.test.ts
+++ b/sites/partners/__tests__/components/listings/helpers.test.ts
@@ -1,0 +1,44 @@
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+import { getValidFutureScheduledDate } from "../../../src/components/listings/helpers"
+
+dayjs.extend(utc)
+
+describe("getValidFutureScheduledDate", () => {
+  beforeEach(() => {
+    jest.useFakeTimers("modern")
+    jest.setSystemTime(new Date("2026-06-15T12:00:00.000Z"))
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("returns false for null", () => {
+    expect(getValidFutureScheduledDate(null)).toBe(false)
+  })
+
+  it("returns false for undefined", () => {
+    expect(getValidFutureScheduledDate(undefined)).toBe(false)
+  })
+
+  it("returns false for an invalid date string", () => {
+    expect(getValidFutureScheduledDate("not-a-date")).toBe(false)
+  })
+
+  it("returns false for a date in the past", () => {
+    expect(getValidFutureScheduledDate("2026-06-14T00:00:00.000Z")).toBe(false)
+  })
+
+  it("returns false for today's UTC date (same day, not strictly in the future)", () => {
+    expect(getValidFutureScheduledDate("2026-06-15T00:00:00.000Z")).toBe(false)
+  })
+
+  it("returns the formatted date string for a date in the future", () => {
+    expect(getValidFutureScheduledDate("2026-06-16T00:00:00.000Z")).toBe("06/16/2026")
+  })
+
+  it("returns the formatted date string when passed a Date object", () => {
+    expect(getValidFutureScheduledDate(new Date("2026-06-20T00:00:00.000Z"))).toBe("06/20/2026")
+  })
+})

--- a/sites/partners/page_content/locales/general.json
+++ b/sites/partners/page_content/locales/general.json
@@ -260,6 +260,7 @@
   "listings.applicationType.referral": "Referral",
   "listings.applicationType.referralUnit": "Referral only units",
   "listings.approval.adminApproveDialogTitle": "Approve listing",
+  "listings.approval.adminPublishWithScheduledDate": "This listing will publish automatically on %{date} between 12:00 AM and 2:00 AM.",
   "listings.approval.adminApproveNoScheduledDate": "This listing has no scheduled publish date entered. Approving it will publish it immediately. To delay publication, set a publish date before approving.",
   "listings.approval.adminApproveScheduledFuture": "This listing is scheduled to publish automatically on %{date} between 12:00 AM and 2:00 AM. Approving now will not publish it immediately.",
   "listings.approval.adminApproveScheduledPast": "The scheduled publish date entered on the listing has passed. Approving this listing will publish it immediately. To delay publication, update the scheduled publish date before approving.",

--- a/sites/partners/page_content/locales/general.json
+++ b/sites/partners/page_content/locales/general.json
@@ -277,6 +277,7 @@
   "listings.approval.reopen": "Reopen",
   "listings.approval.saveScheduledNoDate": "This listing no longer has a scheduled publish date entered. As it is already approved, saving will publish it immediately. To delay publication, set a publish date before saving, or Unapprove the listing.",
   "listings.approval.saveScheduledWithDate": "This listing is approved and scheduled to publish on %{date} between 12:00 AM and 2:00 AM. Saving will not affect its scheduled publication on this date.",
+  "listings.approval.saveScheduledWithPastDate": "The scheduled publish date entered on this listing is in the past. As it is already approved, saving will publish it immediately. To delay publication, update the scheduled publish date before saving, or Unapprove the listing.",
   "listings.approval.unapprove": "Unapprove",
   "listings.approval.unapproveDialogContent": "This listing will be returned to under review status and will no longer be scheduled to automatically publish. It will need to be re-approved before it can be published.",
   "listings.approval.unapproveDialogTitle": "Unapprove listing",

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -740,9 +740,7 @@ const ListingFormActions = ({
             onClose={() => setSaveScheduledDialogOpen(false)}
             onConfirm={() => {
               setSaveScheduledDialogOpen(false)
-              const hasScheduledDate =
-                scheduledPublishAt != null && dayjs.utc(scheduledPublishAt).isValid()
-              if (hasScheduledDate) {
+              if (getValidFutureScheduledDate(scheduledPublishAt)) {
                 submitFormWithStatus("continue", ListingsStatusEnum.scheduled)
               } else {
                 submitFormWithStatus("redirect", ListingsStatusEnum.active)

--- a/sites/partners/src/components/listings/ListingFormActions.tsx
+++ b/sites/partners/src/components/listings/ListingFormActions.tsx
@@ -24,6 +24,7 @@ import { StatusAside } from "../shared/StatusAside"
 import { SubmitFunction } from "./PaperListingForm"
 import { ListingContext } from "./ListingContext"
 import { createDate } from "../../lib/helpers"
+import { getValidFutureScheduledDate } from "./helpers"
 
 export enum ListingFormActionsType {
   add = "add",
@@ -129,17 +130,9 @@ const ListingFormActions = ({
   }, [listing])
 
   const getApprovedStatus = useCallback((): ListingsStatusEnum => {
-    const hasValidScheduledAt =
-      listing?.scheduledPublishAt != null && dayjs.utc(listing.scheduledPublishAt).isValid()
-
-    if (!hasValidScheduledAt) return ListingsStatusEnum.active
-
-    const scheduledAtDate = dayjs.utc(listing.scheduledPublishAt).format("MM/DD/YYYY")
-    if (dayjs().startOf("day").isBefore(dayjs(scheduledAtDate).startOf("day"))) {
-      return ListingsStatusEnum.scheduled
-    }
-
-    return ListingsStatusEnum.active
+    return getValidFutureScheduledDate(listing?.scheduledPublishAt)
+      ? ListingsStatusEnum.scheduled
+      : ListingsStatusEnum.active
   }, [listing?.scheduledPublishAt])
 
   const approveAndSetStatus = useCallback(

--- a/sites/partners/src/components/listings/PaperListingForm/dialogs/AdminListingApprovalDialog.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/dialogs/AdminListingApprovalDialog.tsx
@@ -1,9 +1,7 @@
 import React from "react"
-import dayjs from "dayjs"
-import utc from "dayjs/plugin/utc"
-dayjs.extend(utc)
 import { t } from "@bloom-housing/ui-components"
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
+import { getValidFutureScheduledDate } from "../../helpers"
 
 type AdminListingApprovalDialogProps = {
   isOpen: boolean
@@ -19,22 +17,17 @@ const AdminListingApprovalDialog = ({
   scheduledPublishAt,
 }: AdminListingApprovalDialogProps) => {
   const getAdminListingApprovalModalBody = (): string => {
-    const hasValidScheduledAt =
-      scheduledPublishAt != null && dayjs.utc(scheduledPublishAt).isValid()
+    const scheduledAtDate = getValidFutureScheduledDate(scheduledPublishAt)
 
-    if (!hasValidScheduledAt) {
-      return t("listings.approval.adminApproveNoScheduledDate")
+    if (scheduledAtDate) {
+      return t("listings.approval.adminApproveScheduledFuture", { date: scheduledAtDate })
     }
 
-    const scheduledAtDate = dayjs.utc(scheduledPublishAt).format("MM/DD/YYYY")
-
-    if (dayjs().startOf("day").isBefore(dayjs(scheduledAtDate).startOf("day"))) {
-      return t("listings.approval.adminApproveScheduledFuture", {
-        date: scheduledAtDate,
-      })
+    if (scheduledPublishAt != null) {
+      return t("listings.approval.adminApproveScheduledPast")
     }
 
-    return t("listings.approval.adminApproveScheduledPast")
+    return t("listings.approval.adminApproveNoScheduledDate")
   }
 
   return (

--- a/sites/partners/src/components/listings/PaperListingForm/dialogs/PublishListingDialog.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/dialogs/PublishListingDialog.tsx
@@ -3,18 +3,25 @@ import { ListingsStatusEnum } from "@bloom-housing/shared-helpers/src/types/back
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
 import { t } from "@bloom-housing/ui-components"
 import { SubmitFunction } from "../index"
+import { getValidFutureScheduledDate } from "../../helpers"
 
 export interface PublishListingDialogProps {
   isOpen: boolean
   setOpen: React.Dispatch<React.SetStateAction<boolean>>
   submitFormWithStatus: SubmitFunction
+  enableAutopublish?: boolean
+  scheduledPublishAt?: Date | string | null
 }
 
 const PublishListingDialog = ({
   isOpen,
   setOpen,
   submitFormWithStatus,
+  enableAutopublish,
+  scheduledPublishAt,
 }: PublishListingDialogProps) => {
+  const scheduledDate = enableAutopublish ? getValidFutureScheduledDate(scheduledPublishAt) : false
+
   return (
     <Dialog
       isOpen={!!isOpen}
@@ -26,20 +33,25 @@ const PublishListingDialog = ({
         {t("t.areYouSure")}
       </Dialog.Header>
       <Dialog.Content id="listing-form-publish-listing-dialog-content">
-        {t("listings.publishThisListing")}
+        {scheduledDate
+          ? t("listings.approval.adminPublishWithScheduledDate", { date: scheduledDate })
+          : t("listings.publishThisListing")}
       </Dialog.Content>
       <Dialog.Footer>
         <Button
           id="publishButtonConfirm"
           type="button"
-          variant="success"
+          variant={scheduledDate ? "primary" : "success"}
           onClick={() => {
             setOpen(false)
-            submitFormWithStatus("redirect", ListingsStatusEnum.active)
+            submitFormWithStatus(
+              "redirect",
+              scheduledDate ? ListingsStatusEnum.scheduled : ListingsStatusEnum.active
+            )
           }}
           size="sm"
         >
-          {t("listings.actions.publish")}
+          {scheduledDate ? t("t.submit") : t("listings.actions.publish")}
         </Button>
         <Button
           type="button"

--- a/sites/partners/src/components/listings/PaperListingForm/dialogs/SaveScheduledListingDialog.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/dialogs/SaveScheduledListingDialog.tsx
@@ -4,6 +4,7 @@ import utc from "dayjs/plugin/utc"
 dayjs.extend(utc)
 import { t } from "@bloom-housing/ui-components"
 import { Button, Dialog } from "@bloom-housing/ui-seeds"
+import { getValidFutureScheduledDate } from "../../helpers"
 
 type SaveScheduledListingDialogProps = {
   isOpen: boolean
@@ -18,13 +19,16 @@ const SaveScheduledListingDialog = ({
   onConfirm,
   currentScheduledPublishAt,
 }: SaveScheduledListingDialogProps) => {
-  const hasScheduledDate =
-    currentScheduledPublishAt != null && dayjs.utc(currentScheduledPublishAt).isValid()
+  const scheduledDate = getValidFutureScheduledDate(currentScheduledPublishAt)
+  const hasPastDate =
+    !scheduledDate &&
+    currentScheduledPublishAt != null &&
+    dayjs.utc(currentScheduledPublishAt).isValid()
 
-  const content = hasScheduledDate
-    ? t("listings.approval.saveScheduledWithDate", {
-        date: dayjs.utc(currentScheduledPublishAt).format("MM/DD/YYYY"),
-      })
+  const content = scheduledDate
+    ? t("listings.approval.saveScheduledWithDate", { date: scheduledDate })
+    : hasPastDate
+    ? t("listings.approval.saveScheduledWithPastDate")
     : t("listings.approval.saveScheduledNoDate")
 
   return (

--- a/sites/partners/src/components/listings/PaperListingForm/index.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/index.tsx
@@ -911,6 +911,8 @@ const ListingForm = ({
         isOpen={publishDialog}
         setOpen={setPublishDialog}
         submitFormWithStatus={triggerSubmitWithStatus}
+        enableAutopublish={enableAutopublish}
+        scheduledPublishAt={scheduledPublishAtFromForm}
       />
 
       <LiveConfirmationDialog

--- a/sites/partners/src/components/listings/helpers.tsx
+++ b/sites/partners/src/components/listings/helpers.tsx
@@ -112,10 +112,11 @@ export const formatRange = (
 export function getValidFutureScheduledDate(
   scheduledPublishAt: Date | string | null | undefined
 ): string | false {
-  if (scheduledPublishAt == null || !dayjs.utc(scheduledPublishAt).isValid()) return false
-  const scheduledAtDate = dayjs.utc(scheduledPublishAt).format("MM/DD/YYYY")
-  if (dayjs().startOf("day").isBefore(dayjs(scheduledAtDate).startOf("day"))) {
-    return scheduledAtDate
+  if (scheduledPublishAt == null) return false
+  const scheduledAt = dayjs.utc(scheduledPublishAt)
+  if (!scheduledAt.isValid()) return false
+  if (dayjs().startOf("day").isBefore(scheduledAt.startOf("day"))) {
+    return scheduledAt.format("MM/DD/YYYY")
   }
   return false
 }

--- a/sites/partners/src/components/listings/helpers.tsx
+++ b/sites/partners/src/components/listings/helpers.tsx
@@ -1,4 +1,7 @@
 import React from "react"
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+dayjs.extend(utc)
 import { t } from "@bloom-housing/ui-components"
 import { Tag } from "@bloom-housing/ui-seeds"
 import { ListingsStatusEnum, MinMax } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
@@ -100,6 +103,21 @@ export const formatRange = (
   if (min == max || !max) return `${prefix}${min}${postfix}`
   if (!min) return `${prefix}${max}${postfix}`
   return `${prefix}${min}${postfix} - ${prefix}${max}${postfix}`
+}
+
+/**
+ * Returns the formatted scheduled publish date (MM/DD/YYYY) if it is valid and in the future,
+ * or false if the date is absent, invalid, or in the past.
+ */
+export function getValidFutureScheduledDate(
+  scheduledPublishAt: Date | string | null | undefined
+): string | false {
+  if (scheduledPublishAt == null || !dayjs.utc(scheduledPublishAt).isValid()) return false
+  const scheduledAtDate = dayjs.utc(scheduledPublishAt).format("MM/DD/YYYY")
+  if (dayjs().startOf("day").isBefore(dayjs(scheduledAtDate).startOf("day"))) {
+    return scheduledAtDate
+  }
+  return false
 }
 
 export function formatRentRange(rent: MinMax, percent: MinMax): string {

--- a/sites/partners/src/components/listings/helpers.tsx
+++ b/sites/partners/src/components/listings/helpers.tsx
@@ -115,7 +115,7 @@ export function getValidFutureScheduledDate(
   if (scheduledPublishAt == null) return false
   const scheduledAt = dayjs.utc(scheduledPublishAt)
   if (!scheduledAt.isValid()) return false
-  if (dayjs().startOf("day").isBefore(scheduledAt.startOf("day"))) {
+  if (dayjs.utc().startOf("day").isBefore(scheduledAt.startOf("day"))) {
     return scheduledAt.format("MM/DD/YYYY")
   }
   return false


### PR DESCRIPTION
This PR addresses #6413 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

An admin should be able to submit a listing with a scheduled publish date and have it enter the scheduled state.

## How Can This Be Tested/Reviewed?

As an admin, create a listing with a scheduled publish date. Ensure the dialog indicates it will be scheduled, and upon submitting that the status is scheduled.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
