### PR TITLE
fix: display listing type column when land use flag is on

### DIFF
--- a/sites/partners/__tests__/pages/listings/index.test.tsx
+++ b/sites/partners/__tests__/pages/listings/index.test.tsx
@@ -53,7 +53,9 @@ function mockJurisdictionsHaveFeatureFlagOn(
   enableListingUpdatedAt = true,
   enableUnitGroups = false,
   enableHomeType = true,
-  enableSection8Question = true
+  enableSection8Question = true,
+  enableLandUse = true,
+  enableNonRegulatedListings = true
 ) {
   switch (featureFlag) {
     case FeatureFlagEnum.enableHomeType:
@@ -66,6 +68,10 @@ function mockJurisdictionsHaveFeatureFlagOn(
       return enableIsVerified
     case FeatureFlagEnum.enableListingUpdatedAt:
       return enableListingUpdatedAt
+    case FeatureFlagEnum.enableLandUse:
+      return enableLandUse
+    case FeatureFlagEnum.enableNonRegulatedListings:
+      return enableNonRegulatedListings
     default:
       return true
   }
@@ -438,6 +444,131 @@ describe("listings", () => {
     )
     expect(screen.getByText("Last updated")).toBeDefined()
   })
+
+  it("should show listing type column if only the land use feature flag is on", () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost:3100/listings", (_req, res, ctx) => {
+        return res(ctx.json({ items: [listing], meta: { totalItems: 1, totalPages: 1 } }))
+      }),
+      rest.get("http://localhost/api/adapter/listings", (_req, res, ctx) => {
+        return res(ctx.json({ items: [listing], meta: { totalItems: 1, totalPages: 1 } }))
+      }),
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            roles: { id: "user1", isAdmin: false, isPartner: true },
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      })
+    )
+
+    render(
+      <AuthContext.Provider
+        value={{
+          initialStateLoaded: true,
+          profile: {
+            ...mockUser,
+            jurisdictions: [
+              {
+                id: "id1",
+                featureFlags: [
+                  {
+                    name: FeatureFlagEnum.enableLandUse,
+                    active: true,
+                  } as FeatureFlag,
+                ],
+              } as Jurisdiction,
+            ],
+          },
+          doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
+            mockJurisdictionsHaveFeatureFlagOn(
+              featureFlag,
+              false,
+              true,
+              false,
+              true,
+              true,
+              true,
+              false
+            ),
+        }}
+      >
+        <ListingsList />
+      </AuthContext.Provider>
+    )
+    expect(screen.getByText("Listing Type")).toBeDefined()
+  })
+
+  it("should not show listing type column if no listing type feature flag is on", () => {
+    window.URL.createObjectURL = jest.fn()
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost:3100/listings", (_req, res, ctx) => {
+        return res(ctx.json({ items: [listing], meta: { totalItems: 1, totalPages: 1 } }))
+      }),
+      rest.get("http://localhost/api/adapter/listings", (_req, res, ctx) => {
+        return res(ctx.json({ items: [listing], meta: { totalItems: 1, totalPages: 1 } }))
+      }),
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            roles: { id: "user1", isAdmin: false, isPartner: true },
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      })
+    )
+
+    render(
+      <AuthContext.Provider
+        value={{
+          initialStateLoaded: true,
+          profile: {
+            ...mockUser,
+            jurisdictions: [
+              {
+                id: "id1",
+                featureFlags: [
+                  {
+                    name: FeatureFlagEnum.enableLandUse,
+                    active: false,
+                  } as FeatureFlag,
+                  {
+                    name: FeatureFlagEnum.enableNonRegulatedListings,
+                    active: false,
+                  } as FeatureFlag,
+                ],
+              } as Jurisdiction,
+            ],
+          },
+          doJurisdictionsHaveFeatureFlagOn: (featureFlag) =>
+            mockJurisdictionsHaveFeatureFlagOn(
+              featureFlag,
+              false,
+              true,
+              false,
+              true,
+              true,
+              false,
+              false
+            ),
+        }}
+      >
+        <ListingsList />
+      </AuthContext.Provider>
+    )
+    expect(screen.queryByText("Listing Type")).toBeNull()
+  })
+
   // Skipping for now until the CSV endpoints are created
   it.skip("should render the error text when listings csv api call fails", async () => {
     window.URL.createObjectURL = jest.fn()

--- a/sites/partners/src/pages/index.tsx
+++ b/sites/partners/src/pages/index.tsx
@@ -95,11 +95,6 @@ export const getFlagInAllJurisdictions = (
   }
 }
 
-export const LISTING_TYPE_FEATURE_FLAGS = [
-  FeatureFlagEnum.enableNonRegulatedListings,
-  FeatureFlagEnum.enableLandUse,
-]
-
 type CreateListingFormFields = {
   jurisdiction: string
   listingType: ListingTypeEnum
@@ -166,9 +161,7 @@ export default function ListingsList() {
     true
   )
 
-  const showListingTypeColumn = LISTING_TYPE_FEATURE_FLAGS.some((flag) =>
-    doJurisdictionsHaveFeatureFlagOn(flag, undefined, true)
-  )
+  const showListingTypeColumn = showForNonRegulated || showForLandUse
 
   useEffect(() => {
     if (defaultJurisdiction) {

--- a/sites/partners/src/pages/index.tsx
+++ b/sites/partners/src/pages/index.tsx
@@ -95,6 +95,11 @@ export const getFlagInAllJurisdictions = (
   }
 }
 
+export const LISTING_TYPE_FEATURE_FLAGS = [
+  FeatureFlagEnum.enableNonRegulatedListings,
+  FeatureFlagEnum.enableLandUse,
+]
+
 type CreateListingFormFields = {
   jurisdiction: string
   listingType: ListingTypeEnum
@@ -161,6 +166,10 @@ export default function ListingsList() {
     true
   )
 
+  const showListingTypeColumn = LISTING_TYPE_FEATURE_FLAGS.some((flag) =>
+    doJurisdictionsHaveFeatureFlagOn(flag, undefined, true)
+  )
+
   useEffect(() => {
     if (defaultJurisdiction) {
       const landUseEnabled = doJurisdictionsHaveFeatureFlagOn(FeatureFlagEnum.enableLandUse)
@@ -192,7 +201,7 @@ export default function ListingsList() {
       },
     ]
 
-    if (showForNonRegulated) {
+    if (showListingTypeColumn) {
       columns.push({
         headerName: t("listings.listingType"),
         field: "listingType",


### PR DESCRIPTION
This PR addresses #6489

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Display listing type column for land use

## How Can This Be Tested/Reviewed?

Set land use for all jurisdictions, then it should show listing type column on partners main page

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
