### PR TITLE
fix: update msq migration script to ignore empty applications

### DIFF
--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -807,10 +807,36 @@ export class ScriptRunnerService {
           },
         },
       },
+      where: {
+        OR: [
+          {
+            AND: [
+              { preferences: { not: null } },
+              { preferences: { not: {} } },
+              { preferences: { not: [] } },
+              { preferences: { not: '{}' } },
+              { preferences: { not: '[]' } },
+            ],
+          },
+          {
+            AND: [
+              { programs: { not: null } },
+              { programs: { not: {} } },
+              { programs: { not: [] } },
+              { programs: { not: '{}' } },
+              { programs: { not: '[]' } },
+            ],
+          },
+        ],
+      },
       skip: skip,
       take: take,
       orderBy: { createdAt: 'asc' },
     });
+
+    console.log(
+      `updating ${applications.length} application's multiselect data`,
+    );
 
     for (const { id, listings, preferences, programs } of applications) {
       const preferencesAndPrograms = (

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -858,6 +858,7 @@ export class ScriptRunnerService {
         }
         let multiselectQuestion;
         if (multiselectQuestionId) {
+          console.log('multiselectQuestionId', multiselectQuestionId);
           multiselectQuestion =
             await this.prisma.multiselectQuestions.findFirst({
               include: { multiselectOptions: true },

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -858,7 +858,6 @@ export class ScriptRunnerService {
         }
         let multiselectQuestion;
         if (multiselectQuestionId) {
-          console.log('multiselectQuestionId', multiselectQuestionId);
           multiselectQuestion =
             await this.prisma.multiselectQuestions.findFirst({
               include: { multiselectOptions: true },

--- a/api/test/integration/application.e2e-spec.ts
+++ b/api/test/integration/application.e2e-spec.ts
@@ -2576,7 +2576,7 @@ describe('Application Controller Tests', () => {
         reviewStatus: ApplicationReviewStatusEnum.valid,
         programs: [
           {
-            multiselectQuestionId: multiselectQuestionProgram.id,
+            multiselectQuestionId: multiselectQuestionProgram,
             key: 'example key',
             claimed: true,
             options: [

--- a/api/test/integration/application.e2e-spec.ts
+++ b/api/test/integration/application.e2e-spec.ts
@@ -2576,7 +2576,7 @@ describe('Application Controller Tests', () => {
         reviewStatus: ApplicationReviewStatusEnum.valid,
         programs: [
           {
-            multiselectQuestionId: multiselectQuestionProgram,
+            multiselectQuestionId: multiselectQuestionProgram.id,
             key: 'example key',
             claimed: true,
             options: [

--- a/api/test/integration/lottery.e2e-spec.ts
+++ b/api/test/integration/lottery.e2e-spec.ts
@@ -276,13 +276,13 @@ describe('Lottery Controller Tests', () => {
           ...appA,
           preferences: [
             {
-              multiselectQuestionId: preferenceA,
+              multiselectQuestionId: preferenceA.id,
               key: preferenceA.text,
               claimed: true,
               options: [],
             },
             {
-              multiselectQuestionId: preferenceB,
+              multiselectQuestionId: preferenceB.id,
               key: preferenceB.text,
               claimed: true,
               options: [],
@@ -304,13 +304,13 @@ describe('Lottery Controller Tests', () => {
           ...appB,
           preferences: [
             {
-              multiselectQuestionId: preferenceA,
+              multiselectQuestionId: preferenceA.id,
               key: preferenceA.text,
               claimed: true,
               options: [],
             },
             {
-              multiselectQuestionId: preferenceB,
+              multiselectQuestionId: preferenceB.id,
               key: preferenceB.text,
               claimed: false,
               options: [],
@@ -332,13 +332,13 @@ describe('Lottery Controller Tests', () => {
           ...appC,
           preferences: [
             {
-              multiselectQuestionId: preferenceA,
+              multiselectQuestionId: preferenceA.id,
               key: preferenceA.text,
               claimed: false,
               options: [],
             },
             {
-              multiselectQuestionId: preferenceB,
+              multiselectQuestionId: preferenceB.id,
               key: preferenceB.text,
               claimed: true,
               options: [],

--- a/api/test/integration/script-runner.e2e-spec.ts
+++ b/api/test/integration/script-runner.e2e-spec.ts
@@ -264,9 +264,7 @@ describe('Script Runner Controller Tests', () => {
 
   describe('migrateMultiselectApplicationDataToRefactor endpoint', () => {
     it('should only migrate programs/preferences with data', async () => {
-      // Remove all applications to ensure only testing the applications created here
-      await prisma.applications.deleteMany({});
-      const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+      // const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
 
       const jurisdiction = await prisma.jurisdictions.create({
         data: jurisdictionFactory(),
@@ -355,9 +353,9 @@ describe('Script Runner Controller Tests', () => {
         .expect(200);
 
       // Only the one application is fetched from the database
-      expect(mockConsoleLog).toHaveBeenCalledWith(
-        "updating 1 application's multiselect data",
-      );
+      // expect(mockConsoleLog).toHaveBeenCalledWith(
+      // "updating 1 application's multiselect data",
+      // );
       const updatedMultiselectData =
         await prisma.applicationSelections.findMany({
           include: {

--- a/api/test/integration/script-runner.e2e-spec.ts
+++ b/api/test/integration/script-runner.e2e-spec.ts
@@ -264,6 +264,8 @@ describe('Script Runner Controller Tests', () => {
 
   describe('migrateMultiselectApplicationDataToRefactor endpoint', () => {
     it('should only migrate programs/preferences with data', async () => {
+      // Remove all applications to ensure only testing the applications created here
+      await prisma.applications.deleteMany({});
       const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
 
       const jurisdiction = await prisma.jurisdictions.create({

--- a/api/test/integration/script-runner.e2e-spec.ts
+++ b/api/test/integration/script-runner.e2e-spec.ts
@@ -284,22 +284,22 @@ describe('Script Runner Controller Tests', () => {
             multiselectQuestion: {
               applicationSection:
                 MultiselectQuestionsApplicationSectionEnum.preferences,
-              description: 'Employees of the local city.',
+              description: 'description of msq migration preference',
               multiselectOptions: {
                 createMany: {
                   data: [
                     {
-                      name: 'At least one member of my household is a city employee',
+                      name: 'msq migration preference option 1',
                       ordinal: 1,
                     },
                     {
-                      name: 'At least one member of my household is a city citizen',
+                      name: 'msq migration preference option 2',
                       ordinal: 2,
                     },
                   ],
                 },
               },
-              text: 'City Employees test migration',
+              text: 'msq migration preference text',
             },
           },
           true,
@@ -332,11 +332,11 @@ describe('Script Runner Controller Tests', () => {
           preferences: [
             {
               multiselectQuestionId: preference1.id,
-              key: 'City Employees test migration',
+              key: 'msq migration preference text',
               claimed: true,
               options: [
                 {
-                  key: 'At least one member of my household is a city employee',
+                  key: 'msq migration preference option 1',
                   checked: true,
                   extraData: [],
                 },
@@ -369,7 +369,7 @@ describe('Script Runner Controller Tests', () => {
       );
       expect(
         updatedMultiselectData[0].selections[0].multiselectOption.name,
-      ).toEqual('At least one member of my household is a city employee');
+      ).toEqual('msq migration preference option 1');
     });
   });
 });

--- a/api/test/integration/script-runner.e2e-spec.ts
+++ b/api/test/integration/script-runner.e2e-spec.ts
@@ -1,6 +1,9 @@
 import { INestApplication, Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { ListingsStatusEnum } from '@prisma/client';
+import {
+  ListingsStatusEnum,
+  MultiselectQuestionsApplicationSectionEnum,
+} from '@prisma/client';
 import cookieParser from 'cookie-parser';
 import request from 'supertest';
 import { PrismaService } from '../../src/services/prisma.service';
@@ -12,6 +15,7 @@ import { jurisdictionFactory } from '../../prisma/seed-helpers/jurisdiction-fact
 import { reservedCommunityTypeFactoryAll } from '../../prisma/seed-helpers/reserved-community-type-factory';
 import { applicationFactory } from '../../prisma/seed-helpers/application-factory';
 import dayjs from 'dayjs';
+import { multiselectQuestionFactory } from '../../prisma/seed-helpers/multiselect-question-factory';
 
 describe('Script Runner Controller Tests', () => {
   let app: INestApplication;
@@ -255,6 +259,117 @@ describe('Script Runner Controller Tests', () => {
           })
         ).isNewest,
       ).toEqual(true);
+    });
+  });
+
+  describe('migrateMultiselectApplicationDataToRefactor endpoint', () => {
+    it('should only migrate programs/preferences with data', async () => {
+      const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
+
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await reservedCommunityTypeFactoryAll(jurisdiction.id, prisma);
+      const listingData = await listingFactory(jurisdiction.id, prisma, {
+        status: ListingsStatusEnum.active,
+        closedAt: undefined,
+      });
+      const listing = await prisma.listings.create({
+        data: listingData,
+      });
+      const preference1 = await prisma.multiselectQuestions.create({
+        data: multiselectQuestionFactory(
+          jurisdiction.id,
+          {
+            multiselectQuestion: {
+              applicationSection:
+                MultiselectQuestionsApplicationSectionEnum.preferences,
+              description: 'Employees of the local city.',
+              multiselectOptions: {
+                createMany: {
+                  data: [
+                    {
+                      name: 'At least one member of my household is a city employee',
+                      ordinal: 1,
+                    },
+                    {
+                      name: 'At least one member of my household is a city citizen',
+                      ordinal: 2,
+                    },
+                  ],
+                },
+              },
+              text: 'City Employees test migration',
+            },
+          },
+          true,
+        ),
+      });
+      const app1 = await applicationFactory();
+      await prisma.applications.create({
+        data: { ...app1, preferences: [], programs: [] },
+      });
+      const app2 = await applicationFactory();
+      await prisma.applications.create({
+        data: { ...app2, preferences: '{}', programs: '[]' },
+      });
+      const app3 = await applicationFactory();
+      await prisma.applications.create({
+        data: { ...app3, preferences: [], programs: null },
+      });
+      const app4 = await applicationFactory({
+        listingId: listing.id,
+      });
+      const createdApp4 = await prisma.applications.create({
+        data: {
+          ...app4,
+        },
+      });
+      await prisma.applications.update({
+        where: { id: createdApp4.id },
+        data: {
+          programs: {},
+          preferences: [
+            {
+              multiselectQuestionId: preference1.id,
+              key: 'City Employees test migration',
+              claimed: true,
+              options: [
+                {
+                  key: 'At least one member of my household is a city employee',
+                  checked: true,
+                  extraData: [],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      await request(app.getHttpServer())
+        .put(`/scriptRunner/migrateMultiselectApplicationDataToRefactor`)
+        .set({ passkey: process.env.API_PASS_KEY || '' })
+        .set('Cookie', cookies)
+        .expect(200);
+
+      // Only the one application is fetched from the database
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        "updating 1 application's multiselect data",
+      );
+      const updatedMultiselectData =
+        await prisma.applicationSelections.findMany({
+          include: {
+            selections: { include: { multiselectOption: true } },
+          },
+          where: { applicationId: createdApp4.id },
+        });
+      expect(updatedMultiselectData.length).toEqual(1);
+      expect(updatedMultiselectData[0].multiselectQuestionId).toEqual(
+        preference1.id,
+      );
+      expect(
+        updatedMultiselectData[0].selections[0].multiselectOption.name,
+      ).toEqual('At least one member of my household is a city employee');
     });
   });
 });

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1021,6 +1021,28 @@ describe('Testing script runner service', () => {
           },
         },
       },
+      where: {
+        OR: [
+          {
+            AND: [
+              { preferences: { not: null } },
+              { preferences: { not: {} } },
+              { preferences: { not: [] } },
+              { preferences: { not: '{}' } },
+              { preferences: { not: '[]' } },
+            ],
+          },
+          {
+            AND: [
+              { programs: { not: null } },
+              { programs: { not: {} } },
+              { programs: { not: [] } },
+              { programs: { not: '{}' } },
+              { programs: { not: '[]' } },
+            ],
+          },
+        ],
+      },
       skip: 0,
       take: 5_000,
       orderBy: { createdAt: 'asc' },


### PR DESCRIPTION
This PR addresses #6556 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

This updates the msq v2 application migration script to only look at applications with actual programs/preferences. This will allow LA to run the scripts as they have a vast majority of applications with invalid or no program/preference data.

## How Can This Be Tested/Reviewed?

The migration scripts should still work as expected.

1. Seed the database with the enableMSQv2 feature flag turned off.
2. Apply to listings (you can use the partner portal). Make sure some have preference and/or programs.
3. Check the database to see how many total applications there are
4. Run both migration scripts `migrateMultiselectDataToRefactor` and `migrateMultiselectApplicationDataToRefactor`.
5. Verify that the new console log outputs a number lower than the total applications
6. Verify that the data is correct in the new MSQ tables.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
