### PR TITLE
fix: reset password email updates

### DIFF
--- a/api/prisma/migrations/68_update_forgot_password_translations/migration.sql
+++ b/api/prisma/migrations/68_update_forgot_password_translations/migration.sql
@@ -1,0 +1,118 @@
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "Reset your password?",
+  "resetRequest": "We received a request to reset your password for your Bloom Housing Portal account. You must click the following link to complete the reset:",
+  "ignoreRequest": "This password reset is only valid for the next hour. If you didn’t make this request, please ignore this email."}'::jsonb
+)
+WHERE language = 'en';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "¿Restablecer su contraseña?",
+  "resetRequest": "Recibimos una solicitud para restablecer la contraseña de su cuenta del Portal de Vivienda Bloom. Debe hacer clic en el siguiente enlace para completar el restablecimiento:",
+  "ignoreRequest": "Este restablecimiento de contraseña solo es válido durante la próxima hora. Si usted no hizo esta solicitud, ignore este correo electrónico.",
+  }'::jsonb
+)
+WHERE language = 'es';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "Đặt lại mật khẩu của bạn?",
+  "resetRequest": "Chúng tôi đã nhận được yêu cầu đặt lại mật khẩu cho tài khoản Cổng thông tin Nhà ở Bloom của bạn. Bạn phải nhấp vào liên kết sau để hoàn tất việc đặt lại:",
+  "ignoreRequest": "Việc đặt lại mật khẩu này chỉ có hiệu lực trong một giờ tới. Nếu bạn không thực hiện yêu cầu này, vui lòng bỏ qua email này.",
+  }'::jsonb
+)
+WHERE language = 'vi';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "重置您的密码？",
+  "resetRequest": "我们收到了重置您的 Bloom 住房门户账户密码的请求。您必须点击以下链接才能完成重置：",
+  "ignoreRequest": "此密码重置仅在接下来的一小时内有效。如果您没有提出此请求，请忽略此电子邮件。",
+  '::jsonb
+)
+WHERE language = 'zh';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "I-reset ang iyong password?",
+  "resetRequest": "Nakatanggap kami ng kahilingan na i-reset ang password ng iyong account sa Bloom Housing Portal. Kailangan mong i-click ang sumusunod na link upang makumpleto ang pag-reset:",
+  "ignoreRequest": "Ang pag-reset ng password na ito ay may bisa lamang sa loob ng susunod na isang oras. Kung hindi ikaw ang gumawa ng kahilingang ito, mangyaring huwag pansinin ang email na ito.",
+  }'::jsonb
+)
+WHERE language = 'tl';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "আপনার পাসওয়ার্ড রিসেট করবেন?",
+  "resetRequest": "আমরা আপনার Bloom হাউজিং পোর্টাল অ্যাকাউন্টের পাসওয়ার্ড রিসেট করার একটি অনুরোধ পেয়েছি। রিসেট সম্পূর্ণ করতে আপনাকে অবশ্যই নিচের লিঙ্কে ক্লিক করতে হবে:",
+  "ignoreRequest": "এই পাসওয়ার্ড রিসেটটি শুধুমাত্র পরবর্তী এক ঘণ্টার জন্য বৈধ। আপনি যদি এই অনুরোধটি না করে থাকেন, তাহলে অনুগ্রহ করে এই ইমেলটি উপেক্ষা করুন।",
+  }'::jsonb
+)
+WHERE language = 'bn';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "إعادة تعيين كلمة المرور الخاصة بك؟",
+  "resetRequest": "لقد تلقينا طلباً لإعادة تعيين كلمة المرور لحسابك في بوابة Bloom للإسكان. يجب النقر على الرابط التالي لإكمال إعادة التعيين:",
+  "ignoreRequest": "إعادة تعيين كلمة المرور هذه صالحة للساعة القادمة فقط. إذا لم تقم بتقديم هذا الطلب، فيرجى تجاهل هذا البريد الإلكتروني.",
+  }'::jsonb
+)
+WHERE language = 'ar';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "비밀번호를 재설정하시겠습니까?",
+  "resetRequest": "Bloom 주택 포털 계정의 비밀번호 재설정 요청을 받았습니다. 재설정을 완료하려면 다음 링크를 클릭해야 합니다:",
+  "ignoreRequest": "이 비밀번호 재설정은 앞으로 1시간 동안만 유효합니다. 이 요청을 하지 않으셨다면 이 이메일을 무시하세요.",
+  }'::jsonb
+)
+WHERE language = 'ko';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "Վերականգնե՞լ ձեր գաղտնաբառը:",
+  "resetRequest": "Մենք ստացել ենք ձեր Bloom բնակարանային պորտալի հաշվի գաղտնաբառը վերականգնելու հարցում: Վերականգնումն ավարտելու համար դուք պետք է սեղմեք հետևյալ հղումը.",
+  "ignoreRequest": "Գաղտնաբառի այս վերականգնումը վավեր է միայն հաջորդ մեկ ժամվա ընթացքում: Եթե դուք չեք կատարել այս հարցումը, խնդրում ենք անտեսել այս նամակը:",
+  }'::jsonb
+)
+WHERE language = 'hy';
+
+UPDATE translations
+SET translations = jsonb_set(
+  translations,
+  '{forgotPassword}',
+  COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
+  "subject": "بازنشانی رمز عبور شما؟",
+  "resetRequest": "ما درخواستی برای بازنشانی رمز عبور حساب پورتال مسکن Bloom شما دریافت کردیم. برای تکمیل بازنشانی باید روی پیوند زیر کلیک کنید:",
+  "ignoreRequest": "این بازنشانی رمز عبور فقط تا یک ساعت آینده معتبر است. اگر شما این درخواست را ثبت نکرده‌اید، لطفاً این ایمیل را نادیده بگیرید.",
+  }'::jsonb
+)
+WHERE language = 'fa';

--- a/api/prisma/migrations/68_update_forgot_password_translations/migration.sql
+++ b/api/prisma/migrations/68_update_forgot_password_translations/migration.sql
@@ -1,3 +1,5 @@
+-- Rewords the password reset email and adds forgotPassword translations for every language
+
 UPDATE translations
 SET translations = jsonb_set(
   translations,
@@ -5,7 +7,8 @@ SET translations = jsonb_set(
   COALESCE(translations->'forgotPassword', '{}'::jsonb) || '{
   "subject": "Reset your password?",
   "resetRequest": "We received a request to reset your password for your Bloom Housing Portal account. You must click the following link to complete the reset:",
-  "ignoreRequest": "This password reset is only valid for the next hour. If you didn’t make this request, please ignore this email."}'::jsonb
+  "ignoreRequest": "This password reset is only valid for the next hour. If you didn’t make this request, please ignore this email.",
+  "changePassword": "Change my password"}'::jsonb
 )
 WHERE language = 'en';
 
@@ -17,7 +20,7 @@ SET translations = jsonb_set(
   "subject": "¿Restablecer su contraseña?",
   "resetRequest": "Recibimos una solicitud para restablecer la contraseña de su cuenta del Portal de Vivienda Bloom. Debe hacer clic en el siguiente enlace para completar el restablecimiento:",
   "ignoreRequest": "Este restablecimiento de contraseña solo es válido durante la próxima hora. Si usted no hizo esta solicitud, ignore este correo electrónico.",
-  }'::jsonb
+  "changePassword": "Cambiar mi contraseña"}'::jsonb
 )
 WHERE language = 'es';
 
@@ -29,7 +32,7 @@ SET translations = jsonb_set(
   "subject": "Đặt lại mật khẩu của bạn?",
   "resetRequest": "Chúng tôi đã nhận được yêu cầu đặt lại mật khẩu cho tài khoản Cổng thông tin Nhà ở Bloom của bạn. Bạn phải nhấp vào liên kết sau để hoàn tất việc đặt lại:",
   "ignoreRequest": "Việc đặt lại mật khẩu này chỉ có hiệu lực trong một giờ tới. Nếu bạn không thực hiện yêu cầu này, vui lòng bỏ qua email này.",
-  }'::jsonb
+  "changePassword": "Thay đổi mật khẩu của tôi"}'::jsonb
 )
 WHERE language = 'vi';
 
@@ -41,7 +44,7 @@ SET translations = jsonb_set(
   "subject": "重置您的密码？",
   "resetRequest": "我们收到了重置您的 Bloom 住房门户账户密码的请求。您必须点击以下链接才能完成重置：",
   "ignoreRequest": "此密码重置仅在接下来的一小时内有效。如果您没有提出此请求，请忽略此电子邮件。",
-  '::jsonb
+  "changePassword": "更改我的密码"}'::jsonb
 )
 WHERE language = 'zh';
 
@@ -53,7 +56,7 @@ SET translations = jsonb_set(
   "subject": "I-reset ang iyong password?",
   "resetRequest": "Nakatanggap kami ng kahilingan na i-reset ang password ng iyong account sa Bloom Housing Portal. Kailangan mong i-click ang sumusunod na link upang makumpleto ang pag-reset:",
   "ignoreRequest": "Ang pag-reset ng password na ito ay may bisa lamang sa loob ng susunod na isang oras. Kung hindi ikaw ang gumawa ng kahilingang ito, mangyaring huwag pansinin ang email na ito.",
-  }'::jsonb
+  "changePassword": "Baguhin ang aking password"}'::jsonb
 )
 WHERE language = 'tl';
 
@@ -65,7 +68,7 @@ SET translations = jsonb_set(
   "subject": "আপনার পাসওয়ার্ড রিসেট করবেন?",
   "resetRequest": "আমরা আপনার Bloom হাউজিং পোর্টাল অ্যাকাউন্টের পাসওয়ার্ড রিসেট করার একটি অনুরোধ পেয়েছি। রিসেট সম্পূর্ণ করতে আপনাকে অবশ্যই নিচের লিঙ্কে ক্লিক করতে হবে:",
   "ignoreRequest": "এই পাসওয়ার্ড রিসেটটি শুধুমাত্র পরবর্তী এক ঘণ্টার জন্য বৈধ। আপনি যদি এই অনুরোধটি না করে থাকেন, তাহলে অনুগ্রহ করে এই ইমেলটি উপেক্ষা করুন।",
-  }'::jsonb
+  "changePassword": "আমার পাসওয়ার্ড পরিবর্তন করুন"}'::jsonb
 )
 WHERE language = 'bn';
 
@@ -77,7 +80,7 @@ SET translations = jsonb_set(
   "subject": "إعادة تعيين كلمة المرور الخاصة بك؟",
   "resetRequest": "لقد تلقينا طلباً لإعادة تعيين كلمة المرور لحسابك في بوابة Bloom للإسكان. يجب النقر على الرابط التالي لإكمال إعادة التعيين:",
   "ignoreRequest": "إعادة تعيين كلمة المرور هذه صالحة للساعة القادمة فقط. إذا لم تقم بتقديم هذا الطلب، فيرجى تجاهل هذا البريد الإلكتروني.",
-  }'::jsonb
+  "changePassword": "تغيير كلمة المرور الخاصة بي"}'::jsonb
 )
 WHERE language = 'ar';
 
@@ -89,7 +92,7 @@ SET translations = jsonb_set(
   "subject": "비밀번호를 재설정하시겠습니까?",
   "resetRequest": "Bloom 주택 포털 계정의 비밀번호 재설정 요청을 받았습니다. 재설정을 완료하려면 다음 링크를 클릭해야 합니다:",
   "ignoreRequest": "이 비밀번호 재설정은 앞으로 1시간 동안만 유효합니다. 이 요청을 하지 않으셨다면 이 이메일을 무시하세요.",
-  }'::jsonb
+  "changePassword": "내 비밀번호 변경"}'::jsonb
 )
 WHERE language = 'ko';
 
@@ -101,7 +104,7 @@ SET translations = jsonb_set(
   "subject": "Վերականգնե՞լ ձեր գաղտնաբառը:",
   "resetRequest": "Մենք ստացել ենք ձեր Bloom բնակարանային պորտալի հաշվի գաղտնաբառը վերականգնելու հարցում: Վերականգնումն ավարտելու համար դուք պետք է սեղմեք հետևյալ հղումը.",
   "ignoreRequest": "Գաղտնաբառի այս վերականգնումը վավեր է միայն հաջորդ մեկ ժամվա ընթացքում: Եթե դուք չեք կատարել այս հարցումը, խնդրում ենք անտեսել այս նամակը:",
-  }'::jsonb
+  "changePassword": "Փոխել իմ գաղտնաբառը"}'::jsonb
 )
 WHERE language = 'hy';
 
@@ -113,6 +116,6 @@ SET translations = jsonb_set(
   "subject": "بازنشانی رمز عبور شما؟",
   "resetRequest": "ما درخواستی برای بازنشانی رمز عبور حساب پورتال مسکن Bloom شما دریافت کردیم. برای تکمیل بازنشانی باید روی پیوند زیر کلیک کنید:",
   "ignoreRequest": "این بازنشانی رمز عبور فقط تا یک ساعت آینده معتبر است. اگر شما این درخواست را ثبت نکرده‌اید، لطفاً این ایمیل را نادیده بگیرید.",
-  }'::jsonb
+  "changePassword": "تغییر رمز عبور من"}'::jsonb
 )
 WHERE language = 'fa';

--- a/api/prisma/seed-helpers/translation-factory.ts
+++ b/api/prisma/seed-helpers/translation-factory.ts
@@ -160,6 +160,7 @@ const translations = (
             'Recibimos una solicitud para restablecer la contraseña de su cuenta del Portal de Vivienda Bloom. Debe hacer clic en el siguiente enlace para completar el restablecimiento:',
           ignoreRequest:
             'Este restablecimiento de contraseña solo es válido durante la próxima hora. Si usted no hizo esta solicitud, ignore este correo electrónico.',
+          changePassword: 'Cambiar mi contraseña',
         },
         rentalOpportunity: {
           subject: 'Nueva oportunidad de alquiler en %{listingName}',
@@ -272,6 +273,7 @@ const translations = (
             'Chúng tôi đã nhận được yêu cầu đặt lại mật khẩu cho tài khoản Cổng thông tin Nhà ở Bloom của bạn. Bạn phải nhấp vào liên kết sau để hoàn tất việc đặt lại:',
           ignoreRequest:
             'Việc đặt lại mật khẩu này chỉ có hiệu lực trong một giờ tới. Nếu bạn không thực hiện yêu cầu này, vui lòng bỏ qua email này.',
+          changePassword: 'Thay đổi mật khẩu của tôi',
         },
         rentalOpportunity: {
           subject: 'Cơ hội thuê nhà mới tại %{listingName}',
@@ -379,6 +381,7 @@ const translations = (
             '我们收到了重置您的 Bloom 住房门户账户密码的请求。您必须点击以下链接才能完成重置：',
           ignoreRequest:
             '此密码重置仅在接下来的一小时内有效。如果您没有提出此请求，请忽略此电子邮件。',
+          changePassword: '更改我的密码',
         },
         rentalOpportunity: {
           subject: '新租赁机会：%{listingName}',
@@ -489,6 +492,7 @@ const translations = (
             'Nakatanggap kami ng kahilingan na i-reset ang password ng iyong account sa Bloom Housing Portal. Kailangan mong i-click ang sumusunod na link upang makumpleto ang pag-reset:',
           ignoreRequest:
             'Ang pag-reset ng password na ito ay may bisa lamang sa loob ng susunod na isang oras. Kung hindi ikaw ang gumawa ng kahilingang ito, mangyaring huwag pansinin ang email na ito.',
+          changePassword: 'Baguhin ang aking password',
         },
         rentalOpportunity: {
           subject: 'Bagong pagkakataon sa pag-upa sa %{listingName}',
@@ -601,6 +605,7 @@ const translations = (
             'আমরা আপনার Bloom হাউজিং পোর্টাল অ্যাকাউন্টের পাসওয়ার্ড রিসেট করার একটি অনুরোধ পেয়েছি। রিসেট সম্পূর্ণ করতে আপনাকে অবশ্যই নিচের লিঙ্কে ক্লিক করতে হবে:',
           ignoreRequest:
             'এই পাসওয়ার্ড রিসেটটি শুধুমাত্র পরবর্তী এক ঘণ্টার জন্য বৈধ। আপনি যদি এই অনুরোধটি না করে থাকেন, তাহলে অনুগ্রহ করে এই ইমেলটি উপেক্ষা করুন।',
+          changePassword: 'আমার পাসওয়ার্ড পরিবর্তন করুন',
         },
         rentalOpportunity: {
           subject: '%{listingName}-এ নতুন ভাড়ার সুযোগ',
@@ -709,6 +714,7 @@ const translations = (
             'لقد تلقينا طلباً لإعادة تعيين كلمة المرور لحسابك في بوابة Bloom للإسكان. يجب النقر على الرابط التالي لإكمال إعادة التعيين:',
           ignoreRequest:
             'إعادة تعيين كلمة المرور هذه صالحة للساعة القادمة فقط. إذا لم تقم بتقديم هذا الطلب، فيرجى تجاهل هذا البريد الإلكتروني.',
+          changePassword: 'تغيير كلمة المرور الخاصة بي',
         },
         rentalOpportunity: {
           subject: 'فرصة إيجار جديدة في %{listingName}',
@@ -818,6 +824,7 @@ const translations = (
             'Bloom 주택 포털 계정의 비밀번호 재설정 요청을 받았습니다. 재설정을 완료하려면 다음 링크를 클릭해야 합니다:',
           ignoreRequest:
             '이 비밀번호 재설정은 앞으로 1시간 동안만 유효합니다. 이 요청을 하지 않으셨다면 이 이메일을 무시하세요.',
+          changePassword: '내 비밀번호 변경',
         },
         rentalOpportunity: {
           subject: '%{listingName}의 새로운 임대 기회',
@@ -927,6 +934,7 @@ const translations = (
             'Մենք ստացել ենք ձեր Bloom բնակարանային պորտալի հաշվի գաղտնաբառը վերականգնելու հարցում: Վերականգնումն ավարտելու համար դուք պետք է սեղմեք հետևյալ հղումը.',
           ignoreRequest:
             'Գաղտնաբառի այս վերականգնումը վավեր է միայն հաջորդ մեկ ժամվա ընթացքում: Եթե դուք չեք կատարել այս հարցումը, խնդրում ենք անտեսել այս նամակը:',
+          changePassword: 'Փոխել իմ գաղտնաբառը',
         },
         rentalOpportunity: {
           subject: 'Նոր վարձակալության հնարավորություն՝ %{listingName}',
@@ -1039,6 +1047,7 @@ const translations = (
             'ما درخواستی برای بازنشانی رمز عبور حساب پورتال مسکن Bloom شما دریافت کردیم. برای تکمیل بازنشانی باید روی پیوند زیر کلیک کنید:',
           ignoreRequest:
             'این بازنشانی رمز عبور فقط تا یک ساعت آینده معتبر است. اگر شما این درخواست را ثبت نکرده‌اید، لطفاً این ایمیل را نادیده بگیرید.',
+          changePassword: 'تغییر رمز عبور من',
         },
         rentalOpportunity: {
           subject: 'فرصت اجاره جدید در %{listingName}',
@@ -1290,6 +1299,7 @@ const translations = (
             'We received a request to reset your password for your Bloom Housing Portal account. You must click the following link to complete the reset:',
           ignoreRequest:
             'This password reset is only valid for the next hour. If you didn’t make this request, please ignore this email.',
+          changePassword: 'Change my password',
         },
         requestApproval: {
           header: 'Listing approval requested',

--- a/api/prisma/seed-helpers/translation-factory.ts
+++ b/api/prisma/seed-helpers/translation-factory.ts
@@ -154,6 +154,13 @@ const translations = (
             'Si cree que esta decisión fue un error o tiene preguntas sobre la elegibilidad, comuníquese con nosotros en',
           rejectionInfoEnd: 'para obtener más información.',
         },
+        forgotPassword: {
+          subject: '¿Restablecer su contraseña?',
+          resetRequest:
+            'Recibimos una solicitud para restablecer la contraseña de su cuenta del Portal de Vivienda Bloom. Debe hacer clic en el siguiente enlace para completar el restablecimiento:',
+          ignoreRequest:
+            'Este restablecimiento de contraseña solo es válido durante la próxima hora. Si usted no hizo esta solicitud, ignore este correo electrónico.',
+        },
         rentalOpportunity: {
           subject: 'Nueva oportunidad de alquiler en %{listingName}',
           intro: 'Oportunidad de alquiler en',
@@ -259,6 +266,13 @@ const translations = (
             'Nếu bạn tin rằng quyết định này được đưa ra do sai sót hoặc có câu hỏi về đủ điều kiện, vui lòng liên hệ với chúng tôi tại',
           rejectionInfoEnd: 'để biết thêm thông tin.',
         },
+        forgotPassword: {
+          subject: 'Đặt lại mật khẩu của bạn?',
+          resetRequest:
+            'Chúng tôi đã nhận được yêu cầu đặt lại mật khẩu cho tài khoản Cổng thông tin Nhà ở Bloom của bạn. Bạn phải nhấp vào liên kết sau để hoàn tất việc đặt lại:',
+          ignoreRequest:
+            'Việc đặt lại mật khẩu này chỉ có hiệu lực trong một giờ tới. Nếu bạn không thực hiện yêu cầu này, vui lòng bỏ qua email này.',
+        },
         rentalOpportunity: {
           subject: 'Cơ hội thuê nhà mới tại %{listingName}',
           intro: 'Cơ hội thuê nhà tại',
@@ -358,6 +372,13 @@ const translations = (
           rejectionInfoStart:
             '如果您认为这个决定是错误的或对资格有疑问，请通过以下方式与我们联系',
           rejectionInfoEnd: '获取更多信息。',
+        },
+        forgotPassword: {
+          subject: '重置您的密码？',
+          resetRequest:
+            '我们收到了重置您的 Bloom 住房门户账户密码的请求。您必须点击以下链接才能完成重置：',
+          ignoreRequest:
+            '此密码重置仅在接下来的一小时内有效。如果您没有提出此请求，请忽略此电子邮件。',
         },
         rentalOpportunity: {
           subject: '新租赁机会：%{listingName}',
@@ -461,6 +482,13 @@ const translations = (
           rejectionInfoStart:
             'Kung naniniwala ka na ang desisyon na ito ay nagawa sa error o mayroon kang mga tanong tungkol sa eligibility, mangyaring makipag-ugnayan sa amin sa',
           rejectionInfoEnd: 'para sa higit pang impormasyon.',
+        },
+        forgotPassword: {
+          subject: 'I-reset ang iyong password?',
+          resetRequest:
+            'Nakatanggap kami ng kahilingan na i-reset ang password ng iyong account sa Bloom Housing Portal. Kailangan mong i-click ang sumusunod na link upang makumpleto ang pag-reset:',
+          ignoreRequest:
+            'Ang pag-reset ng password na ito ay may bisa lamang sa loob ng susunod na isang oras. Kung hindi ikaw ang gumawa ng kahilingang ito, mangyaring huwag pansinin ang email na ito.',
         },
         rentalOpportunity: {
           subject: 'Bagong pagkakataon sa pag-upa sa %{listingName}',
@@ -567,6 +595,13 @@ const translations = (
             'যদি আপনি বিশ্বাস করেন যে এই সিদ্ধান্তটি ত্রুটিতে নেওয়া হয়েছে বা যোগ্যতা সম্পর্কে প্রশ্ন থাকে, দয়া করে আমাদের সাথে যোগাযোগ করুন',
           rejectionInfoEnd: 'আরও তথ্যের জন্য।',
         },
+        forgotPassword: {
+          subject: 'আপনার পাসওয়ার্ড রিসেট করবেন?',
+          resetRequest:
+            'আমরা আপনার Bloom হাউজিং পোর্টাল অ্যাকাউন্টের পাসওয়ার্ড রিসেট করার একটি অনুরোধ পেয়েছি। রিসেট সম্পূর্ণ করতে আপনাকে অবশ্যই নিচের লিঙ্কে ক্লিক করতে হবে:',
+          ignoreRequest:
+            'এই পাসওয়ার্ড রিসেটটি শুধুমাত্র পরবর্তী এক ঘণ্টার জন্য বৈধ। আপনি যদি এই অনুরোধটি না করে থাকেন, তাহলে অনুগ্রহ করে এই ইমেলটি উপেক্ষা করুন।',
+        },
         rentalOpportunity: {
           subject: '%{listingName}-এ নতুন ভাড়ার সুযোগ',
           intro: 'ভাড়ার সুযোগ:',
@@ -667,6 +702,13 @@ const translations = (
           rejectionInfoStart:
             'إذا كنت تعتقد أن هذا القرار تم اتخاذه بالخطأ أو لديك أسئلة حول الأهلية، يرجى الاتصال بنا على',
           rejectionInfoEnd: 'للحصول على مزيد من المعلومات.',
+        },
+        forgotPassword: {
+          subject: 'إعادة تعيين كلمة المرور الخاصة بك؟',
+          resetRequest:
+            'لقد تلقينا طلباً لإعادة تعيين كلمة المرور لحسابك في بوابة Bloom للإسكان. يجب النقر على الرابط التالي لإكمال إعادة التعيين:',
+          ignoreRequest:
+            'إعادة تعيين كلمة المرور هذه صالحة للساعة القادمة فقط. إذا لم تقم بتقديم هذا الطلب، فيرجى تجاهل هذا البريد الإلكتروني.',
         },
         rentalOpportunity: {
           subject: 'فرصة إيجار جديدة في %{listingName}',
@@ -770,6 +812,13 @@ const translations = (
             '이 결정이 오류로 인해 결정되었다고 생각하거나 자격 요건에 대해 질문이 있으면 다음 주소로 문의하세요',
           rejectionInfoEnd: '자세한 내용은',
         },
+        forgotPassword: {
+          subject: '비밀번호를 재설정하시겠습니까?',
+          resetRequest:
+            'Bloom 주택 포털 계정의 비밀번호 재설정 요청을 받았습니다. 재설정을 완료하려면 다음 링크를 클릭해야 합니다:',
+          ignoreRequest:
+            '이 비밀번호 재설정은 앞으로 1시간 동안만 유효합니다. 이 요청을 하지 않으셨다면 이 이메일을 무시하세요.',
+        },
         rentalOpportunity: {
           subject: '%{listingName}의 새로운 임대 기회',
           intro: '임대 기회 위치:',
@@ -871,6 +920,13 @@ const translations = (
           rejectionInfoStart:
             'Եթե Դուք կարծում եք, որ այս որոշումը սխալ է կամ ունեք հարցեր պատկանելիության վերաբերյալ, խնդրում ենք մեզ հետ կապ հաստատել',
           rejectionInfoEnd: 'ավելի շատ տեղեկատվության համար:',
+        },
+        forgotPassword: {
+          subject: 'Վերականգնե՞լ ձեր գաղտնաբառը:',
+          resetRequest:
+            'Մենք ստացել ենք ձեր Bloom բնակարանային պորտալի հաշվի գաղտնաբառը վերականգնելու հարցում: Վերականգնումն ավարտելու համար դուք պետք է սեղմեք հետևյալ հղումը.',
+          ignoreRequest:
+            'Գաղտնաբառի այս վերականգնումը վավեր է միայն հաջորդ մեկ ժամվա ընթացքում: Եթե դուք չեք կատարել այս հարցումը, խնդրում ենք անտեսել այս նամակը:',
         },
         rentalOpportunity: {
           subject: 'Նոր վարձակալության հնարավորություն՝ %{listingName}',
@@ -976,6 +1032,13 @@ const translations = (
           rejectionInfoStart:
             'اگر فکر می‌کنید این تصمیم اشتباهی است یا سؤالاتی درباره واجدین شرایط دارید، لطفاً با ما تماس بگیرید',
           rejectionInfoEnd: 'برای اطلاعات بیشتر.',
+        },
+        forgotPassword: {
+          subject: 'بازنشانی رمز عبور شما؟',
+          resetRequest:
+            'ما درخواستی برای بازنشانی رمز عبور حساب پورتال مسکن Bloom شما دریافت کردیم. برای تکمیل بازنشانی باید روی پیوند زیر کلیک کنید:',
+          ignoreRequest:
+            'این بازنشانی رمز عبور فقط تا یک ساعت آینده معتبر است. اگر شما این درخواست را ثبت نکرده‌اید، لطفاً این ایمیل را نادیده بگیرید.',
         },
         rentalOpportunity: {
           subject: 'فرصت اجاره جدید در %{listingName}',
@@ -1222,16 +1285,11 @@ const translations = (
           mfaCode: 'Your access code is: %{singleUseCode}',
         },
         forgotPassword: {
-          subject: 'Forgot your password?',
-          callToAction:
-            'If you did make this request, please click on the link below to reset your password:',
-          passwordInfo:
-            "Your password won't change until you access the link above and create a new one.",
+          subject: 'Reset your password?',
           resetRequest:
-            'A request to reset your Bloom Housing Portal website password for %{appUrl} has recently been made.',
+            'We received a request to reset your password for your Bloom Housing Portal account. You must click the following link to complete the reset:',
           ignoreRequest:
-            "If you didn't request this, please ignore this email.",
-          changePassword: 'Change my password',
+            'This password reset is only valid for the next hour. If you didn’t make this request, please ignore this email.',
         },
         requestApproval: {
           header: 'Listing approval requested',

--- a/api/src/views/forgot-password.hbs
+++ b/api/src/views/forgot-password.hbs
@@ -1,15 +1,8 @@
 <h2>{{t "t.hello"}} {{> user-name }},</h2>
 <p>
-  {{t "forgotPassword.resetRequest" resetOptions}}
+  {{t "forgotPassword.resetRequest"}} <a href="{{resetUrl}}">{{t "forgotPassword.changePassword"}}</a>
 </p>
 <p>
   {{t "forgotPassword.ignoreRequest"}}
-</p>
-<p>
-  {{t "forgotPassword.callToAction"}}
-  <a href="{{resetUrl}}">{{t "forgotPassword.changePassword"}}</a>
-</p>
-<p>
-  {{t "forgotPassword.passwordInfo"}}
 </p>
 {{> simple-footer }}

--- a/api/src/views/partials/simple-footer.hbs
+++ b/api/src/views/partials/simple-footer.hbs
@@ -1,4 +1,4 @@
 <p>
-  {{t "footer.thankYou"}}<br/>
+  {{t "footer.thankYou"}},<br/>
   {{t "footer.footer"}}
 </p>

--- a/api/test/unit/services/email.service.spec.ts
+++ b/api/test/unit/services/email.service.spec.ts
@@ -177,18 +177,15 @@ describe('Testing email service', () => {
     );
     expect(sendMock).toHaveBeenCalled();
     expect(sendMock.mock.calls[0][0].to).toEqual(user.email);
-    expect(sendMock.mock.calls[0][0].subject).toEqual('Forgot your password?');
+    expect(sendMock.mock.calls[0][0].subject).toEqual('Reset your password?');
     expect(sendMock.mock.calls[0][0].body).toContain(
-      'A request to reset your Bloom Housing Portal website password for http://localhost:3001 has recently been made.',
-    );
-    expect(sendMock.mock.calls[0][0].body).toContain(
-      'If you did make this request, please click on the link below to reset your password:',
+      ' We received a request to reset your password for your Bloom Housing Portal account. You must click the following link to complete the reset:',
     );
     expect(sendMock.mock.calls[0][0].body).toContain(
       '<a href="http://localhost:3001/reset-password?token&#x3D;resetToken">Change my password</a>',
     );
     expect(sendMock.mock.calls[0][0].body).toContain(
-      'Your password won&#x27;t change until you access the link above and create a new one.',
+      'This password reset is only valid for the next hour. If you didn’t make this request, please ignore this email.',
     );
   });
 
@@ -205,18 +202,15 @@ describe('Testing email service', () => {
     );
     expect(sendMock).toHaveBeenCalled();
     expect(sendMock.mock.calls[0][0].to).toEqual(user.email);
-    expect(sendMock.mock.calls[0][0].subject).toEqual('Forgot your password?');
+    expect(sendMock.mock.calls[0][0].subject).toEqual('Reset your password?');
     expect(sendMock.mock.calls[0][0].body).toContain(
-      'A request to reset your Bloom Housing Portal website password for http://localhost:3001 has recently been made.',
-    );
-    expect(sendMock.mock.calls[0][0].body).toContain(
-      'If you did make this request, please click on the link below to reset your password:',
+      'We received a request to reset your password for your Bloom Housing Portal account. You must click the following link to complete the reset:',
     );
     expect(sendMock.mock.calls[0][0].body).toContain(
       '<a href="http://localhost:3001/reset-password?token&#x3D;resetToken&amp;redirectUrl&#x3D;redirect&amp;listingId&#x3D;123">Change my password</a>',
     );
     expect(sendMock.mock.calls[0][0].body).toContain(
-      'Your password won&#x27;t change until you access the link above and create a new one.',
+      'This password reset is only valid for the next hour. If you didn’t make this request, please ignore this email.',
     );
   });
 


### PR DESCRIPTION
This PR addresses #6257

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Updates the forgot password email template
* Adds new translation strings with translations to all supported languages
* Adds a new migration file for the email translations
* Updates exsisting integration tests

## How Can This Be Tested/Reviewed?

1.  Run the `yarn setup` CLI command in the `/api` directory to apply new migrations
2. Make sure you have a partner's account with an email with which you can verify the received email.
3. Go to partners site `/sign-in` page and click the ''Forgot Password?"
4. Fill in the desired email and click the "Send email" button
5. Open up your email and verify the received email contents

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
