### PR TITLE
fix: autofill alternate contact for other type

### DIFF
--- a/sites/public/src/pages/applications/contact/alternate-contact-type.tsx
+++ b/sites/public/src/pages/applications/contact/alternate-contact-type.tsx
@@ -124,7 +124,7 @@ const ApplicationAlternateContactType = () => {
                         id="otherType"
                         name="otherType"
                         label={t("application.alternateContact.type.otherTypeFormPlaceholder")}
-                        defaultValue={application.alternateContact.otherType}
+                        defaultValue={application.alternateContact?.otherType}
                         validation={{ required: true, maxLength: 64 }}
                         error={errors.otherType}
                         errorMessage={


### PR DESCRIPTION
## Description

There is a bug on the auto-fill functionality for the alternate contact question if you follow these steps:

1. Go to Bloom https://bloom.exygy.dev/sign-in and login with a public account (or create a new one)
2. Apply to a listing. For the Alternate contact question select "I don't have an alternate contact"
3. After submitting while still logged in apply to a different listing (same listing works as well)
4. Use the auto-fill functionality
5. On the Alternate Contact question you'll see nothing is selected.
6. Try to select "Other". The site redirects to a 404 page.

This is because we are not saving an alternate contact if the user selects nothing and the field tries to autofill the field.

Note: this does not address how the "I don't have an alternate contact" option is not being auto filled 

## How Can This Be Tested/Reviewed?

Do the above steps and the site should allow you to proceed with entering an "other" alternate contact

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 