### PR TITLE
feat: include external listings filter

### DIFF
--- a/api/src/dtos/listings/listings-filter-params.dto.ts
+++ b/api/src/dtos/listings/listings-filter-params.dto.ts
@@ -57,6 +57,7 @@ export class ListingFilterParams extends BaseFilter {
     default: [1],
   })
   @IsNumber({}, { groups: [ValidationsGroupsEnum.default], each: true })
+  @IsArray({ groups: [ValidationsGroupsEnum.default] })
   [ListingFilterKeys.bathrooms]?: number[];
 
   @Expose()
@@ -114,6 +115,14 @@ export class ListingFilterParams extends BaseFilter {
   @IsArray({ groups: [ValidationsGroupsEnum.default] })
   @FixLargeObjectArray()
   [ListingFilterKeys.ids]?: string[];
+
+  @Expose()
+  @ApiPropertyOptional({
+    type: Boolean,
+    example: false,
+  })
+  @IsBoolean({ groups: [ValidationsGroupsEnum.default] })
+  [ListingFilterKeys.includeExternal]?: boolean;
 
   @Expose()
   @ApiPropertyOptional({

--- a/api/src/enums/listings/filter-key-enum.ts
+++ b/api/src/enums/listings/filter-key-enum.ts
@@ -10,6 +10,7 @@ export enum ListingFilterKeys {
   counties = 'counties',
   homeTypes = 'homeTypes',
   ids = 'ids',
+  includeExternal = 'includeExternal',
   isVerified = 'isVerified',
   jurisdiction = 'jurisdiction',
   jurisdictions = 'jurisdictions',

--- a/api/src/services/listing-csv-export.service.ts
+++ b/api/src/services/listing-csv-export.service.ts
@@ -361,6 +361,9 @@ export class ListingCsvExporterService implements CsvExporterServiceInterface {
       jurisdictions: {
         OR: [],
       },
+      externalListingId: {
+        equals: null,
+      },
     };
 
     user.jurisdictions?.forEach((jurisdiction) => {

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -543,6 +543,24 @@ export class ListingService implements OnModuleInit {
       caseSensitive: true,
     });
 
+    const includeExternal = params?.find(
+      (f) => f[ListingFilterKeys.includeExternal] !== undefined,
+    );
+    if (
+      includeExternal === undefined ||
+      includeExternal[ListingFilterKeys.includeExternal] === false
+    ) {
+      filters.push({
+        OR: [
+          {
+            externalListingId: {
+              equals: null,
+            },
+          },
+        ],
+      });
+    }
+
     // detect combined >=/<= monthlyRent filters and add one range filter
     const rentParams =
       params?.filter((f) => f[ListingFilterKeys.monthlyRent] !== undefined) ||
@@ -3392,6 +3410,7 @@ export class ListingService implements OnModuleInit {
               lte: new Date(),
             },
           },
+          { externalListingId: { equals: null } },
         ],
       },
     });
@@ -3468,6 +3487,7 @@ export class ListingService implements OnModuleInit {
         AND: [
           { scheduledPublishAt: { not: null } },
           { scheduledPublishAt: { lte: new Date() } },
+          { externalListingId: { equals: null } },
         ],
       },
     });

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -551,13 +551,9 @@ export class ListingService implements OnModuleInit {
       includeExternal[ListingFilterKeys.includeExternal] === false
     ) {
       filters.push({
-        OR: [
-          {
-            externalListingId: {
-              equals: null,
-            },
-          },
-        ],
+        externalListingId: {
+          equals: null,
+        },
       });
     }
 

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -636,6 +636,7 @@ describe('Listing Controller Tests', () => {
     let listing5WithUnitGroups;
     let listing6WithUnitGroups;
     let listingWithWaitlistReviewOrder;
+    let externalListing;
     let jurisdictionB;
     let jurisdictionC;
     let jurisdictionDWithUnitGroups;
@@ -756,6 +757,13 @@ describe('Listing Controller Tests', () => {
       const listing3Input = await listingFactory(jurisdictionC.id, prisma);
       listing3WithUnits = await prisma.listings.create({
         data: listing3Input,
+      });
+      const externalListingInput = await listingFactory(
+        jurisdictionC.id,
+        prisma,
+      );
+      externalListing = await prisma.listings.create({
+        data: { ...externalListingInput, externalListingId: randomUUID() },
       });
       jurisdictionDWithUnitGroups = await prisma.jurisdictions.create({
         data: jurisdictionFactory(`filterableList D ${randomName()}`),
@@ -1259,8 +1267,8 @@ describe('Listing Controller Tests', () => {
         view: ListingViews.base,
         filter: [
           {
-            $comparison: Compare['='],
-            bathrooms: 1,
+            $comparison: Compare['IN'],
+            bathrooms: [1],
           },
           {
             $comparison: Compare['='],
@@ -1521,6 +1529,35 @@ describe('Listing Controller Tests', () => {
 
       const foundId = res.body.items.some(
         (elem) => elem.id === listing2WithUnits.id,
+      );
+      expect(foundId).toEqual(true);
+    });
+    it('should return a listing based on filter includeExternal', async () => {
+      const query: ListingsQueryBody = {
+        page: 1,
+        view: ListingViews.base,
+        filter: [
+          {
+            $comparison: Compare['='],
+            includeExternal: true,
+          },
+          {
+            $comparison: Compare['='],
+            jurisdiction: jurisdictionC.id,
+          },
+        ],
+      };
+
+      const res = await request(app.getHttpServer())
+        .post(`/listings/list`)
+        .send(query)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .expect(201);
+
+      expect(res.body.items.length).toBeGreaterThanOrEqual(1);
+
+      const foundId = res.body.items.some(
+        (elem) => elem.id === externalListing.id,
       );
       expect(foundId).toEqual(true);
     });

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -632,7 +632,17 @@ describe('Testing listing service', () => {
         take: 10,
         orderBy: undefined,
         where: {
-          AND: [],
+          AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+          ],
         },
         include: {
           jurisdictions: true,
@@ -721,7 +731,17 @@ describe('Testing listing service', () => {
 
       expect(prisma.listings.count).toHaveBeenCalledWith({
         where: {
-          AND: [],
+          AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+          ],
         },
       });
     });
@@ -767,6 +787,15 @@ describe('Testing listing service', () => {
         ],
         where: {
           AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
             {
               OR: [
                 {
@@ -868,6 +897,15 @@ describe('Testing listing service', () => {
       expect(prisma.listings.count).toHaveBeenCalledWith({
         where: {
           AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
             {
               OR: [
                 {
@@ -954,7 +992,17 @@ describe('Testing listing service', () => {
           },
         ],
         where: {
-          AND: [],
+          AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+          ],
         },
         include: {
           jurisdictions: true,
@@ -1001,7 +1049,17 @@ describe('Testing listing service', () => {
 
       expect(prisma.listings.count).toHaveBeenCalledWith({
         where: {
-          AND: [],
+          AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+          ],
         },
       });
     });
@@ -1020,6 +1078,15 @@ describe('Testing listing service', () => {
 
       expect(service.buildWhereClause(params)).toEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1066,6 +1133,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 name: {
                   contains: 'simple search',
                   mode: 'insensitive',
@@ -1097,6 +1173,15 @@ describe('Testing listing service', () => {
 
       expect(service.buildWhereClause(params, 'simple search')).toEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1325,6 +1410,15 @@ describe('Testing listing service', () => {
             {
               OR: [
                 {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
                   name: {
                     in: ['listing', 'name'],
                     mode: 'insensitive',
@@ -1419,6 +1513,15 @@ describe('Testing listing service', () => {
             {
               OR: [
                 {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+            {
+              OR: [
+                {
                   name: {
                     in: ['listing', 'name'],
                     mode: 'insensitive',
@@ -1485,7 +1588,17 @@ describe('Testing listing service', () => {
         take: 10,
         orderBy: undefined,
         where: {
-          AND: [],
+          AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+          ],
         },
         select: {
           name: true,
@@ -1517,7 +1630,17 @@ describe('Testing listing service', () => {
 
       expect(prisma.listings.count).toHaveBeenCalledWith({
         where: {
-          AND: [],
+          AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
+          ],
         },
       });
     });
@@ -1535,6 +1658,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1571,6 +1703,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 marketingType: {
                   equals: MarketingTypeEnum.comingSoon,
                 },
@@ -1592,6 +1733,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1646,6 +1796,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 reviewOrderType: {
                   in: [
                     ReviewOrderTypeEnum.waitlist,
@@ -1670,6 +1829,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1706,6 +1874,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1774,6 +1951,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 AND: [
                   {
                     unitGroups: {
@@ -1807,6 +1993,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 marketingType: {
                   equals: MarketingTypeEnum.comingSoon,
                 },
@@ -1828,6 +2023,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1882,6 +2086,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 reviewOrderType: {
                   in: [
                     ReviewOrderTypeEnum.waitlist,
@@ -1909,6 +2122,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 unitsAvailable: {
                   gte: 1,
                 },
@@ -1930,7 +2152,7 @@ describe('Testing listing service', () => {
 
     it('should return a where clause for filter bathrooms', () => {
       const filter = [
-        { $comparison: '=', bathrooms: 2 } as ListingFilterParams,
+        { $comparison: 'IN', bathrooms: [2] } as ListingFilterParams,
       ];
       const whereClause = service.buildWhereClause(filter, '');
 
@@ -1939,10 +2161,19 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 units: {
                   some: {
                     numBathrooms: {
-                      equals: 2,
+                      in: [2],
                     },
                   },
                 },
@@ -1959,6 +2190,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -1997,6 +2237,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2039,6 +2288,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 listingsBuildingAddress: {
                   city: {
                     equals: cityName,
@@ -2064,6 +2322,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2095,6 +2362,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 homeType: {
                   in: homeTypes,
                 },
@@ -2117,6 +2393,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2150,6 +2435,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 parkType: {
                   carport: true,
                 },
@@ -2175,6 +2469,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 id: {
                   in: uuids,
                 },
@@ -2182,6 +2485,20 @@ describe('Testing listing service', () => {
             ],
           },
         ],
+      });
+    });
+
+    it('should return an empty where clause for filter includeExternal', () => {
+      const filter = [
+        {
+          $comparison: '=',
+          includeExternal: true,
+        } as ListingFilterParams,
+      ];
+      const whereClause = service.buildWhereClause(filter, '');
+
+      expect(whereClause).toStrictEqual({
+        AND: [],
       });
     });
 
@@ -2196,6 +2513,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2224,6 +2550,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 jurisdictionId: {
                   equals: jurisdictionId,
                 },
@@ -2246,6 +2581,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2275,6 +2619,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             AND: [
               {
@@ -2307,6 +2660,15 @@ describe('Testing listing service', () => {
         AND: [
           {
             OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
               { units: { some: { accessibilityPriorityType: 'mobility' } } },
               {
                 unitGroups: { some: { accessibilityPriorityType: 'mobility' } },
@@ -2334,6 +2696,15 @@ describe('Testing listing service', () => {
         AND: [
           {
             OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
               { units: { some: { accessibilityPriorityType: 'mobility' } } },
               {
                 unitGroups: { some: { accessibilityPriorityType: 'mobility' } },
@@ -2357,6 +2728,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2411,6 +2791,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 listingMultiselectQuestions: {
                   some: {
                     multiselectQuestionId: {
@@ -2437,6 +2826,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 name: {
                   contains: name,
                   mode: 'insensitive',
@@ -2460,6 +2858,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 neighborhood: {
                   equals: neighborhood,
                   mode: 'insensitive',
@@ -2480,6 +2887,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2511,6 +2927,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 reservedCommunityTypes: {
                   name: {
                     in: reservedLowerCase,
@@ -2538,6 +2963,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 section8Acceptance: {
                   equals: false,
                 },
@@ -2557,6 +2991,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -2582,6 +3025,15 @@ describe('Testing listing service', () => {
           {
             OR: [
               {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
+          {
+            OR: [
+              {
                 listingsBuildingAddress: {
                   zipCode: {
                     equals: zipCode,
@@ -2602,6 +3054,15 @@ describe('Testing listing service', () => {
 
       expect(whereClause).toStrictEqual({
         AND: [
+          {
+            OR: [
+              {
+                externalListingId: {
+                  equals: null,
+                },
+              },
+            ],
+          },
           {
             OR: [
               {
@@ -7110,6 +7571,7 @@ describe('Testing listing service', () => {
                 lte: expect.anything(),
               },
             },
+            { externalListingId: { equals: null } },
           ],
         },
       });
@@ -7274,6 +7736,7 @@ describe('Testing listing service', () => {
           AND: [
             { scheduledPublishAt: { not: null } },
             { scheduledPublishAt: { lte: expect.any(Date) } },
+            { externalListingId: { equals: null } },
           ],
         },
       });
@@ -7487,6 +7950,15 @@ describe('Testing listing service', () => {
         },
         where: {
           AND: [
+            {
+              OR: [
+                {
+                  externalListingId: {
+                    equals: null,
+                  },
+                },
+              ],
+            },
             {
               OR: [
                 {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -634,13 +634,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
           ],
         },
@@ -733,13 +729,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
           ],
         },
@@ -788,13 +780,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
             {
               OR: [
@@ -898,13 +886,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
             {
               OR: [
@@ -994,13 +978,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
           ],
         },
@@ -1051,13 +1031,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
           ],
         },
@@ -1079,13 +1055,9 @@ describe('Testing listing service', () => {
       expect(service.buildWhereClause(params)).toEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1131,13 +1103,9 @@ describe('Testing listing service', () => {
       expect(service.buildWhereClause(null, 'simple search')).toEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1174,13 +1142,9 @@ describe('Testing listing service', () => {
       expect(service.buildWhereClause(params, 'simple search')).toEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1408,13 +1372,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
             {
               OR: [
@@ -1511,13 +1471,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
             {
               OR: [
@@ -1590,13 +1546,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
           ],
         },
@@ -1632,13 +1584,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
           ],
         },
@@ -1659,13 +1607,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1701,13 +1645,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1734,13 +1674,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1794,13 +1730,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1830,13 +1762,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1875,13 +1803,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1949,13 +1873,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -1991,13 +1911,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2024,13 +1940,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2084,13 +1996,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2120,13 +2028,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2159,13 +2063,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2191,13 +2091,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2238,13 +2134,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2286,13 +2178,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2323,13 +2211,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2360,13 +2244,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2394,13 +2274,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2433,13 +2309,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2467,13 +2339,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2514,13 +2382,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2548,13 +2412,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2582,13 +2442,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2620,13 +2476,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             AND: [
@@ -2659,13 +2511,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2695,13 +2543,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2729,13 +2573,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2789,13 +2629,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2824,13 +2660,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2856,13 +2688,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2888,13 +2716,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2925,13 +2749,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2961,13 +2781,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -2992,13 +2808,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -3023,13 +2835,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -3055,13 +2863,9 @@ describe('Testing listing service', () => {
       expect(whereClause).toStrictEqual({
         AND: [
           {
-            OR: [
-              {
-                externalListingId: {
-                  equals: null,
-                },
-              },
-            ],
+            externalListingId: {
+              equals: null,
+            },
           },
           {
             OR: [
@@ -7951,13 +7755,9 @@ describe('Testing listing service', () => {
         where: {
           AND: [
             {
-              OR: [
-                {
-                  externalListingId: {
-                    equals: null,
-                  },
-                },
-              ],
+              externalListingId: {
+                equals: null,
+              },
             },
             {
               OR: [

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -3441,6 +3441,9 @@ export interface ListingFilterParams {
   ids?: string[]
 
   /**  */
+  includeExternal?: boolean
+
+  /**  */
   isVerified?: boolean
 
   /**  */
@@ -10402,6 +10405,7 @@ export enum ListingFilterKeys {
   "counties" = "counties",
   "homeTypes" = "homeTypes",
   "ids" = "ids",
+  "includeExternal" = "includeExternal",
   "isVerified" = "isVerified",
   "jurisdiction" = "jurisdiction",
   "jurisdictions" = "jurisdictions",
@@ -10752,7 +10756,6 @@ export enum FeatureFlagEnum {
   "enableFilterByBathroom" = "enableFilterByBathroom",
   "enableFullTimeStudentQuestion" = "enableFullTimeStudentQuestion",
   "enableGenderQuestion" = "enableGenderQuestion",
-  "enableSexualOrientationQuestion" = "enableSexualOrientationQuestion",
   "enableGeocodingPreferences" = "enableGeocodingPreferences",
   "enableGeocodingRadiusMethod" = "enableGeocodingRadiusMethod",
   "enableHomeType" = "enableHomeType",
@@ -10788,6 +10791,7 @@ export enum FeatureFlagEnum {
   "enableRegions" = "enableRegions",
   "enableResources" = "enableResources",
   "enableSection8Question" = "enableSection8Question",
+  "enableSexualOrientationQuestion" = "enableSexualOrientationQuestion",
   "enableSingleUseCode" = "enableSingleUseCode",
   "enableSmokingPolicyRadio" = "enableSmokingPolicyRadio",
   "enableSpokenLanguage" = "enableSpokenLanguage",


### PR DESCRIPTION
This PR addresses [#(6363)](https://app.zenhub.com/workspaces/bloom-5dc32d7144bd400001315dac/issues/gh/bloom-housing/bloom/6363)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds new listing filter to include external listings when calling the list endpoint.

## How Can This Be Tested/Reviewed?

Create a new listing in the partners portal
Add a `externalListingId` to the listing through the DB
Listing should no longer appear in partners or on public
Export listings and confirm listing does not appear
Using the API, call POST `listings/list` with `includeExternal`: true in the filters
Returned list should contain new listing with externalListingId set


## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
