### PR TITLE
feat: automate lottery audit workflow

### DIFF
--- a/api/.env.template
+++ b/api/.env.template
@@ -16,6 +16,8 @@ CLOUDINARY_CLOUD_NAME=exygy
 APP_SECRET="some-long-secret-key"
 # url for the proxy 
 PROXY_URL=
+# This endpoint is called after a successful lottery run. If null, the audit operation is skipped.
+LOTTERY_AUDIT_ENDPOINT=
 # the node env the app should be running as
 NODE_ENV=development
 # how long a generated multi-factor authentication code should be

--- a/api/src/modules/lottery.module.ts
+++ b/api/src/modules/lottery.module.ts
@@ -1,4 +1,5 @@
 import { Logger, Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { ApplicationExporterModule } from './application-exporter.module';
 import { ConfigService } from '@nestjs/config';
 import { EmailModule } from './email.module';
@@ -14,6 +15,7 @@ import { SnapshotCreateModule } from './snapshot-create.module';
 @Module({
   imports: [
     ApplicationExporterModule,
+    HttpModule,
     PrismaModule,
     ListingModule,
     EmailModule,

--- a/api/src/services/lottery.service.ts
+++ b/api/src/services/lottery.service.ts
@@ -9,6 +9,8 @@ import {
   Logger,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
 import {
   ApplicationSubmissionTypeEnum,
   LanguagesEnum,
@@ -69,6 +71,7 @@ export class LotteryService {
     private permissionService: PermissionService,
     private cronJobService: CronJobService,
     private snapshotCreateService: SnapshotCreateService,
+    private httpService: HttpService,
   ) {}
 
   onModuleInit() {
@@ -185,6 +188,20 @@ export class LotteryService {
         },
         user,
       );
+
+      // Trigger automated audit if the lottery audit endpoint is configured
+      const auditEndpoint = this.configService.get<string>(
+        'LOTTERY_AUDIT_ENDPOINT',
+      );
+      if (auditEndpoint) {
+        this.triggerLotteryAudit(listingId, auditEndpoint).catch(
+          (auditError) => {
+            this.logger.error(
+              `Automated lottery audit failed to trigger for listing ${listingId}: ${auditError.message}`,
+            );
+          },
+        );
+      }
     } catch (e) {
       console.error(e);
       await this.lotteryStatus(
@@ -902,5 +919,39 @@ export class LotteryService {
     });
 
     return results;
+  }
+
+  async triggerLotteryAudit(
+    listingId: string,
+    endpoint: string,
+  ): Promise<void> {
+    this.logger.warn(`Triggering lottery audit for listing ${listingId}`);
+    try {
+      await firstValueFrom(
+        this.httpService.post(
+          endpoint,
+          { ListingId: listingId },
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          },
+        ),
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to trigger lottery audit for listing ${listingId}: ${error?.message}`,
+      );
+      if (error?.response) {
+        throw new HttpException(
+          error.response?.data || 'Failed to start lottery audit',
+          error.response?.status || 500,
+        );
+      }
+      throw new HttpException(
+        error?.message || 'Failed to start lottery audit',
+        500,
+      );
+    }
   }
 }

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1,9 +1,7 @@
-import { randomUUID } from 'crypto';
-import { Request as ExpressRequest, Response } from 'express';
+import { HttpService } from '@nestjs/axios';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
-import { of, throwError } from 'rxjs';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   ListingEventsTypeEnum,
@@ -12,10 +10,9 @@ import {
   MultiselectQuestionsApplicationSectionEnum,
   ReviewOrderTypeEnum,
 } from '@prisma/client';
-import { S3Service } from '../../../src/services/s3.service';
-import { HttpService } from '@nestjs/axios';
-import { mockApplicationSet } from './application.service.spec';
-import { mockMultiselectQuestion } from './multiselect-question.service.spec';
+import { randomUUID } from 'crypto';
+import { Request as ExpressRequest, Response } from 'express';
+import { of, throwError } from 'rxjs';
 import { randomNoun } from '../../../prisma/seed-helpers/word-generator';
 import { Application } from '../../../src/dtos/applications/application.dto';
 import { ListingLotteryStatus } from '../../../src/dtos/listings/listing-lottery-status.dto';
@@ -34,8 +31,11 @@ import { LotteryService } from '../../../src/services/lottery.service';
 import { MultiselectQuestionService } from '../../../src/services/multiselect-question.service';
 import { PermissionService } from '../../../src/services/permission.service';
 import { PrismaService } from '../../../src/services/prisma.service';
+import { S3Service } from '../../../src/services/s3.service';
 import { SnapshotCreateService } from '../../../src/services/snapshot-create.service';
 import { TranslationService } from '../../../src/services/translation.service';
+import { mockApplicationSet } from './application.service.spec';
+import { mockMultiselectQuestion } from './multiselect-question.service.spec';
 
 const canOrThrowMock = jest.fn();
 const lotteryReleasedMock = jest.fn();

--- a/api/test/unit/services/lottery.service.spec.ts
+++ b/api/test/unit/services/lottery.service.spec.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'crypto';
 import { Request as ExpressRequest, Response } from 'express';
-import { HttpModule } from '@nestjs/axios';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { of, throwError } from 'rxjs';
 import { Test, TestingModule } from '@nestjs/testing';
 import {
   ListingEventsTypeEnum,
@@ -13,6 +13,7 @@ import {
   ReviewOrderTypeEnum,
 } from '@prisma/client';
 import { S3Service } from '../../../src/services/s3.service';
+import { HttpService } from '@nestjs/axios';
 import { mockApplicationSet } from './application.service.spec';
 import { mockMultiselectQuestion } from './multiselect-question.service.spec';
 import { randomNoun } from '../../../prisma/seed-helpers/word-generator';
@@ -80,15 +81,20 @@ describe('Testing lottery service', () => {
             lotteryPublishedApplicant: lotteryPublishedApplicantMock,
           },
         },
-
         ConfigService,
+        {
+          provide: HttpService,
+          useValue: {
+            post: jest.fn(),
+            get: jest.fn(),
+          },
+        },
         Logger,
         SchedulerRegistry,
         GoogleTranslateService,
         CronJobService,
         SnapshotCreateService,
       ],
-      imports: [HttpModule],
     }).compile();
 
     service = module.get<LotteryService>(LotteryService);
@@ -814,6 +820,98 @@ describe('Testing lottery service', () => {
       expect(prisma.listings.update).toHaveBeenCalled();
 
       expect(prisma.listingSnapshot.create).toHaveBeenCalled();
+    });
+
+    it('should trigger lottery audit if env variable is set', async () => {
+      const mockEndpoint = 'https://example.com/audit';
+      config.get = jest.fn().mockImplementation((key: string) => {
+        if (key === 'LOTTERY_AUDIT_ENDPOINT') return mockEndpoint;
+        return undefined; // or the real value for other keys
+      });
+      const mockWorkQueueItemId = randomUUID();
+
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        of({
+          data: { WorkQueueItemID: mockWorkQueueItemId },
+        }),
+      );
+      const listingId = randomUUID();
+      const requestingUser = {
+        firstName: 'requesting fName',
+        lastName: 'requesting lName',
+        email: 'requestingUser@email.com',
+        jurisdictions: [{ id: 'juris id' }],
+        userRoles: { isAdmin: true },
+      } as unknown as User;
+
+      canOrThrowMock.mockResolvedValue(true);
+      prisma.listings.findUnique = jest.fn().mockResolvedValue({
+        id: listingId,
+        jurisdictions: {
+          featureFlags: [],
+        },
+        lotteryLastRunAt: null,
+        lotteryStatus: null,
+        status: ListingsStatusEnum.closed,
+      });
+      const applications = mockApplicationSet(5, new Date());
+      prisma.applications.findMany = jest.fn().mockReturnValue(applications);
+
+      prisma.multiselectQuestions.findMany = jest.fn().mockReturnValue([
+        {
+          ...mockMultiselectQuestion(
+            0,
+            new Date(),
+            MultiselectQuestionsApplicationSectionEnum.preferences,
+          ),
+          options: [
+            { id: 1, text: 'text' },
+            { id: 2, text: 'text', collectAddress: true },
+          ],
+        },
+        {
+          ...mockMultiselectQuestion(
+            1,
+            new Date(),
+            MultiselectQuestionsApplicationSectionEnum.programs,
+          ),
+          options: [{ id: 1, text: 'text' }],
+        },
+      ]);
+
+      prisma.applicationLotteryTotal.create = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.applicationLotteryPositions.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.applicationLotteryTotal.createMany = jest
+        .fn()
+        .mockResolvedValue({ id: randomUUID() });
+
+      prisma.listings.update = jest.fn().mockResolvedValue({
+        id: listingId,
+        lotteryLastRunAt: null,
+        lotteryStatus: null,
+      });
+      prisma.userAccounts.findMany = jest.fn().mockResolvedValue([]);
+      prisma.listingSnapshot.create = jest
+        .fn()
+        .mockResolvedValue({ id: 'example snapshot id' });
+
+      await service.lotteryGenerate(
+        { user: requestingUser } as unknown as ExpressRequest,
+        {} as unknown as Response,
+        { id: listingId },
+      );
+      expect(httpService.post).toHaveBeenCalledWith(
+        mockEndpoint,
+        { ListingId: listingId },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
     });
   });
 
@@ -1622,6 +1720,68 @@ describe('Testing lottery service', () => {
       await expect(
         async () => await service.lotteryTotals(listingId, null),
       ).rejects.toThrowError();
+    });
+  });
+
+  describe('Testing triggerLotteryAudit()', () => {
+    it('should trigger a lottery audit and return the response', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+      const mockWorkQueueItemId = randomUUID();
+
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        of({
+          data: { WorkQueueItemID: mockWorkQueueItemId },
+        }),
+      );
+
+      await service.triggerLotteryAudit(mockListingId, mockEndpoint);
+      expect(httpService.post).toHaveBeenCalledWith(
+        mockEndpoint,
+        { ListingId: mockListingId },
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    it('should throw HttpException with 500 when HttpService returns error response', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        throwError(() => ({
+          response: {
+            status: 500,
+            data: 'Internal error from lottery audit endpoint',
+          },
+        })),
+      );
+
+      await expect(
+        async () =>
+          await service.triggerLotteryAudit(mockListingId, mockEndpoint),
+      ).rejects.toThrowError('Internal error from lottery audit endpoint');
+    });
+
+    it('should throw HttpException with 409 when HttpService returns 409', async () => {
+      const mockListingId = randomUUID();
+      const mockEndpoint = 'https://example.com/audit';
+
+      const httpService = (service as any).httpService;
+      jest.spyOn(httpService, 'post').mockReturnValue(
+        throwError(() => ({
+          response: {
+            status: 409,
+            data: 'Conflict error from lottery audit endpoint',
+          },
+        })),
+      );
+
+      await expect(
+        async () =>
+          await service.triggerLotteryAudit(mockListingId, mockEndpoint),
+      ).rejects.toThrowError('Conflict error from lottery audit endpoint');
     });
   });
 });


### PR DESCRIPTION
This PR addresses #6357 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This pulls over a [custom automated lottery audit flow](https://github.com/metrotranscom/doorway/pull/1519) from Doorway. If a url is provided in the new env variable an external call to an audit tool is triggered immediately after the lottery has been run

## How Can This Be Tested/Reviewed?

There is no external audit endpoint that we have access to but the following steps can be taken:
* Add a dummy url to `LOTTERY_AUDIT_ENDPOINT`
* Trigger a lottery and verify in the logs that the endpoint was called (warn log automatically happens and an error should happen on the actual call)
* Verify that the lottery successfully ran and everything still works

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [x] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
