### PR TITLE
fix(api): check status and time out when fetching translation files

### DIFF
--- a/api/src/modules/script-runner.module.ts
+++ b/api/src/modules/script-runner.module.ts
@@ -1,4 +1,5 @@
 import { Logger, Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { ScriptRunnerController } from '../controllers/script-runner.controller';
 import { ScriptRunnerService } from '../services/script-runner.service';
 import { AmiChartModule } from './ami-chart.module';
@@ -11,6 +12,7 @@ import { PrismaModule } from './prisma.module';
 @Module({
   imports: [
     AmiChartModule,
+    HttpModule,
     EmailModule,
     FeatureFlagModule,
     MultiselectQuestionModule,

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -35,6 +35,8 @@ import { MultiselectOption } from '../dtos/multiselect-questions/multiselect-opt
 import { AmiChartUpdateImportDTO } from '../dtos/script-runner/ami-chart-update-import.dto';
 import { calculateSkip, calculateTake } from '../utilities/pagination-helpers';
 
+const TRANSLATION_FETCH_TIMEOUT_MS = 30_000;
+
 /**
   this is the service for running scripts
   most functions in here will be unique, but each function should only be allowed to fire once
@@ -1517,30 +1519,35 @@ export class ScriptRunnerService {
     return 'no translation';
   }
 
-  getTranslationFile(url) {
-    return new Promise((resolve, reject) =>
-      https
-        .get(url, (res) => {
-          let body = '';
+  getTranslationFile(url: string, timeoutMs = TRANSLATION_FETCH_TIMEOUT_MS) {
+    return new Promise((resolve, reject) => {
+      const request = https.get(url, (res) => {
+        let body = '';
 
-          res.on('data', (chunk) => {
-            body += chunk;
-          });
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
 
-          res.on('end', () => {
-            try {
-              const json = JSON.parse(body);
-              resolve(json);
-            } catch (error) {
-              console.error('on end error:', error.message);
-              reject(`parsing broke: ${url}`);
-            }
-          });
-        })
-        .on('error', (error) => {
-          console.error('on error error:', error.message);
-          reject(`getting broke: ${url}`);
-        }),
-    );
+        res.on('end', () => {
+          if (res.statusCode !== 200) {
+            reject(new Error(`${res.statusCode} fetching ${url}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body));
+          } catch (error) {
+            reject(new Error(`invalid json at ${url}: ${body.slice(0, 120)}`));
+          }
+        });
+      });
+
+      request.setTimeout(timeoutMs, () => {
+        request.destroy(new Error(`timed out fetching ${url}`));
+      });
+
+      request.on('error', (error) => {
+        reject(new Error(`failed fetching ${url}: ${error.message}`));
+      });
+    });
   }
 }

--- a/api/src/services/script-runner.service.ts
+++ b/api/src/services/script-runner.service.ts
@@ -13,9 +13,11 @@ import {
   Prisma,
   ReviewOrderTypeEnum,
 } from '@prisma/client';
+import { AxiosError } from 'axios';
+import { HttpService } from '@nestjs/axios';
+import { catchError, firstValueFrom } from 'rxjs';
 import dayjs from 'dayjs';
 import { Request as ExpressRequest } from 'express';
-import https from 'https';
 import { AmiChartService } from './ami-chart.service';
 import { EmailService } from './email.service';
 import { FeatureFlagService } from './feature-flag.service';
@@ -49,6 +51,7 @@ export class ScriptRunnerService {
     private featureFlagService: FeatureFlagService,
     private multiselectQuestionService: MultiselectQuestionService,
     private prisma: PrismaService,
+    private httpService: HttpService,
     @Inject(Logger)
     private logger = new Logger(ScriptRunnerService.name),
   ) {}
@@ -1519,35 +1522,29 @@ export class ScriptRunnerService {
     return 'no translation';
   }
 
-  getTranslationFile(url: string, timeoutMs = TRANSLATION_FETCH_TIMEOUT_MS) {
-    return new Promise((resolve, reject) => {
-      const request = https.get(url, (res) => {
-        let body = '';
+  async getTranslationFile(
+    url: string,
+    timeoutMs = TRANSLATION_FETCH_TIMEOUT_MS,
+  ): Promise<Record<string, unknown>> {
+    const { data } = await firstValueFrom(
+      this.httpService
+        .get(url, { signal: AbortSignal.timeout(timeoutMs) })
+        .pipe(
+          catchError((error: AxiosError) => {
+            throw new Error(
+              `failed fetching ${url}: ${
+                error.code === 'ERR_CANCELED'
+                  ? `timed out after ${timeoutMs}ms`
+                  : error.message
+              }`,
+            );
+          }),
+        ),
+    );
 
-        res.on('data', (chunk) => {
-          body += chunk;
-        });
-
-        res.on('end', () => {
-          if (res.statusCode !== 200) {
-            reject(new Error(`${res.statusCode} fetching ${url}`));
-            return;
-          }
-          try {
-            resolve(JSON.parse(body));
-          } catch (error) {
-            reject(new Error(`invalid json at ${url}: ${body.slice(0, 120)}`));
-          }
-        });
-      });
-
-      request.setTimeout(timeoutMs, () => {
-        request.destroy(new Error(`timed out fetching ${url}`));
-      });
-
-      request.on('error', (error) => {
-        reject(new Error(`failed fetching ${url}: ${error.message}`));
-      });
-    });
+    if (!data || typeof data !== 'object') {
+      throw new Error(`${url} did not return json`);
+    }
+    return data as Record<string, unknown>;
   }
 }

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -1,5 +1,8 @@
 import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { of, throwError } from 'rxjs';
+import { AxiosError } from 'axios';
 import {
   LanguagesEnum,
   ListingsStatusEnum,
@@ -7,10 +10,6 @@ import {
   ReviewOrderTypeEnum,
 } from '@prisma/client';
 import { randomUUID } from 'crypto';
-import { EventEmitter } from 'events';
-import https from 'https';
-
-jest.mock('https');
 import { Request as ExpressRequest } from 'express';
 import { User } from '../../../src/dtos/users/user.dto';
 import { AmiChartService } from '../../../src/services/ami-chart.service';
@@ -27,6 +26,7 @@ describe('Testing script runner service', () => {
   let emailService: EmailService;
   let multiselectQuestionService: MultiselectQuestionService;
   let mockConsoleLog;
+  const httpServiceMock = { get: jest.fn() };
 
   beforeEach(() => {
     mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
@@ -45,6 +45,10 @@ describe('Testing script runner service', () => {
         },
         AmiChartService,
         FeatureFlagService,
+        {
+          provide: HttpService,
+          useValue: httpServiceMock,
+        },
         JurisdictionService,
         Logger,
         {
@@ -1086,178 +1090,72 @@ describe('Testing script runner service', () => {
   // | ---------- HELPER TESTS BELOW ---------- | //
 
   describe('getTranslationFile', () => {
-    const respondWith = (statusCode: number, body: string) => {
-      const res = new EventEmitter() as EventEmitter & { statusCode: number };
-      res.statusCode = statusCode;
-      const request = Object.assign(new EventEmitter(), {
-        setTimeout: jest.fn(),
-        destroy: jest.fn(),
-      });
-      (https.get as unknown as jest.Mock).mockImplementation((_url, cb) => {
-        cb(res);
-        process.nextTick(() => {
-          res.emit('data', body);
-          res.emit('end');
-        });
-        return request;
-      });
-      return request;
+    const respondWith = (data: unknown) => {
+      httpServiceMock.get.mockReturnValue(of({ data }));
     };
 
-    it('resolves the parsed body on 200', async () => {
-      respondWith(200, '{"a":"b"}');
+    const failWith = (error: Partial<AxiosError>) => {
+      httpServiceMock.get.mockReturnValue(throwError(() => error));
+    };
+
+    it('returns the parsed body', async () => {
+      respondWith({ a: 'b' });
 
       await expect(
         service.getTranslationFile('https://x/f.json'),
-      ).resolves.toEqual({
-        a: 'b',
-      });
+      ).resolves.toEqual({ a: 'b' });
     });
 
-    it('rejects with the status and url when the file is missing', async () => {
-      respondWith(404, '404: Not Found');
-
-      await expect(
-        service.getTranslationFile('https://x/f.json'),
-      ).rejects.toThrow('404 fetching https://x/f.json');
-    });
-
-    it('rejects on a server error rather than trying to parse it', async () => {
-      respondWith(500, 'upstream is unwell');
-
-      await expect(
-        service.getTranslationFile('https://x/f.json'),
-      ).rejects.toThrow('500 fetching https://x/f.json');
-    });
-
-    it('rejects with the url and the start of the body on unparseable json', async () => {
-      respondWith(200, 'not json at all');
-
-      await expect(
-        service.getTranslationFile('https://x/f.json'),
-      ).rejects.toThrow('invalid json at https://x/f.json: not json at all');
-    });
-
-    it('rejects when the socket errors', async () => {
-      const request = respondWith(200, '{}');
-      (https.get as unknown as jest.Mock).mockImplementation(() => {
-        process.nextTick(() =>
-          request.emit('error', new Error('socket hang up')),
-        );
-        return request;
-      });
-
-      await expect(
-        service.getTranslationFile('https://x/f.json'),
-      ).rejects.toThrow('failed fetching https://x/f.json: socket hang up');
-    });
-
-    it('arms a timeout that destroys the request', async () => {
-      const request = respondWith(200, '{}');
+    it('requests the url it was given, under a deadline', async () => {
+      respondWith({});
 
       await service.getTranslationFile('https://x/f.json', 1234);
 
-      expect(request.setTimeout).toHaveBeenCalledWith(
-        1234,
-        expect.any(Function),
+      expect(httpServiceMock.get).toHaveBeenCalledWith('https://x/f.json', {
+        signal: expect.any(AbortSignal),
+      });
+    });
+
+    it('rejects when the file is missing', async () => {
+      failWith({ message: 'Request failed with status code 404' });
+
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow(/failed fetching https:\/\/x\/f\.json.*404/);
+    });
+
+    it('rejects when the response is cut short', async () => {
+      failWith({ message: 'stream has been aborted' });
+
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow(/failed fetching https:\/\/x\/f\.json.*aborted/);
+    });
+
+    it('names the deadline rather than reporting a cancellation', async () => {
+      failWith({ code: 'ERR_CANCELED', message: 'canceled' });
+
+      await expect(
+        service.getTranslationFile('https://x/f.json', 250),
+      ).rejects.toThrow(
+        'failed fetching https://x/f.json: timed out after 250ms',
       );
     });
-  });
 
-  it('should mark script run as started if no script run present in db', async () => {
-    prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
-    prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+    it('rejects a body that is not json, which axios resolves as a string', async () => {
+      respondWith('<html>rate limited</html>');
 
-    const id = randomUUID();
-    const scriptName = 'new run attempt';
-
-    await service.markScriptAsRunStart(scriptName, {
-      id,
-    } as unknown as User);
-
-    expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
-      where: {
-        scriptName,
-      },
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow('https://x/f.json did not return json');
     });
-    expect(prisma.scriptRuns.create).toHaveBeenCalledWith({
-      data: {
-        scriptName,
-        triggeringUser: id,
-      },
-    });
-  });
 
-  it('should error if script run is in progress or failed', async () => {
-    prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue({
-      id: randomUUID(),
-      didScriptRun: false,
-    });
-    prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
+    it('rejects an empty body', async () => {
+      respondWith('');
 
-    const id = randomUUID();
-    const scriptName = 'new run attempt 2';
-
-    await expect(
-      async () =>
-        await service.markScriptAsRunStart(scriptName, {
-          id,
-        } as unknown as User),
-    ).rejects.toThrowError(
-      `${scriptName} has an attempted run and it failed, or is in progress. If it failed, please delete the db entry and try again`,
-    );
-
-    expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
-      where: {
-        scriptName,
-      },
-    });
-    expect(prisma.scriptRuns.create).not.toHaveBeenCalled();
-  });
-
-  it('should error if script run already succeeded', async () => {
-    prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue({
-      id: randomUUID(),
-      didScriptRun: true,
-    });
-    prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);
-
-    const id = randomUUID();
-    const scriptName = 'new run attempt 3';
-
-    await expect(
-      async () =>
-        await service.markScriptAsRunStart(scriptName, {
-          id,
-        } as unknown as User),
-    ).rejects.toThrowError(`${scriptName} has already been run and succeeded`);
-
-    expect(prisma.scriptRuns.findUnique).toHaveBeenCalledWith({
-      where: {
-        scriptName,
-      },
-    });
-    expect(prisma.scriptRuns.create).not.toHaveBeenCalled();
-  });
-
-  it('should mark script run as started if no script run present in db', async () => {
-    prisma.scriptRuns.update = jest.fn().mockResolvedValue(null);
-
-    const id = randomUUID();
-    const scriptName = 'new run attempt 4';
-
-    await service.markScriptAsComplete(scriptName, {
-      id,
-    } as unknown as User);
-
-    expect(prisma.scriptRuns.update).toHaveBeenCalledWith({
-      data: {
-        didScriptRun: true,
-        triggeringUser: id,
-      },
-      where: {
-        scriptName,
-      },
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow('https://x/f.json did not return json');
     });
   });
 

--- a/api/test/unit/services/script-runner.service.spec.ts
+++ b/api/test/unit/services/script-runner.service.spec.ts
@@ -7,6 +7,10 @@ import {
   ReviewOrderTypeEnum,
 } from '@prisma/client';
 import { randomUUID } from 'crypto';
+import { EventEmitter } from 'events';
+import https from 'https';
+
+jest.mock('https');
 import { Request as ExpressRequest } from 'express';
 import { User } from '../../../src/dtos/users/user.dto';
 import { AmiChartService } from '../../../src/services/ami-chart.service';
@@ -64,6 +68,7 @@ describe('Testing script runner service', () => {
 
   afterEach(() => {
     mockConsoleLog.mockRestore();
+    jest.restoreAllMocks();
   });
 
   it('should add lottery translations', async () => {
@@ -791,6 +796,9 @@ describe('Testing script runner service', () => {
     });
     prisma.listings.update = jest.fn().mockResolvedValue(null);
 
+    // The command fetches six override files; stub them so the suite stays off the network.
+    jest.spyOn(service, 'getTranslationFile').mockResolvedValue({});
+
     const res = await service.migrateDetroitToMultiselectQuestions({
       user: {
         id,
@@ -834,7 +842,7 @@ describe('Testing script runner service', () => {
         id: 'example listing_id',
       },
     });
-  }, 100000);
+  });
 
   it('should migrate multiselect data to refactored schema', async () => {
     const id = randomUUID();
@@ -1076,6 +1084,86 @@ describe('Testing script runner service', () => {
   });
 
   // | ---------- HELPER TESTS BELOW ---------- | //
+
+  describe('getTranslationFile', () => {
+    const respondWith = (statusCode: number, body: string) => {
+      const res = new EventEmitter() as EventEmitter & { statusCode: number };
+      res.statusCode = statusCode;
+      const request = Object.assign(new EventEmitter(), {
+        setTimeout: jest.fn(),
+        destroy: jest.fn(),
+      });
+      (https.get as unknown as jest.Mock).mockImplementation((_url, cb) => {
+        cb(res);
+        process.nextTick(() => {
+          res.emit('data', body);
+          res.emit('end');
+        });
+        return request;
+      });
+      return request;
+    };
+
+    it('resolves the parsed body on 200', async () => {
+      respondWith(200, '{"a":"b"}');
+
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).resolves.toEqual({
+        a: 'b',
+      });
+    });
+
+    it('rejects with the status and url when the file is missing', async () => {
+      respondWith(404, '404: Not Found');
+
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow('404 fetching https://x/f.json');
+    });
+
+    it('rejects on a server error rather than trying to parse it', async () => {
+      respondWith(500, 'upstream is unwell');
+
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow('500 fetching https://x/f.json');
+    });
+
+    it('rejects with the url and the start of the body on unparseable json', async () => {
+      respondWith(200, 'not json at all');
+
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow('invalid json at https://x/f.json: not json at all');
+    });
+
+    it('rejects when the socket errors', async () => {
+      const request = respondWith(200, '{}');
+      (https.get as unknown as jest.Mock).mockImplementation(() => {
+        process.nextTick(() =>
+          request.emit('error', new Error('socket hang up')),
+        );
+        return request;
+      });
+
+      await expect(
+        service.getTranslationFile('https://x/f.json'),
+      ).rejects.toThrow('failed fetching https://x/f.json: socket hang up');
+    });
+
+    it('arms a timeout that destroys the request', async () => {
+      const request = respondWith(200, '{}');
+
+      await service.getTranslationFile('https://x/f.json', 1234);
+
+      expect(request.setTimeout).toHaveBeenCalledWith(
+        1234,
+        expect.any(Function),
+      );
+    });
+  });
+
   it('should mark script run as started if no script run present in db', async () => {
     prisma.scriptRuns.findUnique = jest.fn().mockResolvedValue(null);
     prisma.scriptRuns.create = jest.fn().mockResolvedValue(null);


### PR DESCRIPTION
Prerequisite for reworking #6625's translation backfill into a script-runner endpoint. That endpoint fetches the same override files from GitHub.

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

## Description

`getTranslationFile` fetches locale files from `raw.githubusercontent.com` for `migrateDetroitToMultiselectQuestions`. It used its own `https` client, with four defects:

- The response status was ignored, so a 403 with a body of `{"message":"rate limit exceeded"}` resolved as a translation file.
- A response cut short mid-body left the promise pending forever. Node emits that error on the response object, and the handler was on the request. The command hung with its `scriptRuns` row already marked as started, so it could never be re-run.
- `body += chunk` decoded each Buffer separately, so a multi-byte character split across a chunk boundary became two replacement characters. Two of the six files are around 92 KB and 125 KB and contain non-ASCII.
- Rejections were strings rather than `Error` objects.

It now goes through `HttpService`, as `external-listing.service.ts` does.

## How Can This Be Tested/Reviewed?

1. `cd api && yarn test`. The suite no longer depends on a network connection; disconnect and run it if you want to confirm.
2. Read the `getTranslationFile` describe: the parsed body, the url and deadline passed to the client, a missing file, a cut-short response, the deadline being named rather than reported as a cancellation, a non-json body, and an empty body.
3. Removing the json check fails two tests. Removing the deadline fails one.
4. `migrateDetroitToMultiselectQuestions` is otherwise unchanged, so its existing assertions on script runs, query counts and the listing update still stand.

### Verification

The api unit suite passes at 64 suites and 1317 tests, and the api lint gate passes at its 2-warning threshold.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view (not applicable, backend only)
- [ ] Reviewed in a mobile view (not applicable, backend only)
- [ ] Reviewed considering accessibility (not applicable, backend only)
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [x] Ran `yarn generate:client` and/or created a migration when required