### PR TITLE
feat: add tofu setup for SMS

### DIFF
--- a/infra/tofu_importable_modules/bloom_deployer_permission_set_policy/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployer_permission_set_policy/main.tf
@@ -89,10 +89,23 @@ data "aws_iam_policy_document" "deployer" {
       "servicediscovery:Discover*",
       "servicediscovery:Get*",
       "servicediscovery:List*",
+      "sms-voice:DescribePhoneNumbers",
       "sso:Get*",
       "sso:List*",
     ]
     resources = ["*"]
+  }
+  statement {
+    # Allow managing the Pinpoint SMS Voice V2 phone number used for SMS MFA.
+    actions = [
+      "sms-voice:ListTagsForResource",
+      "sms-voice:ReleasePhoneNumber",
+      "sms-voice:RequestPhoneNumber",
+      "sms-voice:TagResource",
+      "sms-voice:UntagResource",
+      "sms-voice:UpdatePhoneNumber",
+    ]
+    resources = ["arn:aws:sms-voice:${local.region_account}:phone-number/*"]
   }
   statement {
     # Allow any cloudshell action.

--- a/infra/tofu_importable_modules/bloom_deployer_permission_set_policy/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployer_permission_set_policy/main.tf
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "deployer" {
     resources = ["*"]
   }
   statement {
-    # Allow managing the Pinpoint SMS Voice V2 phone number used for SMS MFA.
+    # Allow managing the Pinpoint SMS Voice V2 phone number used for SMS functionality.
     actions = [
       "sms-voice:ListTagsForResource",
       "sms-voice:ReleasePhoneNumber",

--- a/infra/tofu_importable_modules/bloom_deployment/ecs.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs.tf
@@ -132,6 +132,11 @@ locals {
             Effect   = "Allow"
             Resource = aws_prometheus_workspace.bloom.arn
           },
+          {
+            Action   = "sms-voice:SendTextMessage"
+            Effect   = "Allow"
+            Resource = "*"
+          },
         ]
       })
     }

--- a/infra/tofu_importable_modules/bloom_deployment/ecs.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs.tf
@@ -135,7 +135,7 @@ locals {
           {
             Action   = "sms-voice:SendTextMessage"
             Effect   = "Allow"
-            Resource = "*"
+            Resource = "arn:aws:sms-voice:${var.aws_region}:${var.aws_account_number}:phone-number/*"
           },
         ]
       })

--- a/infra/tofu_importable_modules/bloom_deployment/ecs_api_service.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/ecs_api_service.tf
@@ -14,6 +14,9 @@ locals {
     S3_PRIVATE_BUCKET           = aws_s3_bucket.private.id
     S3_PUBLIC_BUCKET            = aws_s3_bucket.public.id
     OTEL_EXPORTER_OTLP_ENDPOINT = "http://127.0.0.1:4317"
+    SMS_PROVIDER                = var.bloom_api_sms_config == null ? "" : "aws"
+    AWS_SMS_REGION              = var.bloom_api_sms_config == null ? "" : var.aws_region
+    AWS_SMS_ORIGINATION_NUMBER  = var.bloom_api_sms_config == null ? "" : aws_pinpointsmsvoicev2_phone_number.api_sms[0].phone_number
   }
 }
 resource "aws_ecs_task_definition" "bloom_api" {

--- a/infra/tofu_importable_modules/bloom_deployment/main.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/main.tf
@@ -281,6 +281,21 @@ variable "grafana_editor_group_ids" {
   default     = []
 }
 
+variable "bloom_api_sms_config" {
+  description = "SMS configuration for the Bloom API using AWS Pinpoint SMS Voice V2. When set, provisions a phone number and configures the API to send SMS via AWS."
+  type = object({
+    number_type = optional(string, "LONG_CODE")
+  })
+  default = null
+  validation {
+    condition = var.bloom_api_sms_config == null || contains(
+      ["LONG_CODE", "TOLL_FREE", "SHORT_CODE", "TEN_DLC"],
+      var.bloom_api_sms_config.number_type
+    )
+    error_message = "number_type must be one of: LONG_CODE, TOLL_FREE, SHORT_CODE, TEN_DLC."
+  }
+}
+
 # Create a CloudTrail data store so that audit events are query-able in SQL.
 resource "aws_cloudtrail_event_data_store" "audit" {
   count = local.is_prod ? 1 : 0

--- a/infra/tofu_importable_modules/bloom_deployment/sms.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/sms.tf
@@ -1,0 +1,12 @@
+resource "aws_pinpointsmsvoicev2_phone_number" "api_sms" {
+  count            = var.bloom_api_sms_config != null ? 1 : 0
+  region           = var.aws_region
+  iso_country_code = "US"
+  message_type     = "TRANSACTIONAL"
+  number_type      = var.bloom_api_sms_config.number_type
+}
+
+output "sms_phone_number" {
+  value       = one(aws_pinpointsmsvoicev2_phone_number.api_sms[*].phone_number)
+  description = "Phone number provisioned for sending SMS (E.164 format). Null if SMS is not configured."
+}

--- a/infra/tofu_importable_modules/bloom_deployment/sms.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/sms.tf
@@ -1,10 +1,10 @@
 resource "aws_pinpointsmsvoicev2_phone_number" "api_sms" {
-  count            = var.bloom_api_sms_config != null ? 1 : 0
-  region           = var.aws_region
-  iso_country_code = "US"
-  message_type         = "TRANSACTIONAL"
-  number_type          = var.bloom_api_sms_config.number_type
-  number_capabilities  = ["SMS"]
+  count               = var.bloom_api_sms_config != null ? 1 : 0
+  region              = var.aws_region
+  iso_country_code    = "US"
+  message_type        = "TRANSACTIONAL"
+  number_type         = var.bloom_api_sms_config.number_type
+  number_capabilities = ["SMS"]
 }
 
 output "sms_phone_number" {

--- a/infra/tofu_importable_modules/bloom_deployment/sms.tf
+++ b/infra/tofu_importable_modules/bloom_deployment/sms.tf
@@ -2,8 +2,9 @@ resource "aws_pinpointsmsvoicev2_phone_number" "api_sms" {
   count            = var.bloom_api_sms_config != null ? 1 : 0
   region           = var.aws_region
   iso_country_code = "US"
-  message_type     = "TRANSACTIONAL"
-  number_type      = var.bloom_api_sms_config.number_type
+  message_type         = "TRANSACTIONAL"
+  number_type          = var.bloom_api_sms_config.number_type
+  number_capabilities  = ["SMS"]
 }
 
 output "sms_phone_number" {


### PR DESCRIPTION
This PR addresses #6227 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description
This PR adds the necessary Tofu code for setting up SMS (End User Messaging) inside of AWS.

## How Can This Be Tested/Reviewed?

The deployment is live on the aws dev deployment where you can test it for regressions

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
