### PR TITLE
fix: add missing unit types to database

### DIFF
--- a/api/prisma/migrations/67_add_missing_unit_types/migration.sql
+++ b/api/prisma/migrations/67_add_missing_unit_types/migration.sql
@@ -1,0 +1,39 @@
+-- Unit types have historically been created by seeding rather than by migration, so
+-- jurisdictions can be missing some (or all) of them. Insert every unit type, skipping
+-- any that already exist, so existing databases only gain what they lack and new
+-- jurisdictions get the full set.
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 0, 'studio'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'studio');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 0, 'SRO'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'SRO');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 1, 'oneBdrm'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'oneBdrm');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 2, 'twoBdrm'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'twoBdrm');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 3, 'threeBdrm'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'threeBdrm');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 4, 'fourBdrm'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'fourBdrm');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 5, 'fiveBdrm'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'fiveBdrm');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 6, 'sixBdrm'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'sixBdrm');
+
+INSERT INTO "unit_types" ("num_bedrooms", "name", "updated_at")
+SELECT 7, 'sevenBdrm'::"unit_type_enum", CURRENT_TIMESTAMP
+WHERE NOT EXISTS (SELECT 1 FROM "unit_types" WHERE "name" = 'sevenBdrm');

--- a/api/prisma/seed-helpers/unit-type-factory.ts
+++ b/api/prisma/seed-helpers/unit-type-factory.ts
@@ -22,17 +22,20 @@ export const unitTypeFactorySingle = async (
 export const unitTypeFactoryAll = async (
   prismaClient: PrismaClient,
 ): Promise<UnitTypes[]> => {
-  const all = await prismaClient.unitTypes.findMany({});
   const unitTypes = Object.values(UnitTypeEnum);
+  const all = await prismaClient.unitTypes.findMany({});
   if (all.length !== unitTypes.length) {
     await prismaClient.unitTypes.createMany({
-      data: Object.values(UnitTypeEnum).map((value) => ({
+      data: unitTypes.map((value) => ({
         name: value,
         numBedrooms: unitTypeMapping[value],
       })),
     });
   }
-  return await prismaClient.unitTypes.findMany({});
+  const created = await prismaClient.unitTypes.findMany({});
+  return unitTypes.map((value) =>
+    created.find((unitType) => unitType.name === value),
+  );
 };
 
 export const unitTypeMapping = {

--- a/api/prisma/seed-helpers/unit-type-factory.ts
+++ b/api/prisma/seed-helpers/unit-type-factory.ts
@@ -22,8 +22,8 @@ export const unitTypeFactorySingle = async (
 export const unitTypeFactoryAll = async (
   prismaClient: PrismaClient,
 ): Promise<UnitTypes[]> => {
-  const unitTypes = Object.values(UnitTypeEnum);
   const all = await prismaClient.unitTypes.findMany({});
+  const unitTypes = Object.values(UnitTypeEnum);
   if (all.length !== unitTypes.length) {
     await prismaClient.unitTypes.createMany({
       data: unitTypes.map((value) => ({


### PR DESCRIPTION
This PR addresses #6458

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

Adds missing 6 and 7 bedrooms to database, and backfills other so they will exist for new jurisdictions.
I updated test helper, so it will align to seeded unit types, as it took order from enum, which got SRO in the middle of those for some reason.

## How Can This Be Tested/Reviewed?

Our seed data have all unit_types, so remove some in database (or if you did not seed recently just 
run migration `yarn prisma migration deploy` it should add 6 and 7 bedrooms if they are missing).
It should work similar for other unit_types

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
