### PR TITLE
fix: msq visible to draft check

### DIFF
--- a/api/src/services/multiselect-question.service.ts
+++ b/api/src/services/multiselect-question.service.ts
@@ -208,12 +208,32 @@ export class MultiselectQuestionService {
   }
 
   /*
-    this will return 1 multiselect question or error
+    this will return 1 mapped multiselect question or error
   */
   async findOne(
     multiselectQuestionId: string,
     view: MultiselectQuestionViews = MultiselectQuestionViews.fundamentals,
   ): Promise<MultiselectQuestion> {
+    const rawMultiselectQuestion = await this.findOrThrow(
+      multiselectQuestionId,
+      view,
+    );
+
+    // TODO: Can be removed after MSQ refactor
+    rawMultiselectQuestion['jurisdictions'] = [
+      rawMultiselectQuestion.jurisdiction,
+    ];
+
+    return mapTo(MultiselectQuestion, rawMultiselectQuestion);
+  }
+
+  /*
+    this will return 1 multiselect question or error
+  */
+  async findOrThrow(
+    multiselectQuestionId: string,
+    view: MultiselectQuestionViews = MultiselectQuestionViews.fundamentals,
+  ) {
     const rawMultiselectQuestion =
       await this.prisma.multiselectQuestions.findUnique({
         include: includeViews[view],
@@ -227,13 +247,7 @@ export class MultiselectQuestionService {
         `multiselectQuestionId ${multiselectQuestionId} was requested but not found`,
       );
     }
-
-    // TODO: Can be removed after MSQ refactor
-    rawMultiselectQuestion['jurisdictions'] = [
-      rawMultiselectQuestion.jurisdiction,
-    ];
-
-    return mapTo(MultiselectQuestion, rawMultiselectQuestion);
+    return rawMultiselectQuestion;
   }
 
   /*
@@ -368,7 +382,10 @@ export class MultiselectQuestionService {
       ...updateData
     } = incomingData;
 
-    const currentMultiselectQuestion = await this.findOne(id);
+    const currentMultiselectQuestion = await this.findOrThrow(
+      id,
+      MultiselectQuestionViews.base,
+    );
 
     const rawJurisdiction = await this.prisma.jurisdictions.findFirstOrThrow({
       select: {
@@ -403,6 +420,7 @@ export class MultiselectQuestionService {
       this.validateStatusStateTransition(
         currentMultiselectQuestion.status,
         status,
+        currentMultiselectQuestion.listings,
       );
     }
 
@@ -546,6 +564,7 @@ export class MultiselectQuestionService {
   validateStatusStateTransition(
     currentState: MultiselectQuestionsStatusEnum,
     nextState: MultiselectQuestionsStatusEnum,
+    listings = [],
   ) {
     if (currentState === nextState) {
       if (
@@ -575,6 +594,13 @@ export class MultiselectQuestionService {
         ) {
           throw new BadRequestException(
             "status 'visible' can only change to 'draft' or 'active'",
+          );
+        } else if (
+          nextState === MultiselectQuestionsStatusEnum.draft &&
+          listings.length > 0
+        ) {
+          throw new BadRequestException(
+            "status 'visible' can not return to 'draft' when attached to a listing",
           );
         }
         break;

--- a/api/test/unit/services/multiselect-question.service.spec.ts
+++ b/api/test/unit/services/multiselect-question.service.spec.ts
@@ -1153,6 +1153,15 @@ describe('Testing multiselect question service', () => {
           ),
         ).rejects.toThrowError();
       });
+      it('should error when moving visible to draft and is attached to listings', () => {
+        expect(async () =>
+          service.validateStatusStateTransition(
+            MultiselectQuestionsStatusEnum.visible,
+            MultiselectQuestionsStatusEnum.draft,
+            [{ listingId: 'listingId' }],
+          ),
+        ).rejects.toThrowError();
+      });
     });
 
     describe('active transitions', () => {

--- a/api/test/unit/services/multiselect-question.service.spec.ts
+++ b/api/test/unit/services/multiselect-question.service.spec.ts
@@ -833,6 +833,7 @@ describe('Testing multiselect question service', () => {
       expect(prisma.multiselectQuestions.findUnique).toHaveBeenCalledWith({
         include: {
           jurisdiction: true,
+          listings: true,
           multiselectOptions: true,
         },
         where: {
@@ -937,6 +938,7 @@ describe('Testing multiselect question service', () => {
       expect(prisma.multiselectQuestions.findUnique).toHaveBeenCalledWith({
         include: {
           jurisdiction: true,
+          listings: true,
           multiselectOptions: true,
         },
         where: {
@@ -990,6 +992,7 @@ describe('Testing multiselect question service', () => {
       expect(prisma.multiselectQuestions.findUnique).toHaveBeenCalledWith({
         include: {
           jurisdiction: true,
+          listings: true,
           multiselectOptions: true,
         },
         where: {

--- a/shared-helpers/src/auth/catchNetworkError.ts
+++ b/shared-helpers/src/auth/catchNetworkError.ts
@@ -12,7 +12,7 @@ export type NetworkStatusType = AlertTypes
 
 export type NetworkStatusError = AxiosError
 
-type CatchNetworkError = {
+export type CatchNetworkError = {
   failureCountRemaining?: number
   message?: string
 }

--- a/sites/partners/page_content/locales/general.json
+++ b/sites/partners/page_content/locales/general.json
@@ -186,6 +186,7 @@
   "authentication.createAccount.errors.tokenMissing": "Wrong token provided.",
   "authentication.createAccount.firstName": "First name",
   "authentication.createAccount.lastName": "Last name",
+  "errors.alert.attachedToListing": "This preference is attached to a listing and cannot be returned to draft",
   "errors.alert.emailConflict": "This email is already in use. Please contact your housing department if you're still experiencing issues",
   "errors.alert.listingPublishError": "There are errors in this listing that must be resolved before publishing. To see the errors, please open the listing in edit view.",
   "errors.alphaNumericError": "Please start the string with letters or numbers only",

--- a/sites/partners/src/components/settings/MultiselectQuestions/EditMultiselectQuestion.tsx
+++ b/sites/partners/src/components/settings/MultiselectQuestions/EditMultiselectQuestion.tsx
@@ -1,7 +1,12 @@
 import { AxiosError } from "axios"
 import React, { useContext, useState } from "react"
 import { useSWRConfig } from "swr"
-import { AuthContext, MessageContext, useMutate } from "@bloom-housing/shared-helpers"
+import {
+  AuthContext,
+  CatchNetworkError,
+  MessageContext,
+  useMutate,
+} from "@bloom-housing/shared-helpers"
 import {
   MultiselectQuestion,
   MultiselectQuestionCreate,
@@ -81,7 +86,7 @@ const EditMultiselectQuestion = ({
             )
             addToast(t("settings.preferenceAlertUpdated"), { variant: "success" })
           })
-          .catch((e: AxiosError) => {
+          .catch((e: AxiosError<CatchNetworkError>) => {
             if (
               e?.response?.data?.message ===
               "status 'visible' can not return to 'draft' when attached to a listing"

--- a/sites/partners/src/components/settings/MultiselectQuestions/EditMultiselectQuestion.tsx
+++ b/sites/partners/src/components/settings/MultiselectQuestions/EditMultiselectQuestion.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios"
 import React, { useContext, useState } from "react"
 import { useSWRConfig } from "swr"
 import { AuthContext, MessageContext, useMutate } from "@bloom-housing/shared-helpers"
@@ -78,10 +79,19 @@ const EditMultiselectQuestion = ({
                 ? updatedIds
                 : [...updatedIds, result.id]
             )
-            addToast(t(`settings.preferenceAlertUpdated`), { variant: "success" })
+            addToast(t("settings.preferenceAlertUpdated"), { variant: "success" })
           })
-          .catch((e) => {
-            addToast(t(`errors.alert.badRequest`), { variant: "alert" })
+          .catch((e: AxiosError) => {
+            if (
+              e?.response?.data?.message ===
+              "status 'visible' can not return to 'draft' when attached to a listing"
+            ) {
+              addToast(t("errors.alert.attachedToListing"), {
+                variant: "alert",
+              })
+            } else {
+              addToast(t("errors.alert.badRequest"), { variant: "alert" })
+            }
             console.log(e)
           })
           .finally(() => {
@@ -101,10 +111,10 @@ const EditMultiselectQuestion = ({
                 ? updatedIds
                 : [...updatedIds, result.id]
             )
-            addToast(t(`settings.preferenceAlertCreated`), { variant: "success" })
+            addToast(t("settings.preferenceAlertCreated"), { variant: "success" })
           })
           .catch((e) => {
-            addToast(t(`errors.alert.badRequest`), { variant: "alert" })
+            addToast(t("errors.alert.badRequest"), { variant: "alert" })
             console.log(e)
           })
           .finally(() => {


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

A bug was found in Doorway where one could assign a visible MSQ to a draft listing and then change the status of the MSQ back to `draft` causing problems for the listing. A check has been added to prevent returning a `visible` MSQ to `draft` once it is associated with a listing.

Open question: do we want a better error message for this than the generic one on the FE?

## How Can This Be Tested/Reviewed?

Run `yarn setup --msqV2`
Login to the partners site
Navigate to the Settings page
Create a Preference and `Show to partners`
Choose or create a draft listing and attach the visible MSQ
Return the the Settings page and attempt to return the MSQ to draft
Verify error occurs

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
