### PR TITLE
fix: update background-jobs controller response type

### DIFF
--- a/api/src/controllers/background-jobs.controller.ts
+++ b/api/src/controllers/background-jobs.controller.ts
@@ -87,7 +87,7 @@ export class BackgroundJobsController {
     summary: 'Get an active background job for a listing',
     operationId: 'findActiveJobForListing',
   })
-  @ApiOkResponse({ type: Array<BackgroundJob> })
+  @ApiOkResponse({ type: BackgroundJob, isArray: true })
   public async getListingActiveJob(
     @Request() req: ExpressRequest,
     @Query('listingId', new ParseUUIDPipe({ version: '4' })) listingId: string,

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -2588,12 +2588,24 @@ export class JobsService {
       listingId: string
     } = {} as any,
     options: IRequestOptions = {}
-  ): Promise<BackgroundJob> {
+  ): Promise<BackgroundJob[]> {
     return new Promise((resolve, reject) => {
       let url = basePath + "/jobs"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
       configs.params = { listingId: params["listingId"] }
+
+      axios(configs, resolve, reject)
+    })
+  }
+  /**
+   * Get info if any jobs are currently running
+   */
+  activeJobStatus(options: IRequestOptions = {}): Promise<SuccessDTO> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/jobs/active"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 
       axios(configs, resolve, reject)
     })
@@ -2611,18 +2623,6 @@ export class JobsService {
     return new Promise((resolve, reject) => {
       let url = basePath + "/jobs/{jobId}"
       url = url.replace("{jobId}", params["jobId"] + "")
-
-      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
-
-      axios(configs, resolve, reject)
-    })
-  }
-  /**
-   * Get info if any jobs are currently running
-   */
-  activeJobStatus(options: IRequestOptions = {}): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      let url = basePath + "/jobs/active"
 
       const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
 


### PR DESCRIPTION
This PR addresses #(insert-number-here)

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

When trying to generate the backend-swagger on main an error occurs when reading the swagger doc. This is because an incorrect type is used for a response type of a new endpoint.

## How Can This Be Tested/Reviewed?

You should be able to run `yarn generate:client` successfully

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
