### PR TITLE
fix: update translation tests to not rely on real data

### DIFF
--- a/sites/public/__tests__/lib/translations.test.ts
+++ b/sites/public/__tests__/lib/translations.test.ts
@@ -1,3 +1,21 @@
+// Synthetic fixtures for the layers applyTranslations merges, so this suite verifies the merge
+// contract itself rather than incidental properties of today's real translation content (a key
+// being English-only, differing between locales, etc. can change during normal content edits).
+const TEST_GENERAL_EN = { "test.translated": "General English value" }
+const TEST_GENERAL_ES = { "test.translated": "General Spanish value" }
+const TEST_OVERRIDE_EN = {
+  "test.overrideOnly": "Bundled English-only override",
+  "test.bundledLocale": "Bundled English override, locale key",
+}
+const TEST_OVERRIDE_ES = {
+  "test.bundledLocale": "Bundled Spanish override, locale key",
+}
+
+jest.mock("@bloom-housing/shared-helpers/src/locales/general.json", () => TEST_GENERAL_EN)
+jest.mock("@bloom-housing/shared-helpers/src/locales/es.json", () => TEST_GENERAL_ES)
+jest.mock("../../page_content/locale_overrides/general.json", () => TEST_OVERRIDE_EN)
+jest.mock("../../page_content/locale_overrides/es.json", () => TEST_OVERRIDE_ES)
+
 import { t } from "@bloom-housing/ui-components"
 import { tIfExists } from "@bloom-housing/shared-helpers"
 import { applyTranslations, overrideTranslations, translations } from "../../src/lib/translations"
@@ -5,12 +23,12 @@ import { applyTranslations, overrideTranslations, translations } from "../../src
 describe("applyTranslations", () => {
   // Supplied by the bundled English override file and by neither shared locale file, so a
   // non-English reader has no translation of it to fall back to.
-  const OVERRIDE_ONLY_KEY = "listingResource.additionalCard1.title"
+  const OVERRIDE_ONLY_KEY = "test.overrideOnly"
   const BUNDLED_VALUE = overrideTranslations.en[OVERRIDE_ONLY_KEY]
   // Supplied by both shared locale files with different values, so precedence is visible.
-  const TRANSLATED_KEY = "t.accessibility"
+  const TRANSLATED_KEY = "test.translated"
   // Supplied by both bundled public override files, with a different value in each.
-  const BUNDLED_LOCALE_KEY = "account.create.initialDisclaimer"
+  const BUNDLED_LOCALE_KEY = "test.bundledLocale"
 
   beforeEach(() => applyTranslations("en"))
 
@@ -56,7 +74,7 @@ describe("applyTranslations", () => {
     expect(t(TRANSLATED_KEY)).toEqual("Desde la base de datos")
   })
 
-  // BUNDLED_LOCALE_KEY is supplied by locale_overrides/es.json, so this is the only assertion
+  // BUNDLED_LOCALE_KEY is supplied by the mocked es override layer, so this is the only assertion
   // that fails if that layer stops loading.
   it("applies the site's own bundled file for the locale", () => {
     applyTranslations("es")
@@ -92,9 +110,9 @@ describe("applyTranslations", () => {
 // than through addTranslation directly.
 describe("tIfExists against the layered overrides", () => {
   // Called with tIfExists in the public site and supplied by no bundled layer.
-  const UNSUPPLIED_KEY = "listingFilters.countyFilterNote"
-  // Called with tIfExists and supplied by the bundled public override file.
-  const BUNDLED_KEY = "account.create.initialDisclaimer"
+  const UNSUPPLIED_KEY = "test.unsupplied"
+  // Called with tIfExists and supplied by the mocked bundled override file.
+  const BUNDLED_KEY = "test.bundledLocale"
 
   beforeEach(() => applyTranslations("en"))
 

--- a/sites/public/__tests__/pages/_app.test.tsx
+++ b/sites/public/__tests__/pages/_app.test.tsx
@@ -1,3 +1,10 @@
+// Synthetic fixture for the bundled English override layer, so this suite verifies that
+// _app applies the fetched overrides rather than depending on today's real override content
+// (a key's presence/value there can change during normal content edits).
+const TEST_OVERRIDE_EN = { "test.bundledKey": "Bundled English override" }
+
+jest.mock("../../page_content/locale_overrides/general.json", () => TEST_OVERRIDE_EN)
+
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import { t } from "@bloom-housing/ui-components"
@@ -5,8 +12,8 @@ import { mockNextRouter } from "../testUtils"
 import BloomApp from "../../src/pages/_app"
 import { overrideTranslations } from "../../src/lib/translations"
 
-// Supplied by the bundled English override file, so a stored override has something to beat.
-const BUNDLED_KEY = "account.create.initialDisclaimer"
+// Supplied by the mocked bundled English override file, so a stored override has something to beat.
+const BUNDLED_KEY = "test.bundledKey"
 
 const Page = () => <div>{t(BUNDLED_KEY)}</div>
 


### PR DESCRIPTION
This PR addresses #6514 

- [ ] Addresses the issue in full
- [x] Addresses only certain aspects of the issue

## Description

When pulling some the most recent changes over to bloom-doorway the public unit tests fail because of reliance on actual translation files that could change. Specifically some of the keys used as references are changed in that repo in the override file. This change mocks the data so that fake keys are actually used

## How Can This Be Tested/Reviewed?

All tests should pass

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [ ] Reviewed in a desktop view
- [ ] Reviewed in a mobile view
- [ ] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation
- [ ] Ran `yarn generate:client` and/or created a migration when required

## Review Process:

- Read and understand the issue
- Ensure the author has added QA notes
- Review the code itself from a style point of view
- Pull the changes down locally and test that the acceptance criteria is met
- Either (1) explicitly ask a clarifying question, (2) request changes, or (3) approve the PR, even if there are very small remaining changes, if you don't need to re-review after the updates
