### PR TITLE
fix: clear publishedAt while switching to draft listing

### DIFF
--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -2925,11 +2925,11 @@ export class ListingService implements OnModuleInit {
                 },
               }
             : undefined,
-          publishedAt:
-            storedListing.status !== ListingsStatusEnum.active &&
-            incomingDto.status === ListingsStatusEnum.active
-              ? new Date()
-              : storedListing.publishedAt,
+          publishedAt: ListingService.resolvePublishedAt(
+            incomingDto.status,
+            storedListing.status,
+            storedListing.publishedAt,
+          ),
           closedAt:
             storedListing.status !== ListingsStatusEnum.closed &&
             incomingDto.status === ListingsStatusEnum.closed
@@ -3352,6 +3352,23 @@ export class ListingService implements OnModuleInit {
     const appTimezone = process.env.TIME_ZONE;
     const dateStr = dayjs.utc(scheduledPublishAt).format('YYYY-MM-DD');
     return dayjs.tz(dateStr, 'YYYY-MM-DD', appTimezone).startOf('day').toDate();
+  }
+
+  private static resolvePublishedAt(
+    incomingStatus: ListingsStatusEnum,
+    storedStatus: ListingsStatusEnum,
+    storedPublishedAt: Date | null,
+  ): Date | null {
+    if (
+      incomingStatus === ListingsStatusEnum.active &&
+      storedStatus !== ListingsStatusEnum.active
+    ) {
+      return new Date();
+    }
+    if (incomingStatus === ListingsStatusEnum.pending) {
+      return null;
+    }
+    return storedPublishedAt ?? null;
   }
 
   private checkScheduledDateIsInFuture(date: Date, fieldName: string): void {

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -6178,6 +6178,7 @@ describe('Testing listing service', () => {
           section8Acceptance: false,
           unitsAvailable: 0,
           isVerified: false,
+          publishedAt: null,
         },
         where: {
           id: expect.anything(),
@@ -6399,6 +6400,7 @@ describe('Testing listing service', () => {
           },
           isVerified: false,
           section8Acceptance: false,
+          publishedAt: null,
         },
         where: {
           id: expect.anything(),
@@ -6969,6 +6971,7 @@ describe('Testing listing service', () => {
           name: 'example listing name',
           contentUpdatedAt: expect.anything(),
           closedAt: expect.anything(),
+          publishedAt: null,
           scheduledPublishAt: null,
           scheduledApplicationOpenAt: null,
           lastUpdatedByUser: {
@@ -8014,6 +8017,82 @@ describe('Testing listing service', () => {
       const normalized =
         service.normalizeScheduledApplicationOpenAt(nonMidnight);
       expect(normalized.toISOString()).toBe('2026-05-15T16:00:00.000Z');
+    });
+  });
+
+  describe('resolvePublishedAt', () => {
+    const storedDate = new Date('2025-01-01T00:00:00.000Z');
+
+    it('pending → active: returns a new Date (first publish)', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.active,
+        ListingsStatusEnum.pending,
+        null,
+      );
+      expect(result).toBeInstanceOf(Date);
+    });
+
+    it('active → active: returns stored value (no re-stamp)', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.active,
+        ListingsStatusEnum.active,
+        storedDate,
+      );
+      expect(result).toBe(storedDate);
+    });
+
+    it('active → pending: returns null (clears publishedAt)', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.pending,
+        ListingsStatusEnum.active,
+        storedDate,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('pending → pending: returns null (was never published)', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.pending,
+        ListingsStatusEnum.pending,
+        null,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('active → closed: returns stored value', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.closed,
+        ListingsStatusEnum.active,
+        storedDate,
+      );
+      expect(result).toBe(storedDate);
+    });
+
+    it('active → changesRequested: returns stored value', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.changesRequested,
+        ListingsStatusEnum.active,
+        storedDate,
+      );
+      expect(result).toBe(storedDate);
+    });
+
+    it('active → pendingReview: returns stored value', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.pendingReview,
+        ListingsStatusEnum.active,
+        storedDate,
+      );
+      expect(result).toBe(storedDate);
+    });
+
+    it('scheduled → active: returns a new Date (scheduled auto-publish path)', () => {
+      const result = ListingService['resolvePublishedAt'](
+        ListingsStatusEnum.active,
+        ListingsStatusEnum.scheduled,
+        null,
+      );
+      expect(result).toBeInstanceOf(Date);
     });
   });
 });

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -8068,24 +8068,6 @@ describe('Testing listing service', () => {
       expect(result).toBe(storedDate);
     });
 
-    it('active → changesRequested: returns stored value', () => {
-      const result = ListingService['resolvePublishedAt'](
-        ListingsStatusEnum.changesRequested,
-        ListingsStatusEnum.active,
-        storedDate,
-      );
-      expect(result).toBe(storedDate);
-    });
-
-    it('active → pendingReview: returns stored value', () => {
-      const result = ListingService['resolvePublishedAt'](
-        ListingsStatusEnum.pendingReview,
-        ListingsStatusEnum.active,
-        storedDate,
-      );
-      expect(result).toBe(storedDate);
-    });
-
     it('scheduled → active: returns a new Date (scheduled auto-publish path)', () => {
       const result = ListingService['resolvePublishedAt'](
         ListingsStatusEnum.active,


### PR DESCRIPTION
This PR addresses #6444 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Clears `publishedAt` while listing status changes to `pending`

## How Can This Be Tested/Reviewed?

on partners unpublish listing. It should clear publishedAt.
It should add it on publish (and not modify it while editing published listing) <- so it should work as before

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
