### PR TITLE
fix: add listing number for request approval email

### DIFF
--- a/api/prisma/migrations/63_update_request_approval_email_translations/migration.sql
+++ b/api/prisma/migrations/63_update_request_approval_email_translations/migration.sql
@@ -1,0 +1,11 @@
+-- Adds listing file number to the request approval email
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{requestApproval}',
+  COALESCE(translations->'requestApproval', '{}'::jsonb) || '{
+    "fileNumber": "The listing file number is %{listingFileNumber}."
+  }'::jsonb
+)
+WHERE language = 'en';

--- a/api/prisma/seed-helpers/translation-factory.ts
+++ b/api/prisma/seed-helpers/translation-factory.ts
@@ -1192,6 +1192,7 @@ const translations = (
           header: 'Listing approval requested',
           partnerRequest:
             'A Partner has submitted an approval request to publish the %{listingName} listing.',
+          fileNumber: 'The listing file number is %{listingFileNumber}.',
           logInToReviewStart: 'Please log into the',
           logInToReviewEnd:
             'and navigate to the listing detail page to review and publish.',

--- a/api/src/services/email.service.ts
+++ b/api/src/services/email.service.ts
@@ -660,6 +660,7 @@ export class EmailService {
   public async requestApproval(
     jurisdictionId: IdDTO,
     listingInfo: IdDTO,
+    listingFileNumber: string,
     emails: string[],
     appUrl: string,
   ) {
@@ -669,12 +670,17 @@ export class EmailService {
       this.logger.log(
         `Sending request approval email for listing ${listingInfo.name} to ${emails.length} emails`,
       );
+      const appOptions = {
+        listingName: listingInfo.name,
+        listingFileNumber,
+      };
       await this.send(
         emails,
         jurisdiction.emailFromAddress,
-        this.polyglot.t('requestApproval.header'),
+        `${this.polyglot.t('requestApproval.header')} - ${listingInfo.name}`,
         this.template('request-approval')({
-          appOptions: { listingName: listingInfo.name },
+          appOptions,
+          listingFileNumber,
           appUrl: appUrl,
           listingUrl: `${appUrl}/listings/${listingInfo.id}`,
         }),

--- a/api/src/services/listing.service.ts
+++ b/api/src/services/listing.service.ts
@@ -417,6 +417,7 @@ export class ListingService implements OnModuleInit {
   public async listingApprovalNotify(params: {
     user: User;
     listingInfo: IdDTO;
+    listingFileNumber?: string;
     status: ListingsStatusEnum;
     approvingRoles: UserRoleEnum[];
     previousStatus?: ListingsStatusEnum;
@@ -441,6 +442,7 @@ export class ListingService implements OnModuleInit {
       await this.emailService.requestApproval(
         { id: params.jurisId },
         { id: params.listingInfo.id, name: params.listingInfo.name },
+        params.listingFileNumber,
         userInfo.emails,
         this.configService.get('PARTNERS_PORTAL_URL'),
       );
@@ -1896,6 +1898,7 @@ export class ListingService implements OnModuleInit {
       await this.listingApprovalNotify({
         user: requestingUser,
         listingInfo: { id: mappedListing.id, name: mappedListing.name },
+        listingFileNumber: mappedListing.listingFileNumber,
         status: mappedListing.status,
         approvingRoles: rawJurisdiction.listingApprovalPermissions,
         jurisId: rawJurisdiction.id,
@@ -3028,6 +3031,7 @@ export class ListingService implements OnModuleInit {
       await this.listingApprovalNotify({
         user: requestingUser,
         listingInfo: { id: mappedListing.id, name: mappedListing.name },
+        listingFileNumber: mappedListing.listingFileNumber,
         approvingRoles: listingApprovalPermissions,
         status: incomingDto.status,
         previousStatus: storedListing.status,

--- a/api/src/views/request-approval.hbs
+++ b/api/src/views/request-approval.hbs
@@ -9,7 +9,7 @@
             <p>
                 {{t "t.hello"}},
                 <br/><br/>
-                {{t "requestApproval.partnerRequest" appOptions}}
+                {{t "requestApproval.partnerRequest" appOptions}}{{#if listingFileNumber}} {{t "requestApproval.fileNumber" appOptions}}{{/if}}
                 <br/><br/>
                 {{t "requestApproval.logInToReviewStart"}} <a href="{{ appUrl }}">{{t "t.partnersPortal"}}</a> {{t "requestApproval.logInToReviewEnd"}}
                 <br/><br/>

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -3096,6 +3096,7 @@ describe('Listing Controller Tests', () => {
           id: jurisdictionA.id,
         }),
         { id: listing.id, name: val.name },
+        val.listingFileNumber,
         expect.arrayContaining([adminUser.email, jurisAdmin.email]),
         process.env.PARTNERS_PORTAL_URL,
       );

--- a/api/test/integration/listing.e2e-spec.ts
+++ b/api/test/integration/listing.e2e-spec.ts
@@ -3096,7 +3096,7 @@ describe('Listing Controller Tests', () => {
           id: jurisdictionA.id,
         }),
         { id: listing.id, name: val.name },
-        val.listingFileNumber,
+        null,
         expect.arrayContaining([adminUser.email, jurisAdmin.email]),
         process.env.PARTNERS_PORTAL_URL,
       );

--- a/api/test/unit/services/email.service.spec.ts
+++ b/api/test/unit/services/email.service.spec.ts
@@ -514,6 +514,7 @@ describe('Testing email service', () => {
       await service.requestApproval(
         { name: 'test', id: '1234' },
         { name: 'listing name', id: 'listingId' },
+        undefined,
         emailArr,
         'http://localhost:3001',
       );
@@ -521,7 +522,9 @@ describe('Testing email service', () => {
       expect(sendMock).toHaveBeenCalled();
       const emailMock = sendMock.mock.calls[0][0];
       expect(emailMock.to).toEqual(emailArr);
-      expect(emailMock.subject).toEqual('Listing approval requested');
+      expect(emailMock.subject).toEqual(
+        'Listing approval requested - listing name',
+      );
       expect(emailMock.body).toMatch(
         `<img src="https://res.cloudinary.com/exygy/image/upload/w_400,c_limit,q_65/dev/bloom_logo_generic_zgb4sg.jpg" alt="Bloom Housing Portal" height="137" width="auto" />`,
       );
@@ -531,6 +534,7 @@ describe('Testing email service', () => {
       expect(emailMock.body).toMatch(
         `A Partner has submitted an approval request to publish the listing name listing.`,
       );
+      expect(emailMock.body).not.toMatch('The listing file number is');
       expect(emailMock.body).toMatch('Please log into the');
       expect(emailMock.body).toMatch('Partners Portal');
       expect(emailMock.body).toMatch(/http:\/\/localhost:3001/);
@@ -546,6 +550,24 @@ describe('Testing email service', () => {
       );
       expect(emailMock.body).toMatch('Thank you,');
       expect(emailMock.body).toMatch('Bloom Housing Portal');
+    });
+
+    it('should include the listing file number when present', async () => {
+      const emailArr = ['testOne@xample.com'];
+      const service = await module.resolve(EmailService);
+      await service.requestApproval(
+        { name: 'test', id: '1234' },
+        { name: 'listing name', id: 'listingId' },
+        'ABC-123',
+        emailArr,
+        'http://localhost:3001',
+      );
+
+      expect(sendMock).toHaveBeenCalled();
+      const emailMock = sendMock.mock.calls[0][0];
+      expect(emailMock.body).toMatch(
+        'A Partner has submitted an approval request to publish the listing name listing. The listing file number is ABC-123.',
+      );
     });
   });
 

--- a/api/test/unit/services/listing.service.spec.ts
+++ b/api/test/unit/services/listing.service.spec.ts
@@ -7398,6 +7398,7 @@ describe('Testing listing service', () => {
       expect(requestApprovalMock).toBeCalledWith(
         { id: 'jurisId' },
         { id: 'id', name: 'name' },
+        undefined,
         ['admin@email.com'],
         config.get('PARTNERS_PORTAL_URL'),
       );


### PR DESCRIPTION
This PR addresses #6460

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds listing number for request approval email + adds listing name to subject

## How Can This Be Tested/Reviewed?

Have angelopolis listing in draft (pending) state with listing file number, and your email as admin email. Submit that listing. Email should have number, and new subject.
Check for listings without listing number if it's not broken

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
