### PR TITLE
fix: add optional income (PoC)

### DIFF
--- a/api/src/dtos/units/ami-chart-override-item.dto.ts
+++ b/api/src/dtos/units/ami-chart-override-item.dto.ts
@@ -1,0 +1,15 @@
+import { ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsNumber, IsOptional } from 'class-validator';
+import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
+import { AmiChartItem } from './ami-chart-item.dto';
+
+export class AmiChartOverrideItem extends OmitType(AmiChartItem, [
+  'income',
+] as const) {
+  @Expose()
+  @IsOptional({ groups: [ValidationsGroupsEnum.default] })
+  @IsNumber({}, { groups: [ValidationsGroupsEnum.default] })
+  @ApiPropertyOptional()
+  income?: number;
+}

--- a/api/src/dtos/units/ami-chart-override.dto.ts
+++ b/api/src/dtos/units/ami-chart-override.dto.ts
@@ -2,14 +2,14 @@ import { AbstractDTO } from '../shared/abstract.dto';
 import { Expose, Type } from 'class-transformer';
 import { IsDefined, ValidateNested } from 'class-validator';
 import { ValidationsGroupsEnum } from '../../enums/shared/validation-groups-enum';
-import { AmiChartItem } from './ami-chart-item.dto';
+import { AmiChartOverrideItem } from './ami-chart-override-item.dto';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UnitAmiChartOverride extends AbstractDTO {
   @Expose()
   @IsDefined({ groups: [ValidationsGroupsEnum.default] })
   @ValidateNested({ groups: [ValidationsGroupsEnum.default], each: true })
-  @Type(() => AmiChartItem)
-  @ApiProperty({ isArray: true, type: AmiChartItem })
-  items: AmiChartItem[];
+  @Type(() => AmiChartOverrideItem)
+  @ApiProperty({ isArray: true, type: AmiChartOverrideItem })
+  items: AmiChartOverrideItem[];
 }

--- a/api/src/utilities/unit-utilities.ts
+++ b/api/src/utilities/unit-utilities.ts
@@ -8,6 +8,7 @@ import { MinMax } from '../dtos/shared/min-max.dto';
 import { UnitsSummarized } from '../dtos/units/unit-summarized.dto';
 import { UnitType } from '../dtos/unit-types/unit-type.dto';
 import { AmiChartItem } from '../dtos/units/ami-chart-item.dto';
+import { AmiChartOverrideItem } from '../dtos/units/ami-chart-override-item.dto';
 import { UnitAmiChartOverride } from '../dtos/units/ami-chart-override.dto';
 import { isEmpty } from 'class-validator';
 import UnitGroupAmiLevel from '../dtos/unit-groups/unit-group-ami-level.dto';
@@ -71,7 +72,9 @@ export const yearlyCurrencyStringToMonthly = (currency: string) => {
   );
 };
 
-export const getAmiChartItemUniqueKey = (amiChartItem: AmiChartItem) => {
+export const getAmiChartItemUniqueKey = (
+  amiChartItem: Pick<AmiChartItem, 'householdSize' | 'percentOfAmi'>,
+) => {
   return (
     amiChartItem.householdSize.toString() +
     '-' +
@@ -83,7 +86,7 @@ export const mergeAmiChartWithOverrides = (
   amiChart: AmiChart,
   override: UnitAmiChartOverride,
 ) => {
-  const householdAmiPercentageOverrideMap: Map<string, AmiChartItem> =
+  const householdAmiPercentageOverrideMap: Map<string, AmiChartOverrideItem> =
     override.items?.reduce((acc, amiChartItem) => {
       acc.set(getAmiChartItemUniqueKey(amiChartItem), amiChartItem);
       return acc;

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -1881,6 +1881,25 @@ export class ApplicationsService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * Subscribed for server side events notifications from the application processes
+   */
+  uploadBulkNotifications(
+    params: {
+      /**  */
+      jobId: string
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/applications/bulk-update/notifications"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+      configs.params = { jobId: params["jobId"] }
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export class JobsService {
@@ -5001,6 +5020,18 @@ export interface UnitRentType {
   name: UnitRentTypeEnum
 }
 
+/** AmiChartOverrideItem */
+export interface AmiChartOverrideItem {
+  /**  */
+  percentOfAmi: number
+
+  /**  */
+  householdSize: number
+
+  /**  */
+  income?: number
+}
+
 /** UnitAmiChartOverride */
 export interface UnitAmiChartOverride {
   /**  */
@@ -5013,7 +5044,7 @@ export interface UnitAmiChartOverride {
   updatedAt: Date
 
   /**  */
-  items: AmiChartItem[]
+  items: AmiChartOverrideItem[]
 }
 
 /** Unit */
@@ -5925,7 +5956,7 @@ export interface ListingParkingTypeCreate {
 /** UnitAmiChartOverrideCreate */
 export interface UnitAmiChartOverrideCreate {
   /**  */
-  items: AmiChartItem[]
+  items: AmiChartOverrideItem[]
 }
 
 /** UnitCreate */
@@ -6597,7 +6628,7 @@ export interface ListingDuplicate {
 /** UnitAmiChartOverrideUpdate */
 export interface UnitAmiChartOverrideUpdate {
   /**  */
-  items: AmiChartItem[]
+  items: AmiChartOverrideItem[]
 
   /**  */
   id?: string
@@ -11702,7 +11733,7 @@ export enum FeatureFlagEnum {
   "enableCreditScreeningFee" = "enableCreditScreeningFee",
   "enableCustomListingNotifications" = "enableCustomListingNotifications",
   "enableDbDrivenContent" = "enableDbDrivenContent",
-  "enableDuplicatesDetails" = "enableDuplicatesDetails",
+  "enableDuplicatesDetailsInEmail" = "enableDuplicatesDetailsInEmail",
   "enableExportTerms" = "enableExportTerms",
   "enableFaq" = "enableFaq",
   "enableFilterByBathroom" = "enableFilterByBathroom",

--- a/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/UnitForm.tsx
@@ -21,7 +21,6 @@ type UnitFormProps = {
   amiChartsLoading: boolean
   defaultUnit: TempUnit | undefined
   draft: boolean
-  isLandUse?: boolean
   jurisdictionId: string
   listingType?: EnumListingListingType
   nextId: number
@@ -36,7 +35,6 @@ const UnitForm = ({
   amiChartsLoading,
   defaultUnit,
   draft,
-  isLandUse,
   jurisdictionId,
   listingType,
   nextId,
@@ -132,8 +130,8 @@ const UnitForm = ({
     () => getLandUseMinOccupancy(unitTypes?.find((type) => type.id === unitTypeId)?.name),
     [unitTypes, unitTypeId]
   )
-  const minOccupancyLocked =
-    listingType === EnumListingListingType.landUse && derivedMinOccupancy !== undefined
+  const isLandUse = listingType === EnumListingListingType.landUse
+  const minOccupancyLocked = isLandUse && derivedMinOccupancy !== undefined
 
   useEffect(() => {
     if (minOccupancyLocked) {

--- a/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
+++ b/sites/partners/src/components/listings/PaperListingForm/sections/Units.tsx
@@ -130,8 +130,6 @@ const FormUnits = ({
   const showNonRegulated =
     enableNonRegulatedListings && listingType === EnumListingListingType.nonRegulated
 
-  const isLandUse = listingType === EnumListingListingType.landUse
-
   const homeTypes = [
     "",
     ...Object.values(HomeTypeEnum).map((val) => {
@@ -568,7 +566,6 @@ const FormUnits = ({
             unitTypes={unitTypes}
             unitTypesLoading={unitTypesLoading}
             jurisdictionId={jurisdiction}
-            isLandUse={isLandUse}
             listingType={listingType}
             onSubmit={(unit) => {
               saveUnit(unit)

--- a/sites/partners/src/lib/listings/UnitsFormatter.ts
+++ b/sites/partners/src/lib/listings/UnitsFormatter.ts
@@ -35,25 +35,42 @@ export default class UnitsFormatter extends Formatter {
           unit.numBedrooms = 0
       }
 
+      const percentOfAmi = parseInt(unit.amiPercentage)
+      const overrideItems = []
+
       Object.keys(unit).forEach((key) => {
         if (key.indexOf("maxIncomeHouseholdSize") >= 0) {
-          if (parseInt(unit[key])) {
-            if (!unit.unitAmiChartOverrides) {
-              unit.unitAmiChartOverrides = {
-                id: undefined,
-                createdAt: undefined,
-                updatedAt: undefined,
-                items: [],
-              }
-            }
-            unit.unitAmiChartOverrides.items.push({
-              percentOfAmi: parseInt(unit.amiPercentage),
-              householdSize: parseInt(key[key.length - 1]),
-              income: parseInt(unit[key]),
+          const householdSize = parseInt(key[key.length - 1])
+          const overrideIncome = parseInt(unit[key])
+
+          if (overrideIncome) {
+            overrideItems.push({
+              percentOfAmi,
+              householdSize,
+              income: overrideIncome,
+            })
+          } else if (
+            unit.amiChart?.items?.some(
+              (item) => item.householdSize === householdSize && item.percentOfAmi === percentOfAmi
+            )
+          ) {
+            overrideItems.push({
+              percentOfAmi,
+              householdSize,
+              income: null,
             })
           }
         }
       })
+
+      unit.unitAmiChartOverrides = overrideItems.length
+        ? {
+            id: undefined,
+            createdAt: undefined,
+            updatedAt: undefined,
+            items: overrideItems,
+          }
+        : undefined
 
       unit.floor = stringToNumber(unit.floor)
       unit.maxOccupancy = stringToNumber(unit.maxOccupancy)


### PR DESCRIPTION
This PR addresses #6485 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

It's PoC for making income optional. Just to test (last commit).
This one will make AMI chart income optional for all listings overrides (from backend perspective), on frontend it has additional protection.
There are 2 main questions:
1. should we allow overrides to have optional income on backend?
2. Should optional income be also present for AmiChartItem (not override). Not sure how that should work i never uploaded AMI chart, but thats for jurisdiction if im not mistaken, so there is no way to decide if thats for land use listing (so i guess answer is no 🤔 ).

## How Can This Be Tested/Reviewed?

Go to partners listing Unit AMI chart land use listing it should allow to fully remove ami chart income value.
For non land use it should still be required (on frontend).

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
