### PR TITLE
feat(api): define and test the rich-text sanitizer allowlist

### DIFF
--- a/api/src/decorators/sanitize-html.decorator.ts
+++ b/api/src/decorators/sanitize-html.decorator.ts
@@ -1,12 +1,15 @@
 import { Transform, TransformFnParams } from 'class-transformer';
 import sanitizeHtml from 'sanitize-html';
 
+const ALLOWED_TAGS = ['b', 'strong', 'a', 'hr', 'p', 'ol', 'ul', 'li', 'br'];
+const ALLOWED_ATTRIBUTES = { a: ['href'] };
+const ALLOWED_SCHEMES = ['http', 'https', 'mailto', 'tel'];
+
 export const sanitize = (content: string) => {
   return sanitizeHtml(content, {
-    allowedTags: ['b', 'strong', 'a', 'hr', 'p', 'ol', 'ul', 'li', 'br'],
-    allowedAttributes: {
-      a: ['href'],
-    },
+    allowedTags: ALLOWED_TAGS,
+    allowedAttributes: ALLOWED_ATTRIBUTES,
+    allowedSchemes: ALLOWED_SCHEMES,
   });
 };
 

--- a/api/test/integration/jurisdiction-content.e2e-spec.ts
+++ b/api/test/integration/jurisdiction-content.e2e-spec.ts
@@ -161,6 +161,35 @@ describe('Jurisdiction Content Controller Tests', () => {
         .expect(204);
     });
 
+    it('sanitizes a row written straight to the database', async () => {
+      const jurisdiction = await prisma.jurisdictions.create({
+        data: jurisdictionFactory(),
+      });
+      await prisma.jurisdictionContent.create({
+        data: {
+          jurisdictionId: jurisdiction.id,
+          language: LanguagesEnum.en,
+          disclaimers: {
+            disclaimerHtml:
+              '<p onclick="alert(1)">Notice</p><script>alert(2)</script>',
+          },
+          footer: {
+            textSectionsHtml: ['<a href="javascript:alert(3)">Link</a>'],
+          },
+        },
+      });
+
+      const res = await request(app.getHttpServer())
+        .get(
+          `/jurisdictionContent/jurisdictions/${jurisdiction.id}?language=en`,
+        )
+        .set(passkey)
+        .expect(200);
+
+      expect(res.body.disclaimers.disclaimerHtml).toEqual('<p>Notice</p>');
+      expect(res.body.footer.textSectionsHtml).toEqual(['<a>Link</a>']);
+    });
+
     it('returns 404 for an unknown jurisdiction id', async () => {
       await request(app.getHttpServer())
         .get(`/jurisdictionContent/jurisdictions/${randomUUID()}?language=en`)
@@ -371,7 +400,7 @@ describe('Jurisdiction Content Controller Tests', () => {
         .expect(400);
     });
 
-    it('sanitizes rich-text HTML on write, stripping disallowed tags', async () => {
+    it('sanitizes rich-text HTML on write', async () => {
       await request(app.getHttpServer())
         .put(adminScope('zh'))
         .set('Cookie', adminCookies)
@@ -379,6 +408,10 @@ describe('Jurisdiction Content Controller Tests', () => {
         .send({
           footer: {
             textSectionsHtml: ['<script>alert(1)</script><p>keep</p>'],
+          },
+          disclaimers: {
+            disclaimerHtml:
+              '<p onclick="alert(1)">keep</p><a href="javascript:alert(2)">link</a>',
           },
           faq: {
             categories: [
@@ -397,14 +430,18 @@ describe('Jurisdiction Content Controller Tests', () => {
         })
         .expect(200);
 
-      const res = await request(app.getHttpServer())
-        .get(adminScope('zh'))
-        .set('Cookie', adminCookies)
-        .set(passkey)
-        .expect(200);
+      // Read the row rather than the endpoint: the response is sanitized on its way out, so a
+      // check through the API would pass even if nothing sanitized the value before it was stored.
+      const stored = await prisma.jurisdictionContent.findFirst({
+        where: { jurisdictionId, language: LanguagesEnum.zh },
+        select: { footer: true, disclaimers: true, faq: true },
+      });
 
-      expect(res.body.footer.textSectionsHtml[0]).toEqual('<p>keep</p>');
-      expect(res.body.faq.categories[0].items[0].answerHtml).toEqual(
+      expect(stored.footer['textSectionsHtml'][0]).toEqual('<p>keep</p>');
+      expect(stored.disclaimers['disclaimerHtml']).toEqual(
+        '<p>keep</p><a>link</a>',
+      );
+      expect(stored.faq['categories'][0].items[0].answerHtml).toEqual(
         'drop<strong>keep</strong>',
       );
     });

--- a/api/test/unit/decorators/sanitize-html.spec.ts
+++ b/api/test/unit/decorators/sanitize-html.spec.ts
@@ -16,6 +16,66 @@ describe('sanitize()', () => {
   it('completes unfinished tags', () => {
     expect(sanitize(`<strong>Bold text`)).toEqual(`<strong>Bold text</strong>`);
   });
+  it('removes event handler attributes', () => {
+    expect(sanitize(`<p onclick="alert(1)">text</p>`)).toEqual(`<p>text</p>`);
+    expect(sanitize(`<img src="x" onerror="alert(1)">`)).toEqual(``);
+  });
+  it('removes a link target that would run script', () => {
+    expect(sanitize(`<a href="javascript:alert(1)">link</a>`)).toEqual(
+      `<a>link</a>`,
+    );
+    expect(sanitize(`<a href="JaVaScRiPt:alert(1)">link</a>`)).toEqual(
+      `<a>link</a>`,
+    );
+    expect(sanitize(`<a href="java\tscript:alert(1)">link</a>`)).toEqual(
+      `<a>link</a>`,
+    );
+    expect(sanitize(`<a href="&#106;avascript:alert(1)">link</a>`)).toEqual(
+      `<a>link</a>`,
+    );
+    expect(
+      sanitize(`<a href="data:text/html;base64,PHNjcmlwdD4=">link</a>`),
+    ).toEqual(`<a>link</a>`);
+  });
+  it('keeps the link schemes the editor offers', () => {
+    expect(sanitize(`<a href="https://www.exygy.com">site</a>`)).toEqual(
+      `<a href="https://www.exygy.com">site</a>`,
+    );
+    expect(sanitize(`<a href="mailto:help@bloom.gov">mail</a>`)).toEqual(
+      `<a href="mailto:help@bloom.gov">mail</a>`,
+    );
+    expect(sanitize(`<a href="tel:+15555555555">call</a>`)).toEqual(
+      `<a href="tel:+15555555555">call</a>`,
+    );
+  });
+  it('removes script content along with the tag', () => {
+    expect(
+      sanitize(`<p>before</p><script>alert(1)</script><p>after</p>`),
+    ).toEqual(`<p>before</p><p>after</p>`);
+    expect(sanitize(`<style>body{display:none}</style><p>keep</p>`)).toEqual(
+      `<p>keep</p>`,
+    );
+    expect(sanitize(`<svg><script>alert(1)</script></svg>`)).toEqual(``);
+  });
+  it('removes markup that loads or submits to another origin', () => {
+    expect(
+      sanitize(`<iframe src="https://evil.example"></iframe><p>keep</p>`),
+    ).toEqual(`<p>keep</p>`);
+    expect(
+      sanitize(
+        `<form action="https://evil.example"><input /></form><p>keep</p>`,
+      ),
+    ).toEqual(`<p>keep</p>`);
+  });
+  it('removes presentation attributes and stored text direction', () => {
+    expect(sanitize(`<p class="x" style="color:red">text</p>`)).toEqual(
+      `<p>text</p>`,
+    );
+    expect(sanitize(`<a href="https://x.gov" target="_blank">x</a>`)).toEqual(
+      `<a href="https://x.gov">x</a>`,
+    );
+    expect(sanitize(`<p dir="rtl">text</p>`)).toEqual(`<p>text</p>`);
+  });
   it('removes disallowed tags and attributes', () => {
     expect(
       sanitize(

--- a/api/test/unit/services/jurisdiction-content.service.spec.ts
+++ b/api/test/unit/services/jurisdiction-content.service.spec.ts
@@ -146,6 +146,45 @@ describe('Testing jurisdiction content service', () => {
       expect(prisma.jurisdictionContent.findMany).not.toHaveBeenCalled();
     });
 
+    it('sanitizes stored html on read, whatever wrote the row', async () => {
+      prisma.jurisdictionContent.findMany = jest.fn().mockResolvedValueOnce([
+        {
+          language: LanguagesEnum.en,
+          disclaimers: {
+            disclaimerHtml:
+              '<p onclick="alert(1)">Notice</p><script>alert(2)</script>',
+          },
+          footer: {
+            textSectionsHtml: ['<a href="javascript:alert(3)">Link</a>'],
+          },
+          faq: {
+            categories: [
+              {
+                id: 'general',
+                items: [
+                  {
+                    id: 'a',
+                    question: 'What?',
+                    answerHtml: '<img src="x" onerror="alert(4)"><b>Answer</b>',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ]);
+
+      const merged = await service.getMergedContent(
+        randomUUID(),
+        LanguagesEnum.en,
+      );
+
+      expect(merged.disclaimers.disclaimerHtml).toEqual('<p>Notice</p>');
+      expect(merged.footer.textSectionsHtml).toEqual(['<a>Link</a>']);
+      expect(merged.faq.categories[0].items[0].answerHtml).toEqual(
+        '<b>Answer</b>',
+      );
+    });
     it('logs a warning without throwing when a stored row is malformed', async () => {
       prisma.jurisdictionContent.findMany = jest.fn().mockResolvedValueOnce([
         {
@@ -221,6 +260,23 @@ describe('Testing jurisdiction content service', () => {
         'read',
         { jurisdictionId },
       );
+    });
+
+    it('sanitizes stored html on read', async () => {
+      prisma.jurisdictionContent.findFirst = jest.fn().mockResolvedValueOnce({
+        id: 'row',
+        jurisdictionId: 'jurisdiction',
+        language: 'en',
+        disclaimers: { privacyHtml: '<p onclick="alert(1)">Privacy</p>' },
+      });
+
+      const row = await service.getContent(
+        randomUUID(),
+        LanguagesEnum.en,
+        adminUser,
+      );
+
+      expect(row.disclaimers.privacyHtml).toEqual('<p>Privacy</p>');
     });
 
     it('returns null when no row exists for that language', async () => {


### PR DESCRIPTION
This PR addresses #6513

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

Sets the URL schemes the rich-text sanitizer accepts, and covers the allowlist with tests.

The sanitizer itself was already in place. What was missing was an explicit scheme list, tests for the vectors in the issue, and a test on the write and read passes.

- **Schemes are set rather than inherited.** A link in rich text may use `http`, `https`, `mailto`, or `tel`.
- **Tags and attributes are unchanged**, and now sit in named constants alongside the schemes.
- **Sanitization runs in the API on both write and read.** `@SanitizeHtml()` is a class-transformer `@Transform`, and the content DTOs map both request bodies and responses. On write the `ValidationPipe` runs it before the service sees the payload, so what reaches the database is clean. On read `mapTo` runs it again, which covers a row the API did not write: a seed, the #6519 data migration, or direct SQL.
- **The write test now reads the row.** It previously wrote through the endpoint and read back through the endpoint, which the read pass would clean regardless. It would have passed even if nothing sanitized the value before it was stored. It now asserts against the stored row with prisma.
- **Text direction is not stored.** `dir` stays out of the allowlist. The editor and the public page set direction on their container from the active locale, so a translated body cannot disagree with the language of the row it sits in.

## How Can This Be Tested/Reviewed?

1. **Unit** (`cd api && yarn test`). `sanitize-html.spec.ts` gains six cases: event handler attributes, `javascript:` targets in four evasion forms (upper case, an embedded tab, an HTML entity, and `data:`), script and style contents, `iframe` and `form`, presentation attributes, and stored `dir`. It also pins the three schemes the editor offers. `jurisdiction-content.service.spec.ts` gains two cases proving `getMergedContent` and `getContent` clean a poisoned stored row. All 64 suites pass, 1287 tests.
2. **Integration** (`yarn test:backend:new:e2e`). `jurisdiction-content.e2e-spec.ts` gains a case that writes a row straight to the database with prisma and reads it back through the public endpoint clean. The existing write case now covers an event handler and a `javascript:` href, and asserts against the stored row. 20 passing against a fresh database.
3. **Manual.** Not required. There is no UI and no endpoint change.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view (N/A: backend only)
- [ ] Reviewed in a mobile view (N/A: backend only)
- [ ] Reviewed considering accessibility (N/A: no UI)
- [x] Added tests covering the changes
- [x] Ran `yarn generate:client` and/or created a migration when required (N/A: no schema change and no DTO shape change)

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates