### PR TITLE
add key-level translation strings and jurisdiction content

### DIFF
--- a/api/prisma/migrations/66_key_level_translation_content/migration.sql
+++ b/api/prisma/migrations/66_key_level_translation_content/migration.sql
@@ -1,0 +1,55 @@
+-- CreateEnum
+CREATE TYPE "site_enum" AS ENUM ('public', 'partners');
+
+-- CreateEnum
+CREATE TYPE "translation_origin" AS ENUM ('machine', 'human');
+
+-- CreateTable
+CREATE TABLE "jurisdiction_content" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL,
+    "jurisdiction_id" UUID NOT NULL,
+    "language" "languages_enum" NOT NULL,
+    "footer" JSONB,
+    "faq" JSONB,
+    "resources" JSONB,
+    "disclaimers" JSONB,
+    "contact" JSONB,
+
+    CONSTRAINT "jurisdiction_content_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "translation_strings" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(6) NOT NULL,
+    "jurisdiction_id" UUID,
+    "language" "languages_enum" NOT NULL,
+    "site" "site_enum",
+    "key" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "source_hash" TEXT,
+    "origin" "translation_origin",
+
+    CONSTRAINT "translation_strings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "jurisdiction_content_jurisdiction_id_language_key" ON "jurisdiction_content"("jurisdiction_id", "language");
+
+-- CreateIndex
+CREATE INDEX "translation_strings_jurisdiction_id_language_site_idx" ON "translation_strings"("jurisdiction_id", "language", "site");
+
+-- CreateIndex
+-- NULLS NOT DISTINCT (hand-added; Prisma cannot express it in the schema) so base rows (null
+-- jurisdiction_id and site) and global Partners rows (null jurisdiction_id) cannot be duplicated.
+-- Requires Postgres 15+.
+CREATE UNIQUE INDEX "translation_strings_jurisdiction_id_language_site_key_key" ON "translation_strings"("jurisdiction_id", "language", "site", "key") NULLS NOT DISTINCT;
+
+-- AddForeignKey
+ALTER TABLE "jurisdiction_content" ADD CONSTRAINT "jurisdiction_content_jurisdiction_id_fkey" FOREIGN KEY ("jurisdiction_id") REFERENCES "jurisdictions"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "translation_strings" ADD CONSTRAINT "translation_strings_jurisdiction_id_fkey" FOREIGN KEY ("jurisdiction_id") REFERENCES "jurisdictions"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/api/prisma/migrations/66_key_level_translation_content/migration.sql
+++ b/api/prisma/migrations/66_key_level_translation_content/migration.sql
@@ -40,9 +40,6 @@ CREATE TABLE "translation_strings" (
 CREATE UNIQUE INDEX "jurisdiction_content_jurisdiction_id_language_key" ON "jurisdiction_content"("jurisdiction_id", "language");
 
 -- CreateIndex
-CREATE INDEX "translation_strings_jurisdiction_id_language_site_idx" ON "translation_strings"("jurisdiction_id", "language", "site");
-
--- CreateIndex
 -- NULLS NOT DISTINCT (hand-added; Prisma cannot express it in the schema) so base rows (null
 -- jurisdiction_id and site) and global Partners rows (null jurisdiction_id) cannot be duplicated.
 -- Requires Postgres 15+.

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1764,8 +1764,8 @@ model TranslationStrings {
 
   jurisdictions Jurisdictions? @relation(fields: [jurisdictionId], references: [id], onDelete: NoAction, onUpdate: NoAction)
 
+  // The unique index is NULLS NOT DISTINCT; set in the migration, as Prisma cannot express it here.
   @@unique([jurisdictionId, language, site, key])
-  @@index([jurisdictionId, language, site])
   @@map("translation_strings")
 }
 

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -779,6 +779,27 @@ model HouseholdMemberSnapshot {
 }
 
 // Jurisdiction Section
+model JurisdictionContent {
+  id        String   @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  jurisdictionId String        @map("jurisdiction_id") @db.Uuid
+  language       LanguagesEnum
+
+  // Typed JSON documents; rich-text bodies are sanitized HTML.
+  footer      Json?
+  faq         Json?
+  resources   Json?
+  disclaimers Json?
+  contact     Json?
+
+  jurisdictions Jurisdictions @relation(fields: [jurisdictionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@unique([jurisdictionId, language])
+  @@map("jurisdiction_content")
+}
+
 model Jurisdictions {
   id        String   @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(6)
@@ -818,12 +839,14 @@ model Jurisdictions {
   agency                 Agency[]
   amiCharts              AmiChart[]
   featureFlags           FeatureFlags[]
+  jurisdictionContent    JurisdictionContent[]
   listings               Listings[]
   listingSnapshots       ListingSnapshot[]
   multiselectQuestions   MultiselectQuestions[]
   properties             Properties[]
   reservedCommunityTypes ReservedCommunityTypes[]
   translations           Translations[]
+  translationStrings     TranslationStrings[]
   user_accounts          UserAccounts[]
   userAccountSnapshot    UserAccountSnapshot[]
 
@@ -1726,6 +1749,26 @@ model ScriptRuns {
 }
 
 // Translation Section
+model TranslationStrings {
+  id        String   @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(6)
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamp(6)
+
+  jurisdictionId String?            @map("jurisdiction_id") @db.Uuid
+  language       LanguagesEnum
+  site           SiteEnum?
+  key            String
+  value          String
+  sourceHash     String?            @map("source_hash")
+  origin         TranslationOrigin?
+
+  jurisdictions Jurisdictions? @relation(fields: [jurisdictionId], references: [id], onDelete: NoAction, onUpdate: NoAction)
+
+  @@unique([jurisdictionId, language, site, key])
+  @@index([jurisdictionId, language, site])
+  @@map("translation_strings")
+}
+
 model Translations {
   id        String   @id() @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(6)
@@ -2373,6 +2416,20 @@ enum LanguagesEnum {
   fa
 
   @@map("languages_enum")
+}
+
+enum SiteEnum {
+  public
+  partners
+
+  @@map("site_enum")
+}
+
+enum TranslationOrigin {
+  machine
+  human
+
+  @@map("translation_origin")
 }
 
 enum ListingEventsTypeEnum {


### PR DESCRIPTION
This PR addresses #6508

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Adds the Phase 1 data model (content from the database): the key-level `TranslationStrings` table, the `JurisdictionContent` table, the `SiteEnum` and `TranslationOrigin` enums, and migration `66_key_level_translation_content`.

- **`TranslationStrings`**: one row per `(jurisdiction, language, site, key)` with `value`, a `source_hash` (for staleness detection in later work), and a `machine`/`human` `origin`. The unique index is created `NULLS NOT DISTINCT` in the migration SQL (Prisma cannot express it in the schema) so base rows (`null` jurisdiction and `site`) and global-Partners rows (`null` jurisdiction) cannot be duplicated.
- **`JurisdictionContent`**: typed JSON documents (`footer`, `faq`, `resources`, `disclaimers`, `contact`) per `(jurisdiction, language)`, FK to `jurisdictions` with `ON DELETE CASCADE`.
- Back-relations added on `Jurisdictions`.

The change is additive: nothing reads the new tables yet, and the legacy `translations` table is untouched. It is retired in a later ticket once the read services are switched over.

## How Can This Be Tested/Reviewed?

1. Pull the branch and apply the migration: `cd api && yarn prisma migrate deploy`. It should apply `66_key_level_translation_content` cleanly (requires Postgres 15+; Bloom runs 18).
2. Confirm the `translation_strings` unique index is `NULLS NOT DISTINCT`:
   ```sql
   SELECT indexdef FROM pg_indexes
   WHERE indexname = 'translation_strings_jurisdiction_id_language_site_key_key';
   -- ... (jurisdiction_id, language, site, key) NULLS NOT DISTINCT
   ```
3. Confirm duplicate null-keyed rows are rejected. Base rows (`null` jurisdiction and `site`):
   ```sql
   BEGIN;
   INSERT INTO translation_strings (language, key, value, updated_at) VALUES ('en','x','a',now());
   INSERT INTO translation_strings (language, key, value, updated_at) VALUES ('en','x','b',now()); -- expect unique violation
   ROLLBACK;
   ```
   And global-Partners rows (`null` jurisdiction, `site = 'partners'`) the same way; the second insert should raise a unique-constraint violation.
4. `yarn prisma migrate status` should report the schema is up to date, and `yarn prisma validate` should pass.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view (N/A: backend schema/migration only)
- [ ] Reviewed in a mobile view (N/A: backend schema/migration only)
- [ ] Reviewed considering accessibility (N/A: no UI)
- [ ] Added tests covering the changes (no unit-test surface for a schema/migration change; the models are exercised by the services in #6509+ and the integration/e2e in #6521)
- [x] Ran `yarn generate:client` and/or created a migration when required (created `66_key_level_translation_content`)

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates