### PR TITLE
fix(partners): use Next routing for seeds links

### DIFF
--- a/sites/partners/src/components/settings/SettingsViewHelpers.tsx
+++ b/sites/partners/src/components/settings/SettingsViewHelpers.tsx
@@ -26,7 +26,7 @@ export const getSettingsTabs = (
   enableV2MSQ: boolean,
   { enablePreferences, enableProperties, enableAgencies }: SettingsTabsFeatureFlags
 ) => {
-  const baseUrl = "/settings/"
+  const baseUrl = "/settings"
   const enabledTabs: SettingsIndexEnum[] = []
   if (enablePreferences) enabledTabs.push(SettingsIndexEnum.preferences)
   if (enableProperties) enabledTabs.push(SettingsIndexEnum.properties)

--- a/sites/partners/src/pages/_app.tsx
+++ b/sites/partners/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react"
+import React, { FunctionComponent, useEffect, useMemo, useState } from "react"
 import Head from "next/head"
 import { SWRConfig } from "swr"
 import type { AppProps } from "next/app"
@@ -7,7 +7,14 @@ import { GoogleReCaptchaProvider } from "react-google-recaptcha-v3"
 import "@bloom-housing/ui-components/src/global/css-imports.scss"
 import "@bloom-housing/ui-components/src/global/app-css.scss"
 import "@bloom-housing/ui-seeds/src/global/app-css.scss"
-import { addTranslation, NavigationContext, GenericRouter } from "@bloom-housing/ui-components"
+import {
+  addTranslation,
+  NavigationContext as UICNavigationContext,
+  GenericRouter,
+} from "@bloom-housing/ui-components"
+import { NavigationContext } from "@bloom-housing/ui-seeds/src/global/NavigationContext"
+import type { LinkProps as UICLinkProps } from "@bloom-housing/ui-components/src/config/NavigationContext"
+import type { LinkProps as SeedsLinkProps } from "@bloom-housing/ui-seeds/src/global/NavigationContext"
 import {
   AuthProvider,
   ConfigProvider,
@@ -85,19 +92,25 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
           },
         }}
       >
+        {/* Seeds and UI-Components each have their own NavigationContext; both are needed so
+            internal links use Next's router instead of a full page load. */}
         <NavigationContext.Provider
-          value={{
-            LinkComponent: LinkComponent,
-            router: router as GenericRouter,
-          }}
+          value={{ LinkComponent: LinkComponent as FunctionComponent<SeedsLinkProps> }}
         >
-          {process.env.reCaptchaKey ? (
-            <GoogleReCaptchaProvider reCaptchaKey={process.env.reCaptchaKey}>
-              {pageContent}
-            </GoogleReCaptchaProvider>
-          ) : (
-            pageContent
-          )}
+          <UICNavigationContext.Provider
+            value={{
+              LinkComponent: LinkComponent as FunctionComponent<UICLinkProps>,
+              router: router as GenericRouter,
+            }}
+          >
+            {process.env.reCaptchaKey ? (
+              <GoogleReCaptchaProvider reCaptchaKey={process.env.reCaptchaKey}>
+                {pageContent}
+              </GoogleReCaptchaProvider>
+            ) : (
+              pageContent
+            )}
+          </UICNavigationContext.Provider>
         </NavigationContext.Provider>
       </SWRConfig>
     </>


### PR DESCRIPTION
- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

The `ui-seeds` links in the partners app were causing a full page load instead of a client-side route change. Clicking between settings tabs blanked the whole page for the duration.

- **Cause.** Seeds and UI-Components each define their own `NavigationContext`. Partners only provided the UI-Components one, so seeds' `Link` fell back to its built-in default, which renders a plain `<a>`:

  ```tsx
  export const NavigationContext = createContext<NavigationContextProps>({
    LinkComponent: (props) => <a className={props.className} {...props}>...
  ```

- **Why the page went blank.** A full load remounts the app, so `AuthProvider` starts over and refetches the profile. `RequireLogin` returns `null` while there is no profile, which blanks the entire tree, nav included, until `/api/adapter/user` resolves.
- **Fix.** Provide both contexts in `_app.tsx`, matching what `sites/public` already does. That file carries a note explaining the same thing: "Seeds and UI-Components both use a NavigationContext to help internal links use Next's routing system, so we'll include both here until UIC is no longer in use."
- **Also fixed.** `getSettingsTabs` built its hrefs from a `baseUrl` ending in `/`, producing `/settings//preferences`, which the server answers with a 308. Dropping the trailing slash removes the redirect. Independent of the context problem, but the same symptom.

This changes link behavior across the whole partners app: the site header, listing links, and any seeds `Button` with an `href` now route client-side.

## How Can This Be Tested/Reviewed?

1. Sign in to partners and open Settings, with at least two tabs enabled (`enableProperties` and `enableHousingAdvocate` control Properties and Agencies).
2. Click between the tabs. Before this change the page went blank on each click; it should now stay rendered.
3. In the Network tab, confirm `/api/adapter/user` is no longer requested on each click. It was being refetched because the app remounted.
4. In the console, `performance.getEntriesByType("navigation")[0].type` no longer reports a fresh `"navigate"` after clicking a tab.
5. Spot-check links elsewhere in partners, since the change is app-wide.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [x] Reviewed considering accessibility (no markup change; links keep their existing roles and `aria-current`)
- [ ] Added tests covering the changes (behavior is in the Next router and the seeds context; no unit test covers it)
- [ ] Ran `yarn generate:client` and/or created a migration when required (N/A)

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates