### PR TITLE
fix: enable partners export feature flag

### DIFF
--- a/api/src/enums/feature-flags/feature-flags-enum.ts
+++ b/api/src/enums/feature-flags/feature-flags-enum.ts
@@ -61,6 +61,7 @@ export enum FeatureFlagEnum {
   enableParkingFee = 'enableParkingFee',
   enableParkingType = 'enableParkingType',
   enablePartnerDemographics = 'enablePartnerDemographics',
+  enablePartnerLotteryExport = 'enablePartnerLotteryExport',
   enablePartnerSettings = 'enablePartnerSettings',
   enablePetPolicyCheckbox = 'enablePetPolicyCheckbox',
   enableProperties = 'enableProperties',
@@ -375,6 +376,11 @@ export const featureFlagMap: {
     name: FeatureFlagEnum.enablePartnerDemographics,
     description:
       'When true, demographics data is included in application or lottery exports for partners',
+  },
+  {
+    name: FeatureFlagEnum.enablePartnerLotteryExport,
+    description:
+      'When true, partner can export lottery immediately after it is run.',
   },
   {
     name: FeatureFlagEnum.enablePartnerSettings,

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -47,7 +47,7 @@ The following are all of the feature flags currently available in the Bloom plat
 | [enableCreditScreeningFee](./feature-flags/enableCreditScreeningFee.md) | When true, credit screening fee is enabled for listings |
 | [enableCustomListingNotifications](./feature-flags/enableCustomListingNotifications.md) | When true, users have access to custom notification settings |
 | [enableDbDrivenContent](./feature-flags/enableDbDrivenContent.md) | When true, the jurisdiction reads its translations and structured content from the database instead of the bundled override files |
-| [enableDuplicatesDetails](./feature-flags/enableDuplicatesDetails.md) | When true, lottery published applicant email contains duplicates details section |
+| [enableDuplicatesDetailsInEmail](./feature-flags/enableDuplicatesDetailsInEmail.md) | When true, lottery published applicant email contains duplicates details section |
 | [enableExportTerms](./feature-flags/enableExportTerms.md) | When true, display terms of use before exporting applications and lotteries from the partner site |
 | [enableFaq](./feature-flags/enableFaq.md) | When true, a link to the FAQ page is displayed on the get assistance page |
 | [enableFilterByBathroom](./feature-flags/enableFilterByBathroom.md) | When true, the filter drawer on the public site includes the option to filter listings by number of bathrooms |
@@ -86,6 +86,7 @@ The following are all of the feature flags currently available in the Bloom plat
 | [enableParkingFee](./feature-flags/enableParkingFee.md) | When true, the parking fee field should be visible |
 | [enableParkingType](./feature-flags/enableParkingType.md) | When true, the parking type field is visible in the listing form |
 | [enablePartnerDemographics](./feature-flags/enablePartnerDemographics.md) | When true, demographics data is included in application or lottery exports for partners |
+| [enablePartnerLotteryExport](./feature-flags/enablePartnerLotteryExport.md) | When true, partner can export lottery immediately after it is run. |
 | [enablePartnerSettings](./feature-flags/enablePartnerSettings.md) | When true, the 'settings' tab in the partner site is visible |
 | [enablePetPolicyCheckbox](./feature-flags/enablePetPolicyCheckbox.md) | When true, the pet policy field in the listing form is displayed as checkboxes instead of a text area |
 | [enableProperties](./feature-flags/enableProperties.md) | When true, the properties feature is enabled |

--- a/docs/feature-flags/enablePartnerLotteryExport.md
+++ b/docs/feature-flags/enablePartnerLotteryExport.md
@@ -1,0 +1,13 @@
+# enablePartnerLotteryExport
+
+## Name
+
+`enablePartnerLotteryExport`
+
+## Description
+
+When true, partner can export lottery immediately after it is run.
+
+## Additional Information
+
+## Images

--- a/shared-helpers/src/types/backend-swagger.ts
+++ b/shared-helpers/src/types/backend-swagger.ts
@@ -1881,6 +1881,25 @@ export class ApplicationsService {
       axios(configs, resolve, reject)
     })
   }
+  /**
+   * Subscribed for server side events notifications from the application processes
+   */
+  uploadBulkNotifications(
+    params: {
+      /**  */
+      jobId: string
+    } = {} as any,
+    options: IRequestOptions = {}
+  ): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let url = basePath + "/applications/bulk-update/notifications"
+
+      const configs: IRequestConfig = getConfigs("get", "application/json", url, options)
+      configs.params = { jobId: params["jobId"] }
+
+      axios(configs, resolve, reject)
+    })
+  }
 }
 
 export class JobsService {
@@ -11738,6 +11757,7 @@ export enum FeatureFlagEnum {
   "enableParkingFee" = "enableParkingFee",
   "enableParkingType" = "enableParkingType",
   "enablePartnerDemographics" = "enablePartnerDemographics",
+  "enablePartnerLotteryExport" = "enablePartnerLotteryExport",
   "enablePartnerSettings" = "enablePartnerSettings",
   "enablePetPolicyCheckbox" = "enablePetPolicyCheckbox",
   "enableProperties" = "enableProperties",

--- a/sites/partners/__tests__/pages/listings/lottery.test.tsx
+++ b/sites/partners/__tests__/pages/listings/lottery.test.tsx
@@ -6,6 +6,7 @@ import {
   ListingMultiselectQuestion,
   ListingsStatusEnum,
   LotteryStatusEnum,
+  User,
 } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { listing } from "@bloom-housing/shared-helpers/__tests__/testHelpers"
 import { fireEvent, screen } from "@testing-library/react"
@@ -879,6 +880,58 @@ describe("lottery", () => {
     const updatedListing = {
       ...closedListing,
       lotteryStatus: LotteryStatusEnum.publishedToPublic,
+    }
+
+    render(<Lottery listing={updatedListing} />)
+
+    const header = await screen.findByText("Lottery")
+    expect(header).toBeInTheDocument()
+
+    expect(screen.getByText("Export lottery data")).toBeInTheDocument()
+    expect(screen.getByText("Export")).toBeInTheDocument()
+  })
+
+  it("should show export if ran without publish to public state flag is on as a partner if the enablePartnerLotteryExport", async () => {
+    mockNextRouter({ id: "Uvbk5qurpB2WI9V6WnNdH" })
+    document.cookie = "access-token-available=True"
+    server.use(
+      rest.get("http://localhost/api/adapter/user", (_req, res, ctx) => {
+        return res(
+          ctx.json({
+            id: "user1",
+            userRoles: {
+              isAdmin: false,
+              isPartner: true,
+            },
+            listings: [{ id: "Uvbk5qurpB2WI9V6WnNdH" }],
+            jurisdictions: [
+              {
+                id: "id",
+                name: "Bloomington",
+                featureFlags: [{ name: FeatureFlagEnum.enablePartnerLotteryExport, active: true }],
+              },
+            ],
+          })
+        )
+      }),
+      rest.post("http://localhost:3100/auth/token", (_req, res, ctx) => {
+        return res(ctx.json(""))
+      }),
+      rest.get("http://localhost:3100/applicationFlaggedSets/meta", (_req, res, ctx) => {
+        return res(ctx.json({ totalCount: 5, totalPendingCount: 5 }))
+      }),
+      rest.get(
+        "http://localhost:3100/lottery/lotteryActivityLog/Uvbk5qurpB2WI9V6WnNdH",
+        (_req, res, ctx) => {
+          return res(ctx.json([]))
+        }
+      )
+    )
+
+    const updatedListing = {
+      ...closedListing,
+      lotteryLastRunAt: new Date("September 6, 2025 8:15:00"),
+      lotteryStatus: LotteryStatusEnum.ran,
     }
 
     render(<Lottery listing={updatedListing} />)

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -58,6 +58,11 @@ const Lottery = (props: { listing: Listing | undefined }) => {
     jurisdictionData?.id
   )
 
+  const enablePartnerLotteryExport = doJurisdictionsHaveFeatureFlagOn(
+    FeatureFlagEnum.enablePartnerLotteryExport,
+    jurisdictionData?.id
+  )
+
   const includeDemographicsPartner =
     profile?.userRoles?.isPartner && jurisdictionData?.enablePartnerDemographics
 
@@ -243,7 +248,10 @@ const Lottery = (props: { listing: Listing | undefined }) => {
             )}
           </CardSection>
         )
-      } else if (listing.lotteryStatus === LotteryStatusEnum.publishedToPublic) {
+      } else if (
+        listing.lotteryStatus === LotteryStatusEnum.publishedToPublic ||
+        enablePartnerLotteryExport
+      ) {
         return exportCard
       }
       if (listing.lotteryStatus === LotteryStatusEnum.expired) {

--- a/sites/partners/src/pages/listings/[id]/lottery.tsx
+++ b/sites/partners/src/pages/listings/[id]/lottery.tsx
@@ -250,7 +250,7 @@ const Lottery = (props: { listing: Listing | undefined }) => {
         )
       } else if (
         listing.lotteryStatus === LotteryStatusEnum.publishedToPublic ||
-        enablePartnerLotteryExport
+        (listing.lotteryLastRunAt && enablePartnerLotteryExport)
       ) {
         return exportCard
       }


### PR DESCRIPTION
This PR addresses #6579 

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

* Adds a new `enablePartnerLotteryExport` feature flag.
* Generated new Swagger types
* Updates the listing lottery page to show the Export card as soon as the lottery as run (without the need to publish) when the `enablePartnerLotteryExport` is set to true.

## How Can This Be Tested/Reviewed?

1. Run the "yarn setup" in `/api` directory to apply new changes.
2. Ensure at least one jurisdiction has the new `enablePartnerLotteryExport` turned on
3. Go to partners site and login as a partner user for the jurisdiction configured in step 2.
4. Select a listing for the jurisdiction configured in step 2 that uses lottery review order. 
> [!NOTE]
> If the selected listing is not closed, click the `Edit` button and close the listing
5. Go to the `Lottery` tab in the listing view and click the `Run Lottery` button (Do not publish the lottery)
6. Switch to an parters account assigned to the worked on jurisdiction
7. Go again to the listing lottery tab
8. The "Export" button should be available without the need to publish the lottery 

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [ ] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
