### PR TITLE
fix: styling changes for new features

### DIFF
--- a/sites/public/__tests__/components/browse/map/ListingsSearchCombined.test.tsx
+++ b/sites/public/__tests__/components/browse/map/ListingsSearchCombined.test.tsx
@@ -25,6 +25,7 @@ jest.mock("@vis.gl/react-google-maps", () => ({
       {children}
     </div>
   )),
+  Pin: ({ "data-testid": testId }) => <img alt="Listing pin" data-testid={testId} />,
   InfoWindow: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="info-window">{children}</div>
   ),

--- a/sites/public/__tests__/components/browse/map/MapMarker.test.tsx
+++ b/sites/public/__tests__/components/browse/map/MapMarker.test.tsx
@@ -17,6 +17,7 @@ jest.mock("@vis.gl/react-google-maps", () => {
         </button>
       )
     }),
+    Pin: ({ id }) => <img alt="Listing pin" id={id} data-testid="pin" />,
   }
 })
 

--- a/sites/public/__tests__/components/browse/map/MapMarker.test.tsx
+++ b/sites/public/__tests__/components/browse/map/MapMarker.test.tsx
@@ -17,7 +17,7 @@ jest.mock("@vis.gl/react-google-maps", () => {
         </button>
       )
     }),
-    Pin: ({ id }) => <img alt="Listing pin" id={id} data-testid="pin" />,
+    Pin: () => <img alt="Listing pin" />,
   }
 })
 
@@ -35,10 +35,7 @@ describe("MapMarker", () => {
   it("renders marker pin image and passes coordinate to AdvancedMarker", () => {
     render(<MapMarker marker={marker} onClick={jest.fn()} setMarkerRef={jest.fn()} />)
 
-    expect(screen.getByRole("img", { name: "Listing pin" })).toHaveAttribute(
-      "id",
-      "marker-id-listing-1"
-    )
+    expect(screen.getByRole("img", { name: "Listing pin" })).toBeInTheDocument()
     expect(advancedMarkerMock).toHaveBeenCalledWith({
       onClick: expect.any(Function),
       position: marker.coordinate,

--- a/sites/public/src/components/browse/map/MapMarker.tsx
+++ b/sites/public/src/components/browse/map/MapMarker.tsx
@@ -25,7 +25,6 @@ export const MapMarker = (props: MapMarkerProp) => {
           background={"var(--seeds-color-primary-darker)"}
           borderColor={"white"}
           glyphColor={"white"}
-          // data-testid={`marker-id-${props.marker.id}`}
         ></Pin>
       </span>
     </AdvancedMarker>

--- a/sites/public/src/components/browse/map/MapMarker.tsx
+++ b/sites/public/src/components/browse/map/MapMarker.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from "react"
-import { AdvancedMarker } from "@vis.gl/react-google-maps"
-import { t } from "@bloom-housing/ui-components"
+import { AdvancedMarker, Pin } from "@vis.gl/react-google-maps"
 import { MapMarkerData } from "./ListingsMap"
 
 export type MapMarkerProp = {
@@ -22,11 +21,12 @@ export const MapMarker = (props: MapMarkerProp) => {
   return (
     <AdvancedMarker position={marker.coordinate} onClick={handleClick} ref={ref}>
       <span>
-        <img
-          src="/images/map-pin.svg"
-          alt={t("listings.map.pinLabel")}
+        <Pin
+          background={"var(--seeds-color-primary-darker)"}
+          borderColor={"white"}
+          glyphColor={"white"}
           id={`marker-id-${props.marker.id}`}
-        />
+        ></Pin>
       </span>
     </AdvancedMarker>
   )

--- a/sites/public/src/components/browse/map/MapMarker.tsx
+++ b/sites/public/src/components/browse/map/MapMarker.tsx
@@ -25,7 +25,7 @@ export const MapMarker = (props: MapMarkerProp) => {
           background={"var(--seeds-color-primary-darker)"}
           borderColor={"white"}
           glyphColor={"white"}
-          id={`marker-id-${props.marker.id}`}
+          // data-testid={`marker-id-${props.marker.id}`}
         ></Pin>
       </span>
     </AdvancedMarker>

--- a/sites/public/src/components/home/Home.module.scss
+++ b/sites/public/src/components/home/Home.module.scss
@@ -109,8 +109,17 @@
     }
 
     .hero-property-name {
+      input {
+        height: 3rem;
+      }
       @media (--sm-and-up) {
         min-width: 370px;
+      }
+    }
+
+    .hero-max-rent {
+      input {
+        height: 3rem;
       }
     }
 

--- a/sites/public/src/components/home/HomeSearch.tsx
+++ b/sites/public/src/components/home/HomeSearch.tsx
@@ -152,6 +152,7 @@ export const HomeSearch = (props: HomeSearchProps) => {
                   register={registerFilters}
                   setValue={setValue}
                   controlClassName="seeds-m-be-6"
+                  className={styles["hero-max-rent"]}
                 />
               </div>
               <div className={styles["hero-last-checkbox"]}>


### PR DESCRIPTION
This PR addresses #6253 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When pulling the recent changes over to Doorway some visual regressions were found:

1. The input height sizes are slightly different on the new hero search form

<img width="802" height="209" alt="image" src="https://github.com/user-attachments/assets/3e51a989-9c2f-44f6-9806-a77af32a1dcc" />
3. The map pin colors are off

<img width="578" height="292" alt="image" src="https://github.com/user-attachments/assets/4baf9d23-4b1b-401c-b7f3-3054e253c9b3" />

This fixes it by doing the following:
* Setting the height of the two input fields to the same as the select fields
* Change from using an image as the map pin to using the built in pin. This allows for us to change the color.
<img width="592" height="439" alt="image" src="https://github.com/user-attachments/assets/d9d862ea-0b5a-45b5-bfd9-59b671096480" />


## How Can This Be Tested/Reviewed?

After doing the staging seeding for region `yarn db:setup:staging-region`, set the jurisdiction to "Bridge Bay" and verify the two above changes

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
