### PR TITLE
feat(public): render the brand logo and favicon

### DIFF
--- a/sites/public/__tests__/layouts/application.test.tsx
+++ b/sites/public/__tests__/layouts/application.test.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+import { BrandDTO } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { render, mockNextRouter } from "../testUtils"
+import Layout from "../../src/layouts/application"
+import { BrandContext } from "../../src/lib/BrandContext"
+
+const renderLayout = (brand: BrandDTO | null) =>
+  render(
+    <BrandContext.Provider value={brand}>
+      <Layout>
+        <div>page</div>
+      </Layout>
+    </BrandContext.Provider>
+  )
+
+describe("<Layout>", () => {
+  beforeEach(() => {
+    mockNextRouter()
+    process.env.showNewSeedsDesigns = "TRUE"
+  })
+
+  afterAll(() => delete process.env.showNewSeedsDesigns)
+
+  it("puts the stored logo in the header", () => {
+    const { container } = renderLayout({
+      logoUrl: "https://example.test/logo.png",
+    } as unknown as BrandDTO)
+
+    expect(container.querySelector("header img")).toHaveAttribute(
+      "src",
+      "https://example.test/logo.png"
+    )
+  })
+
+  it("keeps the in-repo icon when the jurisdiction has no brand", () => {
+    const { container } = renderLayout(null)
+
+    expect(container.querySelector("header img")).toBeNull()
+    expect(container.querySelector("header svg")).toBeInTheDocument()
+  })
+})

--- a/sites/public/__tests__/layouts/headerLogo.test.tsx
+++ b/sites/public/__tests__/layouts/headerLogo.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react"
+import { BrandDTO } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { headerLogo } from "../../src/layouts/application"
+
+const brandWith = (logoUrl?: string) => ({ logoUrl } as unknown as BrandDTO)
+
+describe("headerLogo", () => {
+  it("renders the stored logo when the jurisdiction has one", () => {
+    const { container } = render(headerLogo(brandWith("https://example.test/logo.png")))
+
+    const image = container.querySelector("img")
+    expect(image).toHaveAttribute("src", "https://example.test/logo.png")
+    expect(image).toHaveAttribute("alt", "")
+  })
+
+  it("falls back to the in-repo icon when there is no brand", () => {
+    const { container } = render(headerLogo(null))
+
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector("svg")).toBeInTheDocument()
+  })
+
+  it("falls back to the in-repo icon when the brand has no logo", () => {
+    const { container } = render(headerLogo(brandWith()))
+
+    expect(container.querySelector("img")).toBeNull()
+  })
+})

--- a/sites/public/__tests__/pages/_app.test.tsx
+++ b/sites/public/__tests__/pages/_app.test.tsx
@@ -11,6 +11,7 @@ import { t } from "@bloom-housing/ui-components"
 import { mockNextRouter } from "../testUtils"
 import BloomApp from "../../src/pages/_app"
 import { useJurisdictionContent } from "../../src/lib/JurisdictionContentContext"
+import { useBrand } from "../../src/lib/BrandContext"
 import { overrideTranslations } from "../../src/lib/translations"
 
 // Supplied by the mocked bundled English override file, so a stored override has something to beat.
@@ -23,6 +24,18 @@ const ContentReader = () => {
   const content = useJurisdictionContent()
   return <div>{content?.contact?.phone ?? "no content"}</div>
 }
+
+// The layout reads the brand this way to pick the header logo.
+const BrandReader = () => {
+  const brand = useBrand()
+  return <div>{brand?.logoUrl ?? "no brand"}</div>
+}
+
+const jurisdictionWith = (flagOn: boolean) => ({
+  id: "jurisdiction-id",
+  brand: { logoUrl: "https://example.test/logo.png" },
+  featureFlags: [{ name: "enableDbDrivenBranding", active: flagOn }],
+})
 
 const renderApp = (
   pageProps: Record<string, unknown>,
@@ -68,6 +81,24 @@ describe("<BloomApp>", () => {
     renderApp({}, "en", ContentReader)
 
     expect(screen.getByText("no content")).toBeInTheDocument()
+  })
+
+  it("provides the brand when the flag is on for the jurisdiction", () => {
+    renderApp({ jurisdiction: jurisdictionWith(true) }, "en", BrandReader)
+
+    expect(screen.getByText("https://example.test/logo.png")).toBeInTheDocument()
+  })
+
+  it("provides no brand when the flag is off", () => {
+    renderApp({ jurisdiction: jurisdictionWith(false) }, "en", BrandReader)
+
+    expect(screen.getByText("no brand")).toBeInTheDocument()
+  })
+
+  it("provides no brand when a page supplies no jurisdiction", () => {
+    renderApp({}, "en", BrandReader)
+
+    expect(screen.getByText("no brand")).toBeInTheDocument()
   })
 
   it("renders the bundled value when a page supplies none", () => {

--- a/sites/public/__tests__/pages/_document.test.tsx
+++ b/sites/public/__tests__/pages/_document.test.tsx
@@ -161,6 +161,36 @@ describe("_document", () => {
     expect(style).toContain("--bloom-color-primary: #ABC;")
   })
 
+  it("links the favicon when one is stored", async () => {
+    const { children } = await headChildrenFor(
+      jurisdictionWith({ primary, faviconUrl: "https://example.test/favicon.png" })
+    )
+
+    const link = children.find(
+      (child) => React.isValidElement(child) && child.props.rel === "icon"
+    ) as React.ReactElement
+
+    expect(link.props.href).toEqual("https://example.test/favicon.png")
+  })
+
+  it("links no favicon when none is stored, leaving /favicon.ico to apply", async () => {
+    const { children } = await headChildrenFor(jurisdictionWith({ primary }))
+
+    expect(
+      children.some((child) => React.isValidElement(child) && child.props.rel === "icon")
+    ).toBe(false)
+  })
+
+  it("links no favicon when the flag is off", async () => {
+    const { children } = await headChildrenFor(
+      jurisdictionWith({ primary, faviconUrl: "https://example.test/favicon.png" }, false)
+    )
+
+    expect(
+      children.some((child) => React.isValidElement(child) && child.props.rel === "icon")
+    ).toBe(false)
+  })
+
   it("forwards the request so the API sees the visitor's address", async () => {
     await styleFor(jurisdictionWith({ primary }))
 

--- a/sites/public/src/layouts/application.tsx
+++ b/sites/public/src/layouts/application.tsx
@@ -8,7 +8,8 @@ import { Message, Toast, Icon } from "@bloom-housing/ui-seeds"
 import { MenuLink, t, SiteHeader as UICSiteHeader } from "@bloom-housing/ui-components"
 import { CommonMessageVariant } from "@bloom-housing/ui-seeds/src/blocks/shared/CommonMessage"
 import { AuthContext, MessageContext } from "@bloom-housing/shared-helpers"
-import { User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import { useBrand } from "../lib/BrandContext"
+import { BrandDTO, User } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { ToastProps } from "@bloom-housing/ui-seeds/src/blocks/Toast"
 import CustomSiteFooter from "../components/shared/CustomSiteFooter"
 import { HeaderLink, SiteHeader } from "../patterns/SiteHeader"
@@ -206,8 +207,19 @@ interface LayoutProps {
   pageTitle?: string
 }
 
+// The site title sits next to the logo, so the image is decorative and takes no alt text.
+export const headerLogo = (brand: BrandDTO | null) =>
+  brand?.logoUrl ? (
+    <img src={brand.logoUrl} alt="" />
+  ) : (
+    <Icon size={"lg"}>
+      <HomeIcon />
+    </Icon>
+  )
+
 const Layout = (props: LayoutProps) => {
   const { profile, signOut } = useContext(AuthContext)
+  const brand = useBrand()
   const { toastMessagesRef, addToast } = useContext(MessageContext)
   const router = useRouter()
 
@@ -266,11 +278,7 @@ const Layout = (props: LayoutProps) => {
                 favorites: showFavorites,
               })}
               titleLink={"/"}
-              logo={
-                <Icon size={"lg"}>
-                  <HomeIcon />
-                </Icon>
-              }
+              logo={headerLogo(brand)}
               mainContentId="main-content"
               showMessageBar={false}
               banners={[

--- a/sites/public/src/lib/BrandContext.tsx
+++ b/sites/public/src/lib/BrandContext.tsx
@@ -1,0 +1,8 @@
+import { createContext, useContext } from "react"
+import { BrandDTO } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+
+// Null when enableDbDrivenBranding is off for the jurisdiction, or on a page with no data
+// function.
+export const BrandContext = createContext<BrandDTO | null>(null)
+
+export const useBrand = () => useContext(BrandContext)

--- a/sites/public/src/pages/_app.tsx
+++ b/sites/public/src/pages/_app.tsx
@@ -24,9 +24,15 @@ import ApplicationConductor, {
   loadApplicationFromAutosave,
   loadSavedListing,
 } from "../lib/applications/ApplicationConductor"
-import { JurisdictionContentFields } from "@bloom-housing/shared-helpers/src/types/backend-swagger"
+import {
+  FeatureFlagEnum,
+  Jurisdiction,
+  JurisdictionContentFields,
+} from "@bloom-housing/shared-helpers/src/types/backend-swagger"
 import { applyTranslations } from "../lib/translations"
 import { JurisdictionContentContext } from "../lib/JurisdictionContentContext"
+import { BrandContext } from "../lib/BrandContext"
+import { isFeatureFlagOn } from "../lib/helpers"
 import LinkComponent from "../components/core/LinkComponent"
 
 import "../../styles/overrides.scss"
@@ -54,6 +60,12 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
 
   const jurisdictionContent = (pageProps?.jurisdictionContent ??
     null) as JurisdictionContentFields | null
+
+  const jurisdiction = pageProps?.jurisdiction as Jurisdiction | undefined
+  const brand =
+    jurisdiction && isFeatureFlagOn(jurisdiction, FeatureFlagEnum.enableDbDrivenBranding)
+      ? jurisdiction.brand ?? null
+      : null
 
   useMemo(() => {
     applyTranslations(locale, publicOverrides)
@@ -99,10 +111,12 @@ function BloomApp({ Component, router, pageProps }: AppProps) {
       <AuthProvider>
         <MessageProvider>
           <JurisdictionContentContext.Provider value={jurisdictionContent}>
-            <LoggedInUserIdleTimeout onTimeout={() => conductor.reset()} />
-            <div className={jurisdictionClassname}>
-              <Component {...pageProps} />
-            </div>
+            <BrandContext.Provider value={brand}>
+              <LoggedInUserIdleTimeout onTimeout={() => conductor.reset()} />
+              <div className={jurisdictionClassname}>
+                <Component {...pageProps} />
+              </div>
+            </BrandContext.Provider>
           </JurisdictionContentContext.Provider>
         </MessageProvider>
       </AuthProvider>

--- a/sites/public/src/pages/_document.tsx
+++ b/sites/public/src/pages/_document.tsx
@@ -14,6 +14,7 @@ type BrandRamp = Partial<BrandRampDTO>
 interface BrandDocumentProps {
   primary: BrandRamp | null
   secondary: BrandRamp | null
+  faviconUrl: string | null
 }
 
 const rampShades: (keyof BrandRamp)[] = ["base", "dark", "darker", "light", "lighter"]
@@ -70,11 +71,13 @@ export default class BloomDocument extends Document<BrandDocumentProps> {
       ...initialProps,
       primary: hexOnly(brand?.primary),
       secondary: hexOnly(brand?.secondary),
+      faviconUrl: brand?.faviconUrl ?? null,
     }
   }
 
   render() {
     const brandVariables = brandStyleBlock(this.props)
+    const { faviconUrl } = this.props
 
     return (
       <Html>
@@ -82,6 +85,8 @@ export default class BloomDocument extends Document<BrandDocumentProps> {
           {brandVariables && (
             <style id="brand-vars" dangerouslySetInnerHTML={{ __html: brandVariables }} />
           )}
+          {/* Nothing emitted without one, so the browser falls back to /favicon.ico */}
+          {faviconUrl && <link rel="icon" href={faviconUrl} />}
         </Head>
         <body>
           <Main />

--- a/sites/public/src/patterns/SiteHeader.module.scss
+++ b/sites/public/src/patterns/SiteHeader.module.scss
@@ -164,6 +164,8 @@
           color: var(--seeds-color-primary);
           img {
             max-height: var(--seeds-s16);
+            max-width: var(--seeds-s48);
+            object-fit: contain;
           }
           @media (--sm-only) {
             font-size: var(--seeds-font-size-sm);


### PR DESCRIPTION
This PR addresses #6666

- [x] Addresses the issue in full
- [ ] Addresses only certain aspects of the issue

Stacked on #6681 and targets `6665/public-brand-injection`.

## Description

The logo and favicon are the two static assets left after #6665 made the colors runtime-driven. The site header now renders the jurisdiction's stored logo and the document head links its favicon, each falling back to what ships in the repo.

### Favicon

`_document.tsx` already resolves the brand behind `enableDbDrivenBranding`, so the favicon rides on that same resolution and needs no separate gate. It emits `<link rel="icon" href={faviconUrl}>` when one is stored and nothing at all when not, which leaves `/favicon.ico` to apply as it does today.

Two limits of that, both outside what this PR can fix. A stored favicon whose asset no longer resolves shows the browser's blank icon rather than falling back to `/favicon.ico`, because any declared `rel="icon"` stops the browser requesting the default, and a second link does not reliably serve as a fallback. And the 64px width in the delivery URL applies only on the Cloudinary path: with `USE_S3_FILE_STORAGE=TRUE` the stored object is served at its original size on every page load, so a large upload is a per-visit cost. Both are arguments for constraining the upload in #6669 rather than the render.

### Logo

The header is in the React tree rather than the document head, and `layouts/application.tsx` has no jurisdiction of its own. Phase 1 solved the same problem with `JurisdictionContentContext`: `_app.tsx` reads the value out of `pageProps` and provides it, and components consume a hook. This follows that route. `fetchSharedPageProps` already returns the whole jurisdiction, so `_app` applies `isFeatureFlagOn` and provides the brand through a new `BrandContext`, and the layout reads it with `useBrand`. The alternative, passing the brand into `Layout` from every page, is what the Phase 1 work rejected.

`headerLogo` is exported from the layout so the choice between the stored logo and the fallback can be tested without rendering the layout, the same reason `brandStyleBlock` is exported from the document. A second test renders `Layout` itself, so removing the `logo` prop or the context read fails rather than passing silently.

The logo slot in `SiteHeader.module.scss` capped height only. It now caps width as well, at 12rem, with `object-fit: contain`, so a wide wordmark cannot push the header row out of shape at mobile widths. That is the one change here no test covers, since Jest does not evaluate the stylesheet.

### Two to review

The image renders with `alt=""`. The site title sits beside it inside the same link, so a populated alt would announce the same thing twice, and the brand model has no alt-text field to draw from. `CustomSiteFooter` takes the other approach with a stored `logoAltText`, but that field belongs to Phase 1 content rather than to the brand.

The fallback stays the `HomeIcon` the header renders today. The issue and TDD §5.3 both describe the fallback as `/images/logo_glyph.svg`, which is not what the seeds header currently uses; switching to it would change how every unbranded site looks, which is outside what this issue asks for.

The legacy `UICSiteHeader` is deliberately not wired, per §5.3, and Partners is untouched.

## How Can This Be Tested/Reviewed?

Set up from #6681 step 1 applies: the jurisdiction needs a brand and `enableDbDrivenBranding` on. These steps add the two assets. `psql` connects to the database in the api's `DATABASE_URL`, and each change needs `CACHE_REVALIDATE` seconds (30 by default) before a render picks it up.

**1.** Point the jurisdiction at a logo and a favicon. The `file_id` values have to exist in the environment's image store, since the API builds the URL from them rather than storing it.

```sql
INSERT INTO assets (file_id, label, updated_at)
VALUES ('dev/bloom_logo', 'brandLogo', now()), ('dev/bloom_favicon', 'brandFavicon', now());

UPDATE jurisdictions SET
  brand_logo_asset_id = (SELECT id FROM assets WHERE label = 'brandLogo' LIMIT 1),
  brand_favicon_asset_id = (SELECT id FROM assets WHERE label = 'brandFavicon' LIMIT 1)
WHERE name = 'Bloomington';
```

**2.** Confirm the API composes both URLs. On a Cloudinary-backed environment they carry the per-kind width, 400 for the logo and 64 for the favicon; with `USE_S3_FILE_STORAGE=TRUE` they are public bucket URLs instead.

```bash
KEY=$(grep '^API_PASS_KEY' api/.env | cut -d= -f2- | tr -d '"')
curl -s -H "passkey: $KEY" \
  "http://localhost:3100/jurisdictions/byName/Bloomington" \
  | python3 -c "import json,sys; b=json.load(sys.stdin)['brand']; print(b['logoUrl']); print(b['faviconUrl'])"
```

The passkey is required: without it the endpoint returns a 401 body with no `brand` key. The two file ids have to exist in the environment's image store, or the URLs resolve to nothing and the header shows a broken image.

**3.** Confirm the head links the favicon, and that the tab icon changes in the browser.

```bash
curl -s http://localhost:3000/ | grep -o '<link rel="icon"[^>]*>'
```

**4.** Load the site and confirm the header shows the stored logo rather than the house icon. Worth doing with a wide wordmark and at a narrow viewport, since the width cap is not covered by any test.

**5.** Clear both assets and confirm the page returns to the in-repo defaults: the house icon in the header, no `rel="icon"` in the head, and the browser falling back to `/favicon.ico`.

```sql
UPDATE jurisdictions SET brand_logo_asset_id = NULL, brand_favicon_asset_id = NULL
WHERE name = 'Bloomington';
```

**6.** Turn `enableDbDrivenBranding` off with both assets set, and confirm both revert to the defaults.

### Verification

The public suite passes at 117 suites and 1094 tests, including 11 new cases, and the site typechecks and lints clean. Run it with `--runInBand`: in parallel, `create-account` and `finder` fail intermittently on 5s timeouts, with a different set of test names each run and each suite passing on its own.

The new cases cover the favicon link with an asset, without one, and with the flag off; `headerLogo` with a stored logo, with no brand, and with a brand that has no logo; the `_app` gating with the flag on, with it off, and with no jurisdiction in props; and `Layout` itself rendering the stored logo or the fallback icon. The two `Layout` cases were checked against mutations: deleting the `logo` prop fails one, and severing the context read fails the other.

## Author Checklist:

- [ ] Added QA notes to the issue with applicable URLs
- [x] Reviewed in a desktop view
- [x] Reviewed in a mobile view
- [x] Reviewed considering accessibility
- [x] Added tests covering the changes
- [ ] Made corresponding changes to the documentation (none required)
- [ ] Ran `yarn generate:client` and/or created a migration when required (not required)