### PR TITLE
fix: update land use public aplication section

### DIFF
--- a/shared-helpers/src/locales/ar.json
+++ b/shared-helpers/src/locales/ar.json
@@ -890,6 +890,7 @@
   "listings.apply.howToApply": "كيفية التقديم",
   "listings.apply.paperApplicationsMustBeMailed": "يجب إرسال الطلبات الورقية عن طريق البريد الأمريكي ولا يمكن تقديمها شخصيًا.",
   "listings.apply.pickUpAnApplication": "التقط طلبًا",
+  "listings.apply.referToLeasingAgentContact": "يرجى الرجوع إلى قسم الاتصال بوكيل التأجير أو مدير العقار أدناه لتقديم الطلب.",
   "listings.apply.sendByUsMail": "إرسال الطلب عبر البريد الأمريكي",
   "listings.apply.submitAPaperApplication": "تقديم طلب ورقي",
   "listings.apply.submitPaperDueDateNoPostMark": "يجب استلام الطلبات قبل الموعد النهائي. في حال الإرسال عبر البريد الأمريكي، يجب استلام الطلب قبل %{applicationDueDate}. %{developer} غير مسؤول عن البريد المفقود أو المتأخر.",

--- a/shared-helpers/src/locales/bn.json
+++ b/shared-helpers/src/locales/bn.json
@@ -890,6 +890,7 @@
   "listings.apply.howToApply": "কিভাবে আবেদন করবেন",
   "listings.apply.paperApplicationsMustBeMailed": "কাগজের আবেদনগুলি অবশ্যই ইউএস মেইল ​​দ্বারা পাঠানো উচিত এবং ব্যক্তিগতভাবে জমা দেওয়া যাবে না।",
   "listings.apply.pickUpAnApplication": "একটি আবেদন সংগ্রহ করুন",
+  "listings.apply.referToLeasingAgentContact": "আবেদন করার জন্য নিচের লিজ এজেন্ট বা প্রপার্টি ম্যানেজারের যোগাযোগ বিভাগটি দেখুন।",
   "listings.apply.sendByUsMail": "ইউএস মেইলের মাধ্যমে আবেদন পাঠান",
   "listings.apply.submitAPaperApplication": "একটি কাগজের আবেদন জমা দিন",
   "listings.apply.submitPaperDueDateNoPostMark": "আবেদনপত্র নির্ধারিত সময়সীমার মধ্যে গ্রহণ করতে হবে। যদি মার্কিন মেইলের মাধ্যমে পাঠানো হয়, তাহলে আবেদনপত্রটি %{applicationDueDate} এর মধ্যে গ্রহণ করতে হবে। হারিয়ে যাওয়া বা বিলম্বিত মেইলের জন্য %{developer} দায়ী নয়।",

--- a/shared-helpers/src/locales/es.json
+++ b/shared-helpers/src/locales/es.json
@@ -890,6 +890,7 @@
   "listings.apply.howToApply": "Cómo presentar una solicitud",
   "listings.apply.paperApplicationsMustBeMailed": "Las solicitudes impresas deben ser enviadas a través del Servicio Postal de los EE.UU. y no pueden ser entregadas en persona.",
   "listings.apply.pickUpAnApplication": "Recoja una solicitud.",
+  "listings.apply.referToLeasingAgentContact": "Para presentar su solicitud, consulte la sección de contacto del agente de arrendamiento o del administrador de la propiedad que aparece a continuación.",
   "listings.apply.sendByUsMail": "Enviar la solicitud a través del Servicio Postal de los EE.UU.",
   "listings.apply.submitAPaperApplication": "Envíe una solicitud impresa",
   "listings.apply.submitPaperDueDateNoPostMark": "Las solicitudes deben recibirse antes de la fecha límite. Si se envían por correo postal, deben recibirse antes del %{applicationDueDate}. %{developer} no se responsabiliza por la pérdida o el retraso del correo.",

--- a/shared-helpers/src/locales/fa.json
+++ b/shared-helpers/src/locales/fa.json
@@ -887,6 +887,7 @@
   "listings.apply.howToApply": "چگونه درخواست دهیم",
   "listings.apply.paperApplicationsMustBeMailed": "درخواست‌های کاغذی باید از طریق پست ایالات متحده ارسال شوند و نمی‌توانند حضوری ارائه شوند.",
   "listings.apply.pickUpAnApplication": "یک برنامه کاربردی بردارید",
+  "listings.apply.referToLeasingAgentContact": "برای درخواست، به بخش تماس با نماینده اجاره یا مدیر املاک در زیر مراجعه کنید.",
   "listings.apply.sendByUsMail": "ارسال درخواست از طریق پست ایالات متحده",
   "listings.apply.submitAPaperApplication": "ارسال درخواست کاغذی",
   "listings.apply.submitPaperDueDateNoPostMark": "درخواست‌ها باید تا مهلت مقرر دریافت شوند. در صورت ارسال از طریق پست ایالات متحده، درخواست باید توسط %{applicationDueDate} دریافت شود. %{developer} مسئولیتی در قبال گم شدن یا تأخیر در ارسال ندارد.",

--- a/shared-helpers/src/locales/general.json
+++ b/shared-helpers/src/locales/general.json
@@ -886,6 +886,7 @@
   "listings.apply.howToApply": "How to apply",
   "listings.apply.paperApplicationsMustBeMailed": "Paper applications must be sent by US Mail and cannot be submitted in person.",
   "listings.apply.pickUpAnApplication": "Pick up an application",
+  "listings.apply.referToLeasingAgentContact": "Refer to the leasing agent or property manager contact section below to apply.",
   "listings.apply.sendByUsMail": "Send application by US Mail",
   "listings.apply.submitAPaperApplication": "Submit a paper application",
   "listings.apply.submitPaperDueDateNoPostMark": "Applications must be received by the deadline. If sending by U.S. Mail, the application must be received by %{applicationDueDate}. %{developer} is not responsible for lost or delayed mail.",

--- a/shared-helpers/src/locales/hy.json
+++ b/shared-helpers/src/locales/hy.json
@@ -887,6 +887,7 @@
   "listings.apply.howToApply": "Ինչպես դիմել",
   "listings.apply.paperApplicationsMustBeMailed": "Թղթային դիմումները պետք է ուղարկվեն ԱՄՆ փոստով և չեն կարող անձամբ ներկայացվել։",
   "listings.apply.pickUpAnApplication": "Վերցրեք դիմում",
+  "listings.apply.referToLeasingAgentContact": "Դիմելու համար դիմեք ստորև բերված վարձակալության գործակալի կամ գույքի կառավարչի կոնտակտային բաժնին։",
   "listings.apply.sendByUsMail": "Դիմումը ուղարկեք ԱՄՆ փոստով",
   "listings.apply.submitAPaperApplication": "Ներկայացրեք թղթային դիմում",
   "listings.apply.submitPaperDueDateNoPostMark": "Դիմումները պետք է ստացվեն վերջնաժամկետին համապատասխան։ Եթե ուղարկվում են ԱՄՆ փոստով, դիմումը պետք է ստացվի մինչև %{applicationDueDate}: %{developer}-ը պատասխանատվություն չի կրում կորած կամ ուշացած փոստի համար։",

--- a/shared-helpers/src/locales/ko.json
+++ b/shared-helpers/src/locales/ko.json
@@ -887,6 +887,7 @@
   "listings.apply.howToApply": "신청 방법",
   "listings.apply.paperApplicationsMustBeMailed": "서류 신청서는 반드시 미국 우편으로 보내야 하며, 직접 제출할 수 없습니다.",
   "listings.apply.pickUpAnApplication": "신청서를 가져가세요",
+  "listings.apply.referToLeasingAgentContact": "신청하시려면 아래의 임대 담당자 또는 부동산 관리자 연락처를 참조하십시오.",
   "listings.apply.sendByUsMail": "미국 우편으로 신청서를 보내주세요.",
   "listings.apply.submitAPaperApplication": "서면 신청서를 제출하세요.",
   "listings.apply.submitPaperDueDateNoPostMark": "신청서는 마감일까지 접수되어야 합니다. 우편으로 제출하는 경우, 신청서는 %{applicationDueDate}까지 도착해야 합니다. %{developer}는 분실 또는 지연된 우편물에 대해 책임지지 않습니다.",

--- a/shared-helpers/src/locales/tl.json
+++ b/shared-helpers/src/locales/tl.json
@@ -890,6 +890,7 @@
   "listings.apply.howToApply": "Paano mag-apply",
   "listings.apply.paperApplicationsMustBeMailed": "Ang mga papel na application ay dapat ipadala sa pamamagitan ng US Mail at hindi maaaring isumite nang personal.",
   "listings.apply.pickUpAnApplication": "Pick-up-in ang application",
+  "listings.apply.referToLeasingAgentContact": "Sumangguni sa seksyong pangkontak para sa ahente ng pagpapaupa o tagapamahala ng ari-arian sa ibaba upang mag-aplay.",
   "listings.apply.sendByUsMail": "Magpadala application sa US Mail",
   "listings.apply.submitAPaperApplication": "Magsumite ng aplikasyon sa papel",
   "listings.apply.submitPaperDueDateNoPostMark": "Ang mga aplikasyon ay dapat matanggap bago ang deadline. Kung nagpapadala sa pamamagitan ng U.S. Mail, ang aplikasyon ay dapat matanggap bago ang %{applicationDueDate}. Ang %{developer} ay hindi mananagot para sa nawala o naantalang mail.",

--- a/shared-helpers/src/locales/vi.json
+++ b/shared-helpers/src/locales/vi.json
@@ -890,6 +890,7 @@
   "listings.apply.howToApply": "Cách nộp đơn",
   "listings.apply.paperApplicationsMustBeMailed": "Mẫu đơn ghi danh Giấy phải được gửi thư bưu điện Hoa Kỳ và không thể nộp trực tiếp.",
   "listings.apply.pickUpAnApplication": "Nhận đơn ghi danh",
+  "listings.apply.referToLeasingAgentContact": "Vui lòng tham khảo phần liên hệ của người đại diện cho thuê hoặc quản lý bất động sản bên dưới để nộp đơn.",
   "listings.apply.sendByUsMail": "Gửi đơn qua Bưu điện Hoa Kỳ",
   "listings.apply.submitAPaperApplication": "Nộp đơn xin giấy tờ",
   "listings.apply.submitPaperDueDateNoPostMark": "Đơn phải được nhận trước thời hạn. Nếu gửi qua Bưu điện Hoa Kỳ, đơn phải được nhận trước ngày %{applicationDueDate}. %{developer} không chịu trách nhiệm về thư bị mất hoặc bị chậm trễ.",

--- a/shared-helpers/src/locales/zh.json
+++ b/shared-helpers/src/locales/zh.json
@@ -890,6 +890,7 @@
   "listings.apply.howToApply": "如何申请",
   "listings.apply.paperApplicationsMustBeMailed": "紙本申請表必須經由美國郵政寄回，並且不能親自提交。",
   "listings.apply.pickUpAnApplication": "領取申請表",
+  "listings.apply.referToLeasingAgentContact": "如需申请，请参阅下方租赁代理或物业经理联系方式部分。",
   "listings.apply.sendByUsMail": "通过美国邮政发送申请",
   "listings.apply.submitAPaperApplication": "提交纸质申请",
   "listings.apply.submitPaperDueDateNoPostMark": "申請必須在截止日期前收到。如果透過美國郵政寄送，則必須在 %{applicationDueDate} 之前收到申請。 %{developer} 對遺失或延遲的郵件不承擔責任。",

--- a/sites/public/__tests__/components/listing/ListingViewSeedsHelpers.test.ts
+++ b/sites/public/__tests__/components/listing/ListingViewSeedsHelpers.test.ts
@@ -335,6 +335,20 @@ describe("ListingViewSeedsHelpers", () => {
       const result = getHasNonReferralMethods(mockListing)
       expect(result).toBe(0)
     })
+
+    it("should return true if listing has only a leasing agent application method", () => {
+      const mockListing: Listing = {
+        ...listing,
+        applicationMethods: [
+          {
+            type: ApplicationMethodsTypeEnum.LeasingAgent,
+          } as ApplicationMethod,
+        ],
+      }
+
+      const result = getHasNonReferralMethods(mockListing)
+      expect(result).toBe(1)
+    })
   })
 
   describe("getAccessibilityFeatures", () => {

--- a/sites/public/__tests__/components/listing/listing_sections/Apply.test.tsx
+++ b/sites/public/__tests__/components/listing/listing_sections/Apply.test.tsx
@@ -145,6 +145,79 @@ describe("<Apply>", () => {
     expect(screen.queryByText("Download application")).not.toBeInTheDocument()
   })
 
+  it("shows leasing agent contact referral instead of apply button when a LeasingAgent method exists", () => {
+    render(
+      <Apply
+        listing={{
+          ...listing,
+          applicationDueDate: dayjs(new Date()).add(5, "days").toDate(),
+          applicationMethods: [
+            {
+              id: "id",
+              createdAt: new Date(),
+              updatedAt: new Date(),
+              type: ApplicationMethodsTypeEnum.LeasingAgent,
+              acceptsPostmarkedApplications: null,
+              externalReference: null,
+              paperApplications: [],
+              phoneNumber: null,
+            },
+          ],
+          listingsApplicationPickUpAddress: {
+            id: "id",
+            city: "Pick up address city",
+            street: "Pick up address street",
+            street2: "Pick up address unit",
+            zipCode: "67890",
+            state: "CA",
+            latitude: 1,
+            longitude: 2,
+          },
+          listingsApplicationMailingAddress: {
+            id: "id",
+            city: "Mailing address city",
+            street: "Mailing address street",
+            street2: "Mailing address unit",
+            zipCode: "12345",
+            state: "CO",
+            latitude: 1,
+            longitude: 2,
+          },
+          listingsApplicationDropOffAddress: {
+            id: "id",
+            city: "Drop off address city",
+            street: "Drop off address street",
+            street2: "Drop off address unit",
+            zipCode: "45678",
+            state: "CT",
+            latitude: 1,
+            longitude: 2,
+          },
+        }}
+        preview={false}
+        setShowDownloadModal={() => null}
+      />
+    )
+    expect(screen.getByRole("heading", { level: 2, name: "How to apply" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Contact leasing agent or property manager" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Refer to the leasing agent or property manager contact section below to apply."
+      )
+    ).toBeInTheDocument()
+    expect(screen.queryByText("Apply online")).not.toBeInTheDocument()
+    expect(screen.queryByText("Download application")).not.toBeInTheDocument()
+    expect(screen.queryByText("Get a paper application")).not.toBeInTheDocument()
+    expect(screen.queryByText("Pick up an application")).not.toBeInTheDocument()
+    expect(screen.queryByText("Submit a paper application")).not.toBeInTheDocument()
+    expect(screen.queryByText("Drop off application")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Mailing address street, Mailing address unit")
+    ).not.toBeInTheDocument()
+  })
+
   it("shows apply online button for internal online application for external listing", () => {
     render(
       <Apply

--- a/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
+++ b/sites/public/src/components/listing/ListingViewSeedsHelpers.tsx
@@ -134,6 +134,10 @@ export const getHasNonReferralMethods = (listing: Listing) => {
   const nonReferralMethods = listing.applicationMethods.filter(
     (method) => method.type !== ApplicationMethodsTypeEnum.Referral
   )
+
+  if (hasMethod(nonReferralMethods, ApplicationMethodsTypeEnum.LeasingAgent)) {
+    return nonReferralMethods.length
+  }
   if (
     nonReferralMethods.length === 1 &&
     nonReferralMethods[0].type === ApplicationMethodsTypeEnum.FileDownload &&

--- a/sites/public/src/components/listing/listing_sections/Apply.tsx
+++ b/sites/public/src/components/listing/listing_sections/Apply.tsx
@@ -17,6 +17,7 @@ import {
   getMethod,
   getOnlineApplicationURL,
   getPaperApplications,
+  hasMethod,
 } from "../ListingViewSeedsHelpers"
 import listingStyles from "../ListingViewSeeds.module.scss"
 import styles from "./Apply.module.scss"
@@ -117,6 +118,11 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
 
   const hasPrimaryApplicationMethod = onlineApplicationUrl || hasPaperApplication
 
+  const hasLeasingAgentMethod = hasMethod(
+    listing.applicationMethods,
+    ApplicationMethodsTypeEnum.LeasingAgent
+  )
+
   const shouldShowApplyButton = getHasNonReferralMethods(listing)
 
   const showSection =
@@ -130,10 +136,11 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
     !scheduledApplicationOpenInFuture(listing)
 
   const showSecondarySection =
-    (hasPaperApplication && onlineApplicationUrl) ||
-    applicationMailingAddress ||
-    applicationPickUpAddress ||
-    applicationDropOffAddress
+    !hasLeasingAgentMethod &&
+    ((hasPaperApplication && onlineApplicationUrl) ||
+      applicationMailingAddress ||
+      applicationPickUpAddress ||
+      applicationDropOffAddress)
 
   if (!showSection) return <></>
 
@@ -143,18 +150,31 @@ export const Apply = ({ listing, preview, setShowDownloadModal }: ApplyProps) =>
     >
       <Card.Section
         divider="flush"
-        className={`${hasPrimaryApplicationMethod ? styles["card-section-background"] : null}`}
+        className={`${
+          !hasLeasingAgentMethod && hasPrimaryApplicationMethod
+            ? styles["card-section-background"]
+            : null
+        }`}
       >
         <Heading priority={2} size={"lg"} className={"seeds-m-be-header"}>
           {t("listings.apply.howToApply")}
         </Heading>
-        {hasPrimaryApplicationMethod && (
+        {hasLeasingAgentMethod ? (
           <>
-            {onlineApplicationUrl ? ApplyOnlineButton : DownloadApplicationButton}
-            <div className={"seeds-m-bs-content"}>
-              {listing.externalURL && t("listings.apply.applyOnlineMessage")}
-            </div>
+            <Heading priority={3} size={"md"} className={"seeds-m-be-header"}>
+              {t("leasingAgent.contactManagerProp")}
+            </Heading>
+            <p>{t("listings.apply.referToLeasingAgentContact")}</p>
           </>
+        ) : (
+          hasPrimaryApplicationMethod && (
+            <>
+              {onlineApplicationUrl ? ApplyOnlineButton : DownloadApplicationButton}
+              <div className={"seeds-m-bs-content"}>
+                {listing.externalURL && t("listings.apply.applyOnlineMessage")}
+              </div>
+            </>
+          )
         )}
       </Card.Section>
       {showSecondarySection && (


### PR DESCRIPTION
This PR addresses #6487

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Displays different application section for land use listing.
Just not fully sure if `If the leasing agent method exists, don't show any other content in there, and the section should look like:` from ticket refers to that apply card, or all those between `Apply` and `LeasingAgent` (i left them for now, as it seem it refers to data in apply section like address etc.)
<img width="738" height="128" alt="image" src="https://github.com/user-attachments/assets/c48f5192-f517-4283-aa38-f69c71e8cf2e" />


## How Can This Be Tested/Reviewed?

Set application method for listing to the one with type: `leasingAgent` (in prisma studio for example or like [here](https://github.com/bloom-housing/bloom/pull/6540) if merged). Then visit listing on public site, it's apply section should be adjusted.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
